### PR TITLE
Report plugins errors.

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -2505,7 +2505,7 @@ sub run_plugins {
                             }
                         }
                         else {
-                            warn "Plugin '".(ref $plugin)."' did not return a hashref, output ignored!\n";
+                            warning_msg($config, "Plugin '".(ref $plugin)."' did not return a hashref, output ignored!\n");
                         }
                     }
                     else {
@@ -2514,7 +2514,7 @@ sub run_plugins {
                     }
                 };
                 if ($@) {
-                    warn "Plugin '".(ref $plugin)."' went wrong: $@";
+                    warning_msg($config, "Plugin '".(ref $plugin)."' went wrong: $@");
                 }
 
                 # there's no point running any other plugins if we're filtering this line,

--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -4940,7 +4940,7 @@ sub prefetch_transcript_data {
         $tr->{_variation_effect_feature_cache}->{three_prime_utr} = $transferred->three_prime_utr();
     };
     if($@) {
-        warn "Problem getting 3' UTR:".$@;
+        warning_msg($config, "Problem getting 3' UTR:".$@);
     }
 
     # peptide


### PR DESCRIPTION
The warn() function call does not output anything. It just supresses errors, in case there are errors in plugins. warning_msg() is the right function to call.