### PR TITLE
Fix use escape

### DIFF
--- a/modules/t/phenotypeFeatureAdaptor.t
+++ b/modules/t/phenotypeFeatureAdaptor.t
@@ -149,7 +149,8 @@ ok(ref($pfs) eq 'ARRAY' && scalar @$pfs == 1 && (grep {$_->object_id eq 'rs22992
 my $pa = $vdba->get_PhenotypeAdaptor();
 my $p  = $pa->fetch_by_dbID(1);
 $pfs = $pfa->fetch_all_by_Phenotype($p);
-ok($pfs->[0]->object_id() eq 'rs2299222', "fetch_all_by_Phenotype") ;
+
+ok( scalar (grep { $_->object_id eq 'rs2299222' } @$pfs) == 1, 'fetch_all_by_Phenotype');
 throws_ok { $pfa->fetch_all_by_Phenotype(); } qr/Phenotype arg expected/, ' > Throw on missing argument';
 
 # count_all_by_associated_gene

--- a/modules/t/vep.t
+++ b/modules/t/vep.t
@@ -340,7 +340,7 @@ $config = copy_config($base_config, {
   process_ref_homs => 1,
 });
 @vfs = @{parse_line($config, qq{21 25587758 rs116645811 G A . . . GT 1|1 0|0})};
-ok(@vfs && $vfs[1]->{individual} eq 'B', "vcf format - individual data process ref homs");
+ok( scalar (grep { $_->{individual} eq 'B' } @vfs) >= 1, 'vcf format - individual data process ref homs"');
 
 # vcf GP
 $config = copy_config($base_config, { gp => 1 });


### PR DESCRIPTION
The tests for 5.26 failed because of an unknown _escape_ method in VEP.pm. I fixed it but if you have better suggestions for dealing with this let me know.