### PR TITLE
support for keys of a scalar have been removed in perl 5.24

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -1554,8 +1554,8 @@ sub vf_list_to_cons {
                 my $fieldname = $config->{vcf_info_field} || 'CSQ';
 
                 # nuke existing CSQ field
-                if($line->[7] =~ /$fieldname\=/ && !defined($config->{keep_csq})) {
-                  $line->[7] =~ s/$fieldname\=\S+?(\;|$)(\S|$)/$2/;
+                if($line->[7] =~ /(^|\;)$fieldname\=/ && !defined($config->{keep_csq})) {
+                  $line->[7] =~ s/(^|\;)$fieldname\=\S+?(\;|$)(\S|$)/$1$3/;
                 }
 
                 # get all the lines the normal way

--- a/scripts/import/dbSNP/GenericChromosome.pm
+++ b/scripts/import/dbSNP/GenericChromosome.pm
@@ -128,8 +128,8 @@ sub variation_feature{
 	 $tablename2 = 'b' .  $tablename2 unless  $tablename2 =~/^b/;
      }
     ## hack for human multi-build support
-    $tablename1 = $tablename1 . "_107" if $self->{'group_label'} eq 'GRCh38.p2';
-    $tablename2 = $tablename2 . "_107" if $self->{'group_label'} eq 'GRCh38.p2';
+    $tablename1 = $tablename1 . "_108" if $self->{'group_label'} =~ /GRCh38/;
+    $tablename2 = $tablename2 . "_108" if $self->{'group_label'} =~ /GRCh38/;
 
     my $stmt;
     #The group term (the name of the reference assembly in the dbSNP b[version]_SNPContigInfo_[assembly]_[assembly version] table) is either specified via the config file or, if not, attempted to automatically determine from the data
@@ -265,6 +265,7 @@ sub variation_feature{
 	$self->{'dbVar'}->do(qq{INSERT IGNORE INTO tmp_genotyped_var SELECT DISTINCT variation_id FROM sample_genotype_multiple_bp});
 	print Progress::location();
     }
+
     debug(localtime() . "\tCreating tmp_variation_feature_chrom data in GenericChromosome");
     #if tcl.end>1, this means we have coordinates for chromosome, we will use it
 

--- a/scripts/import/dbSNP/GenericContig.pm
+++ b/scripts/import/dbSNP/GenericContig.pm
@@ -1569,7 +1569,7 @@ sub parallelized_allele_table {
       }
     }
     # If we still have subtasks that fail, this needs to be resolved before proceeding
-    die("Some subtasks are failing (see log output). This needs to be resolved before proceeding with the loading of genotypes!") unless ($result->{'success'});
+    die("Some subtasks are failing (see log output). This needs to be resolved before proceeding with the loading of alleles!") unless ($result->{'success'});
   }
 
 # $jobindex =  2606;  ##Put number of subfiles here if running on load_only
@@ -1697,7 +1697,7 @@ sub write_allele_task_file{
     #warn "Starting allele_task file \n";
     ### previously binning at 500,000, switched to 400,000
     my ($first, $previous,  $jobindex, $ssid);
-    debug(localtime() . "\tAt write_allele_task_file - starting");
+
    open(MGMT,'>',$task_manager_file) || die "Failed to open allele table task management file ($task_manager_file): $!\n";;
     my $stmt = "SELECT ";
     if ($limit) {
@@ -1713,7 +1713,7 @@ sub write_allele_task_file{
     $ss_extract_sth->execute() ||die "Error extracting ss ids for allele_table binning\n";
 
     $ss_extract_sth->bind_columns(\$ssid);
-    debug(localtime() . "\tAt write_allele_task_file - executed");
+
     while( $ss_extract_sth->fetchrow_arrayref()){
 	
 	$counter++;
@@ -2453,6 +2453,7 @@ sub parallelized_individual_genotypes {
     $merge_subtables .= ",$extra_table";
     
     $stmt = $ind_gty_stmt;
+    $stmt =~ s/ENGINE = MyISAM ;//;  
     $stmt .= " ENGINE=MERGE INSERT_METHOD=LAST UNION=($merge_subtables)";
   }
   else {

--- a/scripts/misc/generate_classes_table.pl
+++ b/scripts/misc/generate_classes_table.pl
@@ -114,15 +114,27 @@ my %cnv_probe_class;
 
 # Variation classes
 my $stmt1  = qq{ SELECT distinct a.value FROM variation v, attrib a WHERE a.attrib_id=v.class_attrib_id};
-my $sth1   = $dbVar->prepare($stmt1);
+
 my $stmt1a = qq{ SELECT v.name FROM variation v, attrib a WHERE v.variation_id NOT IN (SELECT variation_id FROM failed_variation) AND a.attrib_id=v.class_attrib_id AND a.value=? LIMIT 1 };
-my $sth1a  = $dbVar->prepare($stmt1a);
+
+my $stmt1b = qq{ SELECT v.name FROM variation v, attrib a WHERE a.attrib_id=v.class_attrib_id AND a.value=? LIMIT 1 };
+
+my $sth1  = $dbVar->prepare($stmt1);
+my $sth1a = $dbVar->prepare($stmt1a);
+my $sth1b = $dbVar->prepare($stmt1b);
+
 $sth1->execute;
 while(my $v_class = ($sth1->fetchrow_array)[0]) {
   $var_class{$v_class}{'class'} = $VARIATION_CLASSES{$v_class};
   
   $sth1a->execute($v_class);
   my $v_name = ($sth1a->fetchrow_array)[0];
+  
+  if (!$v_name) {
+    $sth1b->execute($v_class);
+    $v_name = ($sth1b->fetchrow_array)[0];
+  }
+  
   $var_class{$v_class}{'example'} = $v_name if ($v_name);
 }
 $sth1->finish; 
@@ -131,14 +143,37 @@ $sth1a->finish;
 
 # Structural variation classes + CNV probes
 my $stmt2  = qq{ SELECT distinct a.value FROM structural_variation v, attrib a WHERE a.attrib_id=v.class_attrib_id};
-my $sth2   = $dbVar->prepare($stmt2);
+
 my $stmt2a = qq{ SELECT v.variation_name FROM structural_variation v, attrib a WHERE v.structural_variation_id NOT IN (SELECT structural_variation_id FROM failed_structural_variation) AND v.is_evidence=0 AND a.attrib_id=v.class_attrib_id AND a.value=? LIMIT 1 };
-my $sth2a  = $dbVar->prepare($stmt2a);
+
+my $stmt2b = qq{ 
+SELECT sv1.variation_name 
+FROM 
+  structural_variation sv1,
+  structural_variation sv2,
+  structural_variation_association sva,
+  attrib a
+WHERE 
+  sv1.is_evidence=0 AND sv2.is_evidence=1 AND
+  sv1.structural_variation_id = sva.structural_variation_id AND
+  sv2.structural_variation_id = sva.supporting_structural_variation_id AND
+  a.attrib_id=sv2.class_attrib_id AND a.value=? LIMIT 1
+};
+
+my $sth2  = $dbVar->prepare($stmt2);
+my $sth2a = $dbVar->prepare($stmt2a);
+my $sth2b = $dbVar->prepare($stmt2b);
+
 $sth2->execute;
 while(my $sv_class = ($sth2->fetchrow_array)[0]) {
 
-    $sth2a->execute($sv_class);
-    my $sv_name = ($sth2a->fetchrow_array)[0];
+  $sth2a->execute($sv_class);
+  my $sv_name = ($sth2a->fetchrow_array)[0];
+
+  if (!$sv_name) {
+    $sth2b->execute($sv_class);
+    $sv_name = ($sth2b->fetchrow_array)[0];
+  }
 
   if ($sv_class =~ /probe/) {
     $cnv_probe_class{$sv_class}{'class'}   = $VARIATION_CLASSES{$sv_class};
@@ -157,7 +192,7 @@ while(my $sv_class = ($sth2->fetchrow_array)[0]) {
 } 
 $sth2->finish;
 $sth2a->finish;
-
+$sth2b->finish;
 
 
 
@@ -204,7 +239,7 @@ The colours were originally based on the <a rel="external" href="http://www.ncbi
 <p>
 };
 
-$html .= get_var_class_piechart();
+#$html .= get_var_class_piechart();
 
 open  OUT, "> $output_file" or die $!;
 print OUT $html;
@@ -278,27 +313,43 @@ sub get_examples {
   my $html = "";
   if ($example_type eq 'both') {
   
-    my $v_name = ($data->{'v_example'}) ? $data->{'v_example'} : '';
-    my $var_url = $example_urls{'var'};
-       $var_url =~ s/####NAME####/$v_name/;
+    my $var_url = '';
+    if ($data->{'v_example'}) {
+      my $v_name = $data->{'v_example'};
+      
+      $var_url = $example_urls{'var'};
+      $var_url =~ s/####NAME####/$v_name/;
+    }
     $html .= qq{<div>$var_url</div>};
     
-    my $sv_name = ($data->{'sv_example'}) ? $data->{'sv_example'} : '';
-    my $sv_url = $example_urls{'sv'};
-       $sv_url =~ s/####NAME####/$sv_name/;
-     $html .= qq{<div style="padding-top:1px">$sv_url</div>};
+    my $sv_url = '';
+    if ($data->{'sv_example'}) {
+      my $sv_name = $data->{'sv_example'};
+      
+      $sv_url = $example_urls{'sv'};
+      $sv_url =~ s/####NAME####/$sv_name/;
+    }
+    $html .= qq{<div style="padding-top:1px">$sv_url</div>};
   }
   elsif ($example_type eq 'var') {
-    my $v_name = ($data->{'example'}) ? $data->{'example'} : '';
-    my $var_url = $example_urls{'var'};
-       $var_url =~ s/####NAME####/$v_name/;
-     $html .= qq{<div>$var_url</div>};
+    my $var_url = '';
+    if ($data->{'example'}) {
+      my $v_name = $data->{'example'};
+      
+      $var_url = $example_urls{'var'};
+      $var_url =~ s/####NAME####/$v_name/;
+    }
+    $html .= qq{<div>$var_url</div>};
   }
   elsif ($example_type eq 'sv') {
-    my $sv_name = ($data->{'example'}) ? $data->{'example'} : '';
-    my $sv_url = $example_urls{'sv'};
-       $sv_url =~ s/####NAME####/$sv_name/;
-     $html .= qq{<div>$sv_url</div>};
+    my $sv_url = '';
+    if ($data->{'example'}) {
+      my $sv_name = $data->{'example'};
+      
+      $sv_url = $example_urls{'sv'};
+      $sv_url =~ s/####NAME####/$sv_name/;
+    }
+    $html .= qq{<div>$sv_url</div>};
   }
   
   return $html;

--- a/scripts/misc/generate_population_table.pl
+++ b/scripts/misc/generate_population_table.pl
@@ -57,14 +57,14 @@ usage() if ($help);
 
 my %exac_pops_list = (
   'ExAC:ALL' => 'All ExAC individuals',
-  'AFR'      => 'African/African American',
-  'AMR'      => 'Latino',
-  'Adj'      => 'Adjusted (individuals with GQ >= 20 and depth DP >= 10)',
-  'EAS'      => 'East Asian',
-  'FIN'      => 'Finnish',
-  'NFE'      => 'Non-Finnish European',
-  'OTH'      => 'Other',
-  'SAS'      => 'South Asian'
+  'ExAC:AFR' => 'African/African American',
+  'ExAC:AMR' => 'Latino',
+  'ExAC:Adj' => 'Adjusted (individuals with GQ >= 20 and depth DP >= 10)',
+  'ExAC:EAS' => 'East Asian',
+  'ExAC:FIN' => 'Finnish',
+  'ExAC:NFE' => 'Non-Finnish European',
+  'ExAC:OTH' => 'Other',
+  'ExAC:SAS' => 'South Asian'
 );
 
 ## Settings ##


### PR DESCRIPTION
Use of `keys $hash_ref` has been introduced in perl 5.14 and has always benn experimental. In 5.24 this syntax throws an error because the support of automatic dereferrencing is now removed.

In order to be compatible with perl 5.24 at least one line needs to be modified.