### PR TITLE
Fix vcf sample synonyms (request 2)

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/SampleAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/SampleAdaptor.pm
@@ -354,14 +354,7 @@ sub fetch_all_by_name_list {
   
   my $id_str = (@$list > 1)  ? " IN (". join(',', map {'"'.$_.'"'} @$list).")" : ' = \''.$list->[0].'\'';
   
-  my $result = $self->generic_fetch("s.name" . $id_str);
-
-  if (scalar @$result == 0) {
-    foreach my $name (@$list) {
-      push @$result, @{$self->fetch_by_synonym($name)};
-    }
-  }
-  return $result;
+  return $self->generic_fetch("s.name" . $id_str . " OR ss.name" . $id_str);
 }
 
 =head2 fetch_all_by_Population

--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -474,16 +474,31 @@ sub get_all_Samples {
     my $sample_adpt = $self->use_db ? $self->adaptor->db->get_SampleAdaptor() : undef;
     my $individual_adpt = $self->use_db ? $self->adaptor->db->get_IndividualAdaptor() : undef;
     
-    my $sample_names = $vcf->get_samples();
+    my $vcf_sample_names = $vcf->get_samples();
     
     # do a fetch_all_by_name_list
     my %sample_objs;
-    %sample_objs = map {$_->name() => $_} @{$sample_adpt->fetch_all_by_name_list([map {$prefix.$_} @$sample_names])} if $self->use_db;
-    
+    %sample_objs = map {$_->name() => $_} @{$sample_adpt->fetch_all_by_name_list([map {$prefix.$_} @$vcf_sample_names])} if $self->use_db;
+   
+    # Get the list of sample synonyms
+    my %synonyms;
+    for my $sample_name (keys %sample_objs) {
+      my $sample = $sample_objs{$sample_name};
+      for my $syn ($sample->get_all_synonyms) {
+        $synonyms{$syn} = $sample->name;
+      }
+    }
+
     # some may not be in DB
-    foreach my $sample_name(@$sample_names) {
+    foreach my $vcf_sample_name (@$vcf_sample_names) {
+      # Use the main sample name to retrieve its metadata
+      my $sample_name = $vcf_sample_name;
+      if (exists $synonyms{ $vcf_sample_name }) {
+        $sample_name = $synonyms{$vcf_sample_name}->{sample_name};
+      }
+      
       # either use the DB one or create one
-      my $sample = $sample_objs{$prefix.$sample_name} ||
+      my $sample = $sample_objs{ $prefix.$sample_name } //
         Bio::EnsEMBL::Variation::Sample->new_fast({
           name            => $prefix.$sample_name,
           adaptor         => $sample_adpt,
@@ -497,7 +512,7 @@ sub get_all_Samples {
           }),
         });
       # store the raw name to easily match to data returned from other methods
-      $sample->{_raw_name} = $sample_name;
+      $sample->{_raw_name} = $vcf_sample_name;
       push @samples, $sample;
     }
 


### PR DESCRIPTION
Here is another go at fixing ENSVAR-591.
This pull request also includes a speed improvement to the retrieval of a list of sample synonyms, replacing a long loop with a single fetch (so all samples are fetch in one go, synonyms or not). This is noticeably faster for VCF files with a lot of synonyms.
