### PR TITLE
missing use for make_path which is used by EG-specific code

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVEP/BaseVEP.pm
@@ -32,6 +32,8 @@ package Bio::EnsEMBL::Variation::Pipeline::DumpVEP::BaseVEP;
 use strict;
 use warnings;
 
+use File::Path qw(make_path);
+
 use base qw(Bio::EnsEMBL::Variation::Pipeline::BaseVariationProcess);
 
 sub tar {


### PR DESCRIPTION
Trying to run the existing EG FTP pipeline which includes VEP dumping and found this problem which I imagine would only be found if you supply the flag to tell the dump code that its EG.