### PR TITLE
Plugged a memory leak in the results cache of BaseVepTabixPlugin

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/BaseVepTabixPlugin.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/BaseVepTabixPlugin.pm
@@ -340,7 +340,7 @@ sub _add_result_to_cache {
   my $cache = $self->cache;
 
   $cache->{results}->{$pos_string} = $result;
-  push @{$cache->{results_order}}, $result;
+  push @{$cache->{results_order}}, $pos_string;
 
   if(scalar @{$cache->{results_order}} > $self->cache_size) {
     my $del = shift @{$cache->{results_order}};


### PR DESCRIPTION
Hi Will,

The linked commit plugs a memory leak in the BaseVepTabixPlugin module that showed with the CADD VEP plugin. For a genome-wide VCF (around 16M variants), VEP previously required in excess of 105 GiB, which is a bit much. With this fix applied, it only requires around 750 MiB throughout.

Thanks,
Michael
