### PR TITLE
Bugfix/ldfcadaptor

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
@@ -491,7 +491,11 @@ sub _fetch_by_Slice_VCF {
   delete $self->{_pairwise};
   delete $self->{_pairwise_vf_name};
 
-  return $container || Bio::EnsEMBL::Variation::LDFeatureContainer->new('-adaptor' => $self, '-ldContainer' => {}, 'name' => '', '-slices' => []);
+  if (!$container) {
+    warning('The population is not represented in the configured VCF file for fetching genotypes for LD computation.');
+    return  Bio::EnsEMBL::Variation::LDFeatureContainer->new('-adaptor' => $self, '-ldContainer' => {}, 'name' => '', '-slices' => []);
+  }
+  return $container;
 }
 
 sub _merge_containers {

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
@@ -491,7 +491,7 @@ sub _fetch_by_Slice_VCF {
   delete $self->{_pairwise};
   delete $self->{_pairwise_vf_name};
 
-  return $container;
+  return $container || Bio::EnsEMBL::Variation::LDFeatureContainer->new('-adaptor' => $self, '-ldContainer' => {}, 'name' => '', '-slices' => []);
 }
 
 sub _merge_containers {

--- a/modules/t/LDFeatureContainerAdaptor.t
+++ b/modules/t/LDFeatureContainerAdaptor.t
@@ -17,6 +17,7 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
+use Test::Warnings qw(warning);
 use Bio::EnsEMBL::Test::TestUtils;
 use Bio::EnsEMBL::Test::MultiTestDB;
 use Bio::EnsEMBL::Variation::VariationFeature;
@@ -62,7 +63,9 @@ my $slice = $sa->fetch_by_region('chromosome', '9', 22124503, 22126503);
 my $population = $pa->fetch_by_name('1000GENOMES:phase_1_ASW');
 my $population_no_genotypes_in_vcf = $pa->fetch_by_name('PGA-UW-FHCRC:HSP_GENO_PANEL');
 
-my $ldfc = $ldfca->fetch_by_Slice($slice, $population_no_genotypes_in_vcf);
+my $ldfc;
+warning { $ldfc = $ldfca->fetch_by_Slice($slice, $population_no_genotypes_in_vcf); };
+#like($warning, qr/^The population is not represented in the configured VCF file/, 'got a warning if population is not in a VCF file');
 my $ld_values = $ldfc->get_all_ld_values;
 cmp_ok(scalar @$ld_values, '==', 0, "Return empty container if population is not present in any VCF file");
 

--- a/modules/t/LDFeatureContainerAdaptor.t
+++ b/modules/t/LDFeatureContainerAdaptor.t
@@ -65,7 +65,6 @@ my $population_no_genotypes_in_vcf = $pa->fetch_by_name('PGA-UW-FHCRC:HSP_GENO_P
 
 my $ldfc;
 warning { $ldfc = $ldfca->fetch_by_Slice($slice, $population_no_genotypes_in_vcf); };
-#like($warning, qr/^The population is not represented in the configured VCF file/, 'got a warning if population is not in a VCF file');
 my $ld_values = $ldfc->get_all_ld_values;
 cmp_ok(scalar @$ld_values, '==', 0, "Return empty container if population is not present in any VCF file");
 

--- a/modules/t/LDFeatureContainerAdaptor.t
+++ b/modules/t/LDFeatureContainerAdaptor.t
@@ -44,10 +44,8 @@ my $vfa = $vdb->get_VariationFeatureAdaptor();
 my $va = $vdb->get_VariationAdaptor();
 my $pa = $vdb->get_PopulationAdaptor();
 
-
 my $dir = $multi->curr_dir();
 ok($vdb->vcf_config_file($dir.'/ld_vcf_config.json') eq $dir.'/ld_vcf_config.json', "DBAdaptor vcf_config_file");
-
 
 my $vca = $vdb->get_VCFCollectionAdaptor();
 my $coll = $vca->fetch_by_id('ld');
@@ -62,9 +60,14 @@ $ldfca->db->use_vcf(1);
 # fetch_by_Slice
 my $slice = $sa->fetch_by_region('chromosome', '9', 22124503, 22126503);
 my $population = $pa->fetch_by_name('1000GENOMES:phase_1_ASW');
+my $population_no_genotypes_in_vcf = $pa->fetch_by_name('PGA-UW-FHCRC:HSP_GENO_PANEL');
 
-my $ldfc = $ldfca->fetch_by_Slice($slice, $population);
+my $ldfc = $ldfca->fetch_by_Slice($slice, $population_no_genotypes_in_vcf);
 my $ld_values = $ldfc->get_all_ld_values;
+cmp_ok(scalar @$ld_values, '==', 0, "Return empty container if population is not present in any VCF file");
+
+$ldfc = $ldfca->fetch_by_Slice($slice, $population);
+$ld_values = $ldfc->get_all_ld_values;
 
 my $results = [
 { population_id => 102179, vf1_name => 'rs79944118', vf2_name => 'rs1333049', r2 => 0.087731, d_prime => 0.999965, test_name => 'ld_values for rs79944118 and rs1333049' },


### PR DESCRIPTION
Fixing a problem that came up in the REST test cases for LD endpoints. There was a problem if the population is not represented in any of the VCF files from which we try to get genotypes for LD computation. Now an empty LDFeatureContainer and a warning are returned. 
This is a quick fix to get REST tests passing again.

Note for next release: I will test earlier if the population has genotypes and if not throw an exception. 