### PR TITLE
+doc, 'sample' to 'population', +link and sorted

### DIFF
--- a/sql/table.sql
+++ b/sql/table.sql
@@ -250,15 +250,16 @@ create table variation_synonym (
 @column variation_id	 	   Foreign key references to the @link variation table.
 @column subsnp_id		   Foreign key references to the @link subsnp_handle table.
 @column allele_code_id 		   Foreign key reference to @link allele_code table.
-@column frequency		   Frequency of this allele in the sample.
 @column population_id		   Foreign key references to the @link population table.
-@column count			   Number of individuals in the sample where this allele is found.
+@column frequency		   Frequency of this allele in the population.
+@column count			   Number of individuals in the population where this allele is found.
 @column frequency_submitter_handle dbSNP handle for submitter of frequency data [may be different to submitter of observed variant]
 
 @see variation
-@see population
 @see subsnp_handle
 @see allele_code
+@see population
+@see submitter_handle
 */
 
 CREATE TABLE allele (


### PR DESCRIPTION
I'm only changing the documentation here, not SQL!

The inline documentation is used to generate http://www.ensembl.org/info/docs/api/variation/variation_schema.html#allele

The documentation for a couple of columns has outdated references to 'samples' where the table now uses population_id.

I added a link to the submitter_handle table, so all FKs are now linked under the 'see also' list.

I re-ordered the columns to match what's in the SQL.

I re-ordered the 'see also' list to match the order of the columns.
