### PR TITLE
convert single base inversion to a substitution

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -650,11 +650,6 @@ sub format_hgvs_string{
     $hgvs_notation->{'hgvs'} .= $coordinates . $hgvs_notation->{'type'};
   }
 
-  elsif( $hgvs_notation->{'type'} eq '>'){
-    ### substitution - list both alleles
-    $hgvs_notation->{'hgvs'} .= $hgvs_notation->{'start'} . $hgvs_notation->{'ref'} . $hgvs_notation->{'type'} . $hgvs_notation->{'alt'};
-  }
-
   elsif( $hgvs_notation->{'type'} eq 'delins'){
     $hgvs_notation->{'hgvs'} .= $coordinates . 'delins' . $hgvs_notation->{'alt'};
   }   

--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -638,7 +638,12 @@ sub format_hgvs_string{
 
   ##### format rest of string according to type
 
-  if($hgvs_notation->{'type'} eq 'del' ||  $hgvs_notation->{'type'} eq 'inv' || $hgvs_notation->{'type'} eq 'dup'){
+  if( $hgvs_notation->{'type'} eq '>' || ($hgvs_notation->{'type'} eq 'inv' && length($hgvs_notation->{'ref'}) ==1)  ){
+    ### substitution - list both alleles
+    $hgvs_notation->{'hgvs'} .= $hgvs_notation->{'start'} . $hgvs_notation->{'ref'} . '>' . $hgvs_notation->{'alt'};
+  }
+
+  elsif($hgvs_notation->{'type'} eq 'del' ||  $hgvs_notation->{'type'} eq 'inv' || $hgvs_notation->{'type'} eq 'dup'){
     ### inversion of reference bases => list ref not alt
     ### deletion  of reference bases => list ref lost
     ### duplication  of reference bases (eg ref = GAAA alt = GAAAGAAA) => list duplicated ref (dupGAAA)

--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -260,7 +260,16 @@ my %test_output = (
             "TTTTT",
             "ENSP00000344757.2:p.Leu117_Lys118delinsPheLeu",
             "del ins if > 1 aa not a subs"
-           ]
+           ],
+     36 => ["NC_000019.9:g.7706085T>A",
+            "A",
+            "ENST00000320400.4:c.1186T>A",
+            "A",
+            "",
+            "convert single base inv to subs"
+           ],
+
+
 );
 
 my %test_output_shifted = (   
@@ -435,7 +444,12 @@ my %test_input = (
             "ENST00000345392.2:c.349_353delinsTTTTT",
             "ENSP00000344757.2:p.Leu117_Lys118delinsPheLeu",
             "ENSP00000344757.2:p.LeuLys117PheLeu"
-            ]
+            ],
+     36 => ["NC_000019.9:g.7706085invT",
+            "NC_000019.9:g.7706085T>A",
+            "ENST00000320400.4:c.1186T>A",
+           ],
+
 );
 
 my %test_input_shifted = (


### PR DESCRIPTION
Update to HGVS writer for substitutions with redundant bases. Input ACT/AGT currently flagged as an inversion, but should be a C>G substitution.