### PR TITLE
Deal with unwanted stringified perl object

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Source.pm
+++ b/modules/Bio/EnsEMBL/Variation/Source.pm
@@ -63,8 +63,16 @@ use warnings;
 package Bio::EnsEMBL::Variation::Source;
 
 use Bio::EnsEMBL::Storable;
-use Bio::EnsEMBL::Utils::Exception qw(throw warning);
+use Bio::EnsEMBL::Utils::Exception qw(throw warning deprecate);
 use Bio::EnsEMBL::Utils::Argument  qw(rearrange);
+
+use overload qw("" to_string);
+
+sub to_string {
+  ## Deal with unwanted stringified perl object when $v->source is used instead of $v->source_name
+  deprecate("Use method 'source_name' instead of 'source', or call 'name' on the Source object.");
+  return $_[0]->name;
+}
 
 our @ISA = ('Bio::EnsEMBL::Storable');
 


### PR DESCRIPTION
There are still some instances where we are seeing Bio::EnsEMBL::Variation::Source=HASH(...) strings in some pages or export output. It's not only the web code, but ensembl core API code as well.

This fix is to prevent that from happening and return the actual name of the Source if the Source object is treated as a string.