### PR TITLE
Getting the healthchecks to work for an EG database and an ensrw user

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
@@ -134,8 +134,7 @@ sub get_vep_params {
      $params->{host}       = $meta_container->dbc->host();
      $params->{port}       = $meta_container->dbc->port();
      $params->{user}       = $meta_container->dbc->username();
-     $params->{pass}       = $meta_container->dbc->password() ? '--pass '.$meta_container->dbc->password() : '';
-
+     $params->{pass}       = $meta_container->dbc->password() ? $meta_container->dbc->password() : '';
      $meta_container->dbc()->disconnect_if_idle();
      
      $self->param('assembly', $params->{assembly});
@@ -147,7 +146,7 @@ sub get_vep_params {
      $params->{host}     = $self->required_param('host');
      $params->{port}     = $self->required_param('port');
      $params->{user}     = $self->required_param('user');
-     $params->{pass}     = $self->required_param('pass') ? '--pass '.$self->required_param('pass') : '';
+     $params->{pass}     = $self->required_param('pass') ? $self->required_param('pass') : '';
   }
 
   # species-specific

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
@@ -209,6 +209,7 @@ sub healthcheck_cache {
   $ENV{HC_VEP_PASS}     = $params->{pass};
   $ENV{HC_VEP_SPECIES}  = $params->{species}.($params->{refseq} ? '_refseq' : '');
   $ENV{HC_VEP_VERSION}  = $params->{version};
+  $ENV{HC_VEP_CACHE_VERSION} = $params->{eg} ? $params->{eg_version} : undef;
   $ENV{HC_VEP_DIR}      = $params->{dir};
   $ENV{HC_VEP_NO_FASTA} = 1;
   $ENV{HC_VEP_MAX_VARS} = 100;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/DumpVEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/DumpVEP.pm
@@ -1,4 +1,4 @@
-pa=head1 LICENSE
+=head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 Copyright [2016] EMBL-European Bioinformatics Institute
@@ -63,7 +63,7 @@ sub run {
     $params->{host},
     $params->{port},
     $params->{user},
-    $params->{pass} ? '--pass' . $params->{pass} : '',
+    $params->{pass} ? '--pass ' . $params->{pass} : '',
     
     $params->{species},
     $params->{assembly},

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/DumpVEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/DumpVEP.pm
@@ -1,4 +1,4 @@
-=head1 LICENSE
+pa=head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
 Copyright [2016] EMBL-European Bioinformatics Institute
@@ -63,7 +63,7 @@ sub run {
     $params->{host},
     $params->{port},
     $params->{user},
-    $params->{pass},
+    $params->{pass} ? '--pass' . $params->{pass} : '',
     
     $params->{species},
     $params->{assembly},

--- a/scripts/misc/healthcheck_vep_caches.pl
+++ b/scripts/misc/healthcheck_vep_caches.pl
@@ -78,7 +78,7 @@ $config->{species}       ||= $ENV{HC_VEP_SPECIES}       || 'all';
 $config->{host}          ||= $ENV{HC_VEP_HOST}          || 'ens-staging1,ens-staging2';
 $config->{user}          ||= $ENV{HC_VEP_USER}          || 'ensro';
 $config->{port}          ||= $ENV{HC_VEP_PORT}          || 3306;
-$config->{password}      ||= $ENV{HC_VEP_PASS}          || 3306;
+$config->{password}      ||= $ENV{HC_VEP_PASS}          || undef;
 $config->{no_fasta}      ||= $ENV{HC_VEP_NO_FASTA}      || undef;
 $config->{max_vars}      ||= $ENV{HC_VEP_MAX_VARS}      || 100;
 


### PR DESCRIPTION
Some small changes:
- appending "--pass " to the password only in DumpVEP.pm but not in BaseVEP.pm. This is because the VEP dumping script requires "--pass " but the healthcheck script does not.
- setting the env parameter HC_VEP_CACHE_VERSION to the EG version if we're working with a EG database. Otherwise, this defaults to the Ensembl schema version the healthchecks fail.
- if no password is given (as for an ensro user), it defaults to undef.