### PR TITLE
added store() method for StudyAdaptor.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/StudyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/StudyAdaptor.pm
@@ -277,4 +277,42 @@ sub _objs_from_sth {
 }
 
 
+sub store {
+
+  my ($self, $study) = @_;
+     
+  my $dbh = $self->dbc->db_handle;
+     
+  my $sth = $dbh->prepare(q{
+         INSERT INTO study (
+             source_id,
+             name,
+             description,
+             url,
+             external_reference,
+             study_type
+         ) VALUES (?,?,?,?,?,?)
+     });
+     
+  $sth->execute(
+		$study->{_source_id},
+		$study->name,
+		$study->description || undef,
+		$study->url || undef,
+		$study->external_reference || undef,
+		$study->type || undef
+	       );
+     
+  $sth->finish;
+     
+     # get dbID
+  my $dbID = $dbh->last_insert_id(undef, undef, 'study', 'study_id');
+
+  $study->{dbID}    = $dbID;
+
+  $study->{adaptor} = $self;
+
+}
+
+
 1;

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/StudyAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/StudyAdaptor.pm
@@ -276,10 +276,9 @@ sub _objs_from_sth {
   return \@study;
 }
 
-
 sub store {
 
-  my ($self, $study) = @_;
+  my ($self, $study ) = @_;
      
   my $dbh = $self->dbc->db_handle;
      
@@ -295,17 +294,17 @@ sub store {
      });
      
   $sth->execute(
-		$study->{_source_id},
-		$study->name,
-		$study->description || undef,
-		$study->url || undef,
-		$study->external_reference || undef,
-		$study->type || undef
-	       );
+               $study->source->dbID(),
+               $study->name,
+               $study->description || undef,
+               $study->url || undef,
+               $study->external_reference || undef,
+               $study->type || undef
+              );
      
   $sth->finish;
      
-     # get dbID
+# get dbID
   my $dbID = $dbh->last_insert_id(undef, undef, 'study', 'study_id');
 
   $study->{dbID}    = $dbID;

--- a/modules/t/studyAdaptor.t
+++ b/modules/t/studyAdaptor.t
@@ -61,7 +61,33 @@ my $studies2 = $sta->fetch_all_by_dbID_list(\@study_IDs);
 ok($studies2->[0]->name() eq $name, "study by dbID list");
 
 # test fetch all by external reference
-my $studies = $sta->fetch_all_by_external_reference($external_ref);
-ok($studies->[0]->name() eq $name, "study by external reference");
+my $studies3 = $sta->fetch_all_by_external_reference($external_ref);
+ok($studies3->[0]->name() eq $name, "study by external reference");
+
+# store
+
+print "\n# Test - store\n";
+
+my $sa = $vdb->get_SourceAdaptor();
+
+my $source = Bio::EnsEMBL::Variation::Source->new( -data_types => ['variation'] );
+$source->name( 'test study source' );
+
+ok($sa->store($source), "store");
+
+$source = $sa->fetch_by_name('test study source');
+
+ok($source && $source->name eq 'test study source', "fetch stored source");
+
+my $study3 = Bio::EnsEMBL::Variation::Study->new();
+$study3->name('test study');
+$study3->source( $source );
+$study3->description( 'test study for study->store method' );
+
+ok($sta->store( $study3 ), "store");
+
+my $st = $sta->fetch_by_name('test study');
+
+ok($st && $st->name eq 'test study', "fetch stored study");
 
 done_testing();


### PR DESCRIPTION
Current StudyAdaptor lacks a store() method for newly created objects. This functionality is desirable for Ensemblgenomes.