### PR TITLE
modified fix input vf constrain

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -3218,6 +3218,7 @@ sub validate_vf {
 
     # user specified chr skip list
     return 0 if defined($config->{chr}) && !$config->{chr}->{$vf->{chr}};
+    my $valid_chrs = get_cache_chromosomes($config);
     # fix inputs
     if(!$valid_chrs->{$vf->{chr}}) {
          $vf->{chr} =~ s/^chr//ig unless $vf->{chr} =~ /^chromosome$/i || $vf->{chr} =~ /^CHR\_/;

--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -3218,10 +3218,12 @@ sub validate_vf {
 
     # user specified chr skip list
     return 0 if defined($config->{chr}) && !$config->{chr}->{$vf->{chr}};
-
     # fix inputs
-    $vf->{chr} =~ s/^chr//ig unless $vf->{chr} =~ /^chromosome$/i || $vf->{chr} =~ /^CHR\_/;
-    $vf->{chr} = 'MT' if $vf->{chr} eq 'M';
+    if(!$valid_chrs->{$vf->{chr}}) {
+         $vf->{chr} =~ s/^chr//ig unless $vf->{chr} =~ /^chromosome$/i || $vf->{chr} =~ /^CHR\_/;
+         $vf->{chr} = 'MT' if $vf->{chr} eq 'M';
+	} 
+    
     $vf->{strand} ||= 1;
     $vf->{strand} = ($vf->{strand} =~ /\-/ ? "-1" : "1");
 


### PR DESCRIPTION
check first if the cache has the same chr naming, before we have actually try to fix them!

As I had the issue that it was complaining not to find any slice as the chr names in only one direction where changed (vf object). 