### PR TITLE
Methods to retrieve HGVS exon coordinates and intron distances

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1,7 +1,7 @@
 =head1 LICENSE
 
 Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
-Copyright [2016-2017] EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -718,6 +718,11 @@ sub hgvs_transcript {
   );
   print "post pos sort: $hgvs_notation->{start},$hgvs_notation->{end}\n" if $DEBUG ==1;
 
+  # save these to be able to report exon coordinates and intron distances
+  $self->{_hgvs_exon_start_coordinate} = $exon_start_coord;
+  $self->{_hgvs_intron_start_offset} = $intron_start_offset;
+  $self->{_hgvs_exon_end_coordinate} = $exon_end_coord;
+  $self->{_hgvs_intron_end_offset} = $intron_end_offset;
 
   if($tr->cdna_coding_start()){
     $hgvs_notation->{'numbering'} = "c";  ### set 'c' if transcript is coding 
@@ -983,6 +988,57 @@ sub hgvs_offset {
   return $self->{_hgvs_offset};
 }
 
+=head2 hgvs_exon_start_coordinate
+
+  Description: Return the HGVS exon start coordinate
+  Returntype : int or undef if HGVS has not been calculated
+  Exceptions : none
+  Status     : At risk
+
+=cut
+sub hgvs_exon_start_position {
+  my $self = shift;
+  return $self->{_hgvs_exon_start_coordinate};
+}
+
+=head2 hgvs_intron_start_offset
+
+  Description: Return the HGVS intron start offset
+  Returntype : int or undef if HGVS has not been calculated
+  Exceptions : none
+  Status     : At risk
+
+=cut
+sub hgvs_intron_start_offset {
+  my $self = shift;
+  return $self->{_hgvs_intron_start_offset};
+}
+
+=head2 hgvs_exon_end_coordinate
+
+  Description: Return the HGVS exon end coordinate
+  Returntype : int or undef if HGVS has not been calculated
+  Exceptions : none
+  Status     : At risk
+
+=cut
+sub hgvs_exon_end_position {
+  my $self = shift;
+  return $self->{_hgvs_exon_end_coordinate};
+}
+
+=head2 hgvs_intron_end_offset
+
+  Description: Return the HGVS intron end offset
+  Returntype : int or undef if HGVS has not been calculated
+  Exceptions : none
+  Status     : At risk
+
+=cut
+sub hgvs_intron_end_offset {
+  my $self = shift;
+  return $self->{_hgvs_intron_end_offset};
+}
 
 sub _make_hgvs_tva {
   my $self       = shift;


### PR DESCRIPTION
Hi, I'd like to be able to filter some VEP output using the HGVS intron offset values as a measure of intronic distance. I couldn't see an easy way to retrieve these and the exon coordinates without having to either parse the HGVS string or re-calculate them. I added some methods for these, but if there's a better way to do this please let me know.