### PR TITLE
fix for obsolete perl syntax (perl 5.24)

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/LDFeatureContainer.pm
+++ b/modules/Bio/EnsEMBL/Variation/LDFeatureContainer.pm
@@ -136,7 +136,7 @@ sub new {
 
   # only add these keys if it they are properly populated
   # makes the lazy-load later easier
-  $self->{pos2vf} = $pos2vf if $pos2vf && scalar keys $pos2vf;
+  $self->{pos2vf} = $pos2vf if $pos2vf && scalar keys %$pos2vf;
 
   return $self;
 }


### PR DESCRIPTION
Use of keys $hash_ref has been introduced in perl 5.14 and has always been experimental. In 5.24 this syntax throws an error because the support of automatic dereferencing is now removed.

In order to be compatible with perl 5.24 at least one line needs to be modified.