### PR TITLE
Fix loop on sample synonyms in get_all_Samples

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -485,7 +485,7 @@ sub get_all_Samples {
     for my $sample_name (keys %sample_objs) {
       my $sample = $sample_objs{$sample_name};
       for my $syn (@{$sample->get_all_synonyms}) {
-        $synonyms{$syn->[0]} = $sample->name;
+        $synonyms{$syn} = $sample->name;
       }
     }
 


### PR DESCRIPTION
Two parts bug: instead of looping on all sample_synonyms, only the first
synonym was retrieved at first. So the array ref was dereferenced in a
previous commit, but the second part of the bug was not fixed, which
lead to a string being used as an array.