### PR TITLE
Mbarba/sift fixes release 92

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/BaseVariationProcess.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/BaseVariationProcess.pm
@@ -65,15 +65,17 @@ sub required_param {
 sub get_transcript_file_adaptor {
     my $self = shift;
     my $transcripts = shift;
+    my $fasta_file = $self->param('fasta_file');
     
-    unless ($self->{tfa}) {
-        $self->{tfa} = Bio::EnsEMBL::Variation::Pipeline::TranscriptFileAdaptor->new(
-            fasta_file  => $self->param('fasta_file'),
+    # New adaptor for different fasta_files (i.e. species)
+    unless ($self->{tfa}->{$fasta_file}) {
+        $self->{tfa}->{$fasta_file} = Bio::EnsEMBL::Variation::Pipeline::TranscriptFileAdaptor->new(
+            fasta_file  => $fasta_file,
             transcripts => $transcripts,
         );
     }
 
-    return $self->{tfa};
+    return $self->{tfa}->{$fasta_file};
 }
 
 sub get_species_adaptor {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
@@ -188,7 +188,7 @@ sub fetch_input {
         # but it doesn't have any parameters we need to set here
 
         # setup fasta
-        if(my $fasta = $self->param('fasta')) {
+        if(my $fasta = $self->param('fasta_file')) {
 
           # run this here as it generates the index
           # don't want competing jobs writing to it

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
@@ -89,11 +89,13 @@ sub fetch_input {
         if($gene->length > 1e6) {
           push @big_gene_output_ids, {
             gene_stable_id  => $gene->stable_id,
+            species => $self->param('species'),
           };
         }
         else {
           push @gene_output_ids, {
             gene_stable_id  => $gene->stable_id,
+            species => $self->param('species'),
           };
         }
 
@@ -189,6 +191,7 @@ sub fetch_input {
         $self->param(
             'rebuild_indexes', [{
                 tables => \@rebuild,
+                species => $self->param('species'),
             }]
         );
 
@@ -196,11 +199,21 @@ sub fetch_input {
         # but it doesn't have any parameters we need to set here
 
         $self->param(
-            'update_vf', [{}]
+            'update_vf', [{
+                species => $self->param('species'),
+              }]
         );
 
         $self->param(
-            'finish_transcript_effect', [{}]
+            'finish_transcript_effect', [{
+                species => $self->param('species'),
+              }]
+        );
+
+        $self->param(
+            'check_transcript_variation', [{
+                species => $self->param('species'),
+              }]
         );
 
         # setup fasta

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/InitTranscriptEffect.pm
@@ -146,8 +146,6 @@ sub fetch_input {
         $self->param('gene_output_ids', \@gene_output_ids);
         $self->param('big_gene_output_ids', \@big_gene_output_ids);
 
-        my @rebuild = qw(transcript_variation variation_hgvs variation_genename);
-
         # set up MTMP table
         if($mtmp) {
           my @exclude = qw(transcript_variation_id hgvs_genomic hgvs_protein hgvs_transcript somatic codon_allele_string);
@@ -184,37 +182,10 @@ sub fetch_input {
 
           $dbc->do($create_sth);
           $dbc->do("ALTER TABLE $table DISABLE KEYS");
-
-          push @rebuild, $table;
         }
-
-        $self->param(
-            'rebuild_indexes', [{
-                tables => \@rebuild,
-                species => $self->param('species'),
-            }]
-        );
 
         # we need to kick off the update_vf analysis as well, 
         # but it doesn't have any parameters we need to set here
-
-        $self->param(
-            'update_vf', [{
-                species => $self->param('species'),
-              }]
-        );
-
-        $self->param(
-            'finish_transcript_effect', [{
-                species => $self->param('species'),
-              }]
-        );
-
-        $self->param(
-            'check_transcript_variation', [{
-                species => $self->param('species'),
-              }]
-        );
 
         # setup fasta
         if(my $fasta = $self->param('fasta')) {
@@ -230,15 +201,11 @@ sub write_output {
   my $self = shift;
 
   if (my $gene_output_ids = $self->param('gene_output_ids')) {
-    $self->dataflow_output_id($self->param('rebuild_indexes'), 2);
-    $self->dataflow_output_id($self->param('update_vf'), 3);
-    $self->dataflow_output_id($gene_output_ids, 4);
-    $self->dataflow_output_id($self->param('check_transcript_variation'), 5);
-    $self->dataflow_output_id($self->param('finish_transcript_effect'), 6);
+    $self->dataflow_output_id($gene_output_ids, 2);
   }
 
   if (my $big_gene_output_ids = $self->param('big_gene_output_ids')) {
-    $self->dataflow_output_id($big_gene_output_ids, 7);
+    $self->dataflow_output_id($big_gene_output_ids, 3);
   }
 
   return;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/InitVariationClass.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/InitVariationClass.pm
@@ -100,6 +100,7 @@ sub fetch_input {
             variation_id_stop   => $stop,
             temp_var_table      => $temp_var_table,
             temp_var_feat_table => $temp_var_feat_table,
+            species             => $self->param('species'),
         };
       $start = $stop + 1;
     }
@@ -110,6 +111,7 @@ sub fetch_input {
         'finish_var_class', [{
             temp_var_table      => $temp_var_table,
             temp_var_feat_table => $temp_var_feat_table,
+            species             => $self->param('species'),
         }]
     );
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/InitVariationClass.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/InitVariationClass.pm
@@ -119,8 +119,8 @@ sub fetch_input {
 sub write_output {
     my $self = shift;
 
-    $self->dataflow_output_id($self->param('finish_var_class'), 1);
-    $self->dataflow_output_id($self->param('chunk_output_ids'), 2);
+    $self->dataflow_output_id($self->param('chunk_output_ids'), 1);
+    $self->dataflow_output_id($self->param('finish_var_class'), 2);
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/Cleanup.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/Cleanup.pm
@@ -1,0 +1,47 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2017] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=head1 CONTACT
+
+ Please email comments or questions to the public Ensembl
+ developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+ Questions may also be sent to the Ensembl help desk at
+ <http://www.ensembl.org/Help/Contact>.
+
+=cut
+package Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::Cleanup;
+
+use strict;
+
+use Bio::EnsEMBL::Registry;
+
+use base qw(Bio::EnsEMBL::Variation::Pipeline::BaseVariationProcess);
+
+sub run {
+    my $self = shift;
+    
+    my $var_dba  = $self->get_species_adaptor('variation');
+
+    # Remove temp table
+    $var_dba->dbc->do(qq{DROP TABLE translation_mapping});
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -81,7 +81,6 @@ sub fetch_input {
     push @transcripts, @{$self->get_refseq_transcripts} if $self->param('include_refseq');
 
     # store a table mapping each translation stable ID to its corresponding MD5
-
     $var_dba->dbc->do(qq{DROP TABLE IF EXISTS translation_mapping});
 
     $var_dba->dbc->do(qq{
@@ -92,6 +91,12 @@ sub fetch_input {
             KEY md5_idx (md5)
         )
     });
+  
+    # Also truncate the protein_function_prediction + _attrib tables if in sift FULL mode
+    if ($sift_run_type == FULL) {
+      $var_dba->dbc->do(qq/TRUNCATE protein_function_predictions/);
+      $var_dba->dbc->do(qq/TRUNCATE protein_function_predictions_attrib/);
+    }
 
     my $add_mapping_sth = $var_dba->dbc->prepare(qq{
         INSERT IGNORE INTO translation_mapping (stable_id, md5) VALUES (?,?)

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -202,8 +202,8 @@ sub fetch_input {
 
     # set up our list of output ids
 
-    $self->param('pph_output_ids',  [ map { {translation_md5 => $_} } @pph_md5s ]);
-    $self->param('sift_output_ids', [ map { {translation_md5 => $_} } @sift_md5s ]);
+    $self->param('pph_output_ids',  [ map { {translation_md5 => $_, species => $self->param('species')} } @pph_md5s ]);
+    $self->param('sift_output_ids', [ map { {translation_md5 => $_, species => $self->param('species')} } @sift_md5s ]);
 }
 
 ## hold code & protein database version in meta table if new complete run

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -65,9 +65,14 @@ sub fetch_input {
         @transcripts = grep { $_->translation } @{ $ga->fetch_all_by_external_name('BRCA1')->[0]->get_all_Transcripts };
     }
     else {
-        my $sa = $core_dba->get_SliceAdaptor or die "Failed to get slice adaptor";
+        my $sa  = $core_dba->get_SliceAdaptor or die "Failed to get slice adaptor";
+        my $vfa = $var_dba->get_VariationFeatureAdaptor or die "Failed to get variation feature adaptor";
         
         for my $slice (@{ $sa->fetch_all('toplevel', undef, 1, undef, ($include_lrg ? 1 : undef)) }) {
+            # Is there even a variation on this slice?
+            my $slice_iter = $vfa->fetch_Iterator_by_Slice($slice);
+            next if not $slice_iter->next;
+            
             for my $gene (@{ $slice->get_all_Genes(undef, undef, 1) }) {
                 for my $transcript (@{ $gene->get_all_Transcripts }) {
                     if (my $translation = $transcript->translation) {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -275,7 +275,7 @@ sub pipeline_analyses {
                 @common_params,
             },
             -failed_job_tolerance => 10,
-            -max_retry_count => 5,
+            -max_retry_count => 0,
             -input_ids      => [],
             -hive_capacity  => $self->o('sift_max_workers'),
             -rc_name        => 'medmem',

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -247,8 +247,9 @@ sub pipeline_analyses {
             },
             -rc_name    => 'highmem',
             -flow_into  => {
-                2 => [ 'run_polyphen' ],
-                3 => [ 'run_sift' ],
+                '2->A' => [ 'run_polyphen' ],
+                '3->A' => [ 'run_sift' ],
+                'A->1' => [ 'cleanup' ],
             },
         },
 
@@ -318,6 +319,15 @@ sub pipeline_analyses {
             -rc_name        => 'highmem',
         },
 
+        {   -logic_name => 'cleanup',
+            -module     => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::Cleanup',
+            -parameters => {
+                @common_params,
+            },
+            -meadow_type       => 'LOCAL',
+            -max_retry_count => 0,
+            -rc_name    => 'default',
+        },
     ];
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -59,6 +59,9 @@ sub default_options {
         hive_no_init => 0,
 
         debug_mode              => 0,
+        
+        # The species to analyse
+        species => [],
 
         # the location of your ensembl checkout, the hive looks here for SQL files etc.
 
@@ -68,7 +71,7 @@ sub default_options {
         pipeline_name           => 'protein_function',
         pipeline_dir            => '/hps/nobackup/production/ensembl/'.$ENV{USER}.'/'.$self->o('pipeline_name'),
         
-        species_dir             => $self->o('pipeline_dir').'/'.$self->o('species'),
+        species_dir             => $self->o('pipeline_dir').'/#species#',
         
         # directory used for the hive's own output files
 
@@ -83,7 +86,7 @@ sub default_options {
 
         # peptide sequences for all unique translations for this species will be dumped to this file
 
-        fasta_file              => $self->o('species_dir').'/'.$self->o('species').'_translations.fa',
+        fasta_file              => $self->o('species_dir').'/#species#_translations.fa',
         
         # set this flag to include LRG translations in the analysis
 
@@ -103,7 +106,7 @@ sub default_options {
             -port   => 4449,
             -user   => 'ensadmin',
             -pass   => $self->o('password'),            
-            -dbname => $ENV{USER}.'_'.$self->o('pipeline_name').'_'. $self->o('species') .'_hive',
+            -dbname => $ENV{USER}.'_'.$self->o('pipeline_name') .'_hive',
             -driver => 'mysql',
         },
         
@@ -199,17 +202,35 @@ sub resource_classes {
     };
 }
 
+sub beekeeper_extra_cmdline_options {
+    my $self = shift;
+    # Required by the species factory
+    return "-reg_conf " . $self->o("ensembl_registry");
+}
+
 sub pipeline_analyses {
     my ($self) = @_;
     
     my @common_params = (
         fasta_file          => $self->o('fasta_file'),
         ensembl_registry    => $self->o('ensembl_registry'),
-        species             => $self->o('species'),
         debug_mode          => $self->o('debug_mode'),
     );
 
     return [
+        {   -logic_name => 'species_factory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::SpeciesFactory',
+            -parameters => {
+                db_types => [ 'variation' ],
+                species  => $self->o('species'),
+            },
+            -meadow_type       => 'LOCAL',
+            -input_ids  => [{}],
+            -rc_name    => 'default',
+            -flow_into  => {
+                2 => [ 'init_jobs' ],
+            },
+        },
         {   -logic_name => 'init_jobs',
             -module     => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::InitJobs',
             -parameters => {
@@ -224,7 +245,6 @@ sub pipeline_analyses {
                 species_dir     => $self->o('species_dir'),
                 @common_params,
             },
-            -input_ids  => [{}],
             -rc_name    => 'highmem',
             -flow_into  => {
                 2 => [ 'run_polyphen' ],

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -219,7 +219,7 @@ sub pipeline_analyses {
 
     return [
         {   -logic_name => 'species_factory',
-            -module     => 'Bio::EnsEMBL::Production::Pipeline::SpeciesFactory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::Production::SpeciesFactory',
             -parameters => {
                 db_types => [ 'variation' ],
                 species  => $self->o('species'),

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunPolyPhen.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunPolyPhen.pm
@@ -206,6 +206,7 @@ sub write_output {
         $self->dataflow_output_id( [{
             translation_md5 => $self->param('translation_md5'),
             feature_file    => $feature_file,
+            species         => $self->param('species'),
         }], 2);
     }
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -84,6 +84,7 @@ sub run {
   # fetch our protein 
 
   my $peptide = $self->get_protein_sequence($translation_md5);
+  $self->dbc and $self->dbc->disconnect_if_idle();
 
   my $alignment_ok = 1;
 
@@ -263,6 +264,8 @@ sub run {
         or die "Failed to get matrix adaptor";
     
       $pfpma->store($pred_matrix);
+      $var_dba->dbc and $var_dba->dbc->disconnect_if_idle();
+      $self->dbc and $self->dbc->disconnect_if_idle();
     }
   }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -136,6 +136,18 @@ sub run {
         $alignment_ok = 1;
       }
       else {
+        # If we just did not find enough hits, that's ok, just skip this
+        my $error_file = $fasta_file . ".query.globalX.error";
+        if (-s $error_file) {
+          open my $error_fh, "<", $error_file or die $!;
+          my $error_msg = <$error_fh>;
+          close $error_fh;
+          chomp $error_msg;
+          if ($error_msg =~ /Not enough sequences \(only \d\) found by the PSI-BLAST search!|PSI-BLAST found no hits/) {
+            return;
+          }
+          die("Failed to run $translation_md5 with $flat_cmd: error $exit_code. Message: [$error_msg]. Stderr: [$stderr]\n");
+        }
         # the alignment failed for some reason, what to do?
         die "Alignment for $translation_md5 failed - cmd: $flat_cmd: $stderr";
         $alignment_ok = 0;
@@ -176,7 +188,23 @@ sub run {
     my $cmd = "$sift_dir/bin/info_on_seqs $aln_file $subs_file $res_file";
     my ($exit_code, $stderr, $flat_cmd) = $self->run_system_command($cmd);
 
-    die("Failed to run $flat_cmd: $stderr\n") unless $exit_code == 0;
+    if ($exit_code != 0) {
+      # If there was not enough sequences selected, skip it
+      my $error_file = "protein.alignedfasta.error";
+      if (-s $error_file) {
+        open my $error_fh, "<", $error_file or die $!;
+        my $error_msg = <$error_fh>;
+        close $error_fh;
+        chomp $error_msg;
+        if ($error_msg =~ /\d sequence\(s\) were chosen\. Less than the minimum number of sequences required/) {
+          return;
+        }
+        die("Failed to run $translation_md5 with $flat_cmd: error $exit_code. Message: [$error_msg]. Stderr: [$stderr]\n");
+      }
+      
+      # Otherwise die with a reason
+      die("Failed to run for $translation_md5 with $flat_cmd: error $exit_code = [$stderr]\n");
+    }
 
     $self->dbc->disconnect_when_inactive(0);
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/SetVariationClass.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/SetVariationClass.pm
@@ -193,6 +193,7 @@ sub run {
     
     $vf_insert_sth->finish();
     $v_insert_sth->finish();
+    $dbc and $dbc->disconnect_if_idle();
 }
 
 sub assign_SO_variation_class {
@@ -213,6 +214,7 @@ sub assign_SO_variation_class {
             my $cdba = $self->get_species_adaptor('core');
             my $ma = $cdba->get_MarkerAdaptor;
             my $marker_list = $ma->fetch_all_by_synonym($allele_string);
+            $cdba->dbc and $cdba->dbc->disconnect_if_idle();
             if (scalar @$marker_list > 0) {
                 $so_term = $genetic_marker;
             }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -35,7 +35,7 @@ use warnings;
 
 use Bio::EnsEMBL::Variation::TranscriptVariation;
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(MAX_DISTANCE_FROM_TRANSCRIPT overlap);
-use Bio::EnsEMBL::Variation::Utils::FastaSequence qw(setup_fasta);
+use Bio::EnsEMBL::Variation::Utils::FastaSequence qw(setup_fasta revert_fasta);
 
 use ImportUtils qw(load);
 use FileHandle;
@@ -290,7 +290,10 @@ sub run {
   $self->dump_hgvs_var($hgvs_by_var, $hgvs_fh);
 
   $hgvs_fh->close();
-
+  
+  # Because the next job might use a different fasta file, we need to forget this one
+  revert_fasta();
+  
   print STDERR "All done\n" if $DEBUG;
 
   return;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -281,6 +281,9 @@ sub run {
     load($var_dba->dbc, ($table, @{$files->{$table}->{cols}}));
   }
   ## end block
+  
+  $var_dba->dbc and $var_dba->dbc->disconnect_if_idle();
+  $core_dba->dbc and $core_dba->dbc->disconnect_if_idle();
 
   # dump HGVS stubs to file for web index
   $self->dump_hgvs_var($hgvs_by_var, $hgvs_fh);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -41,6 +41,7 @@ use ImportUtils qw(load);
 use FileHandle;
 use Fcntl qw(:flock SEEK_END);
 use Digest::MD5 qw(md5_hex);
+use File::Path qw(make_path);
 
 use base qw(Bio::EnsEMBL::Variation::Pipeline::BaseVariationProcess);
 
@@ -306,7 +307,7 @@ sub get_table_files_prefix {
   my $dir = $self->required_param('pipeline_dir').'/table_files/'.substr(md5_hex($id), 0, 2);
 
   unless(-d $dir) {
-    mkdir($dir) or die "ERROR: Could not make directory $dir\n";
+    make_path($dir) or die "ERROR: Could not make directory $dir\n";
   }
 
   return $dir.'/'.$id;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -93,7 +93,7 @@ sub run {
   # we need to include failed variations
   $tva->db->include_failed_variations(1);
 
-  if((my $fasta = $self->param('fasta')) && !$Bio::EnsEMBL::Slice::_fasta_redefined && !$Bio::EnsEMBL::Slice::fasta_db) {
+  if((my $fasta = $self->param('fasta_file')) && !$Bio::EnsEMBL::Slice::_fasta_redefined && !$Bio::EnsEMBL::Slice::fasta_db) {
 
     # we need to find the assembly version to tell it about PARs
     my ($highest_cs) = @{$core_dba->get_CoordSystemAdaptor->fetch_all()};

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -132,7 +132,7 @@ sub default_options {
 
         # points to a FASTA file, much faster than using DB for sequence lookup if available
         fasta_dir => undef,
-        fasta => $self->o('fasta_dir') ? catfile($self->o('fasta_dir'), '#species#', '#species#.fa') : undef,
+        fasta_file => $self->o('fasta_dir') ? catfile($self->o('fasta_dir'), '#species#', '#species#.fa') : undef,
 
         # sets the maximum distance to a transcript for which up/downstream consequences are assessed
         max_distance => undef,
@@ -202,6 +202,7 @@ sub pipeline_analyses {
   my @common_params = (
     ensembl_registry    => $self->o('reg_file'),
     pipeline_dir => catdir($self->o('pipeline_dir'), '#species#'),
+    fasta_file => $self->o('fasta_file'),
   );
 
   my @rebuild_tables = qw(transcript_variation variation_hgvs variation_genename);
@@ -233,7 +234,6 @@ sub pipeline_analyses {
         include_lrg => $self->o('include_lrg'),
         limit_biotypes => $self->o('limit_biotypes'),
         mtmp_table => $self->o('mtmp_table'),
-        fasta => $self->o('fasta'),
         sort_variation_feature => $self->o('sort_variation_feature'),
         @common_params,
       },
@@ -253,7 +253,6 @@ sub pipeline_analyses {
       -parameters     => { 
         disambiguate_single_nucleotide_alleles => $self->o('disambiguate_single_nucleotide_alleles'),
         mtmp_table => $self->o('mtmp_table'),
-        fasta => $self->o('fasta'),
         max_distance => $self->o('max_distance'),
         @common_params,
       },
@@ -271,7 +270,6 @@ sub pipeline_analyses {
       -parameters     => {
         disambiguate_single_nucleotide_alleles => $self->o('disambiguate_single_nucleotide_alleles'),
         mtmp_table => $self->o('mtmp_table'),
-        fasta => $self->o('fasta'),
         max_distance => $self->o('max_distance'),
         @common_params,
       },

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_full_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_full_conf.pm
@@ -1,0 +1,555 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=head1 CONTACT
+
+ Please email comments or questions to the public Ensembl
+ developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+ Questions may also be sent to the Ensembl help desk at
+ <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+package Bio::EnsEMBL::Variation::Pipeline::VariationConsequence_full_conf;
+
+use strict;
+use warnings;
+use File::Spec::Functions qw(catfile catdir);
+
+use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
+use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf qw(WHEN ELSE);
+use Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::Constants qw(FULL UPDATE NONE);
+
+sub default_options {
+    my ($self) = @_;
+
+    # The hash returned from this function is used to configure the
+    # pipeline, you can supply any of these options on the command
+    # line to override these default values.
+    
+    # You shouldn't need to edit anything in this file other than
+    # these values, if you find you do need to then we should probably
+    # make it an option here, contact the variation team to discuss
+    # this - patches are welcome!
+
+    return {
+      
+        # List of species to use
+        species => [],
+
+        # general pipeline options that you should change to suit your environment
+       
+        hive_force_init => 1,
+        hive_use_param_stack => 0,
+        hive_use_triggers => 0,
+        hive_auto_rebalance_semaphores => 0, 
+        hive_no_init => 0,
+        # the location of your checkout of the ensembl API (the hive looks for SQL files here)
+        
+        debug_mode              => 0,
+        
+        ensembl_cvs_root_dir    => $ENV{'HOME'} . '/src',
+        hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive', 
+        # a name for your pipeline (will also be used in the name of the hive database)
+        
+        pipeline_name           => 'variation_consequence_all',
+
+        # a directory to keep hive output files and your registry file, you should
+        # create this if it doesn't exist
+
+        pipeline_dir            => '/hps/nobackup/production/ensembl/' . $ENV{USER} . '/' . $self->o('pipeline_name'),
+        
+        species_dir             => $self->o('pipeline_dir').'/#species#',
+        output_dir              => $self->o('species_dir').'/hive_output',
+
+        # a standard ensembl registry file containing connection parameters
+        # for your target database(s) (and also possibly aliases for your species
+        # of interest that you can then supply to init_pipeline.pl with the -species
+        # option)
+        
+        reg_file                => $self->o('pipeline_dir').'#species#/ensembl.registry',
+
+        # points to a FASTA file, much faster than using DB for sequence lookup if available
+        fasta_dir => undef,
+        fasta_file => $self->o('fasta_dir') ? catfile($self->o('fasta_dir'), '#species#', '#species#.fa') : undef,
+
+        # if set to 1 this option tells the transcript_effect analysis to disambiguate
+        # ambiguity codes in single nucleotide alleles, so e.g. an allele string like
+        # 'T/M' will be treated as if it were 'T/A/C' (this was a request from ensembl
+        # genomes and we don't use it by default in the ensembl variation pipeline)
+        
+        disambiguate_single_nucleotide_alleles => 0,
+
+        # configuration for the various resource options used in the pipeline
+        # Users of other farms should change these here, or override them on
+        # the command line to suit your farm. The names of each option hopefully
+        # reflect their usage, but you may want to change the details (memory
+        # requirements, queue parameters etc.) to suit your own data
+        
+        default_lsf_options => '-qproduction-rh7 -R"select[mem>2000] rusage[mem=2000]" -M2000',
+        medmem_lsf_options  => '-qproduction-rh7 -R"select[mem>4000] rusage[mem=4000]" -M4000',
+        urgent_lsf_options  => '-qproduction-rh7 -R"select[mem>2000] rusage[mem=2000]" -M2000',
+        highmem_lsf_options => '-qproduction-rh7 -R"select[mem>15000] rusage[mem=15000] span[hosts=1]" -M15000 -n4', # this is LSF speak for "give me 15GB of memory"
+        long_lsf_options    => '-qproduction-rh7 -R"select[mem>2000] rusage[mem=2000]" -M2000',
+
+        # options controlling the number of workers used for the parallelisable analyses
+        # these default values seem to work for most species
+
+        transcript_effect_capacity      => 50,
+        set_variation_class_capacity    => 10,
+        
+        # set this flag to 1 to include LRG transcripts in the transcript effect analysis
+
+        include_lrg => 1, 
+
+        # set this flag to 1 to try and identify genetic markers in SetVariationClass module
+        # This is very specific to data imported from dbSNP by ensembl.
+        # ensembl genomes might need different methods for idenfifying markers:
+        # for the future add identify_marker_eg flag and add code to SetVariationClass module 
+        identify_marker_e => 1, 
+
+        # Limit analysis to specific gene biotypes
+        limit_biotypes => [],
+
+        # create MTMP_transcript_variation
+        mtmp_table => 1,
+
+        # sort variation_feature before we start?
+        # disable this if you are sure the table is already sorted
+        # or if the table is sufficiently small that it won't make much difference
+        sort_variation_feature => 0,
+
+        # sets the maximum distance to a transcript for which up/downstream consequences are assessed
+        max_distance => undef,
+
+        # these flags control which parts of the pipeline are run
+
+        run_transcript_effect   => 1,
+        run_variation_class     => 1,
+
+        # connection parameters for the hive database, you should supply the hive_db_password
+        # option on the command line to init_pipeline.pl (parameters for the target database
+        # should be set in the registry file defined above)
+
+        # Should hive use triggeres?
+        hive_use_triggers       => 0,
+
+        # init_pipeline.pl will create the hive database on this machine, naming it
+        # <username>_<pipeline_name>, and will drop any existing database with this
+        # name
+
+        hive_db_host    => 'mysql-ens-var-prod-1',
+        hive_db_port    => 4449,
+        hive_db_user    => 'ensadmin',
+
+        pipeline_db => {
+            -host   => $self->o('hive_db_host'),
+            -port   => $self->o('hive_db_port'),
+            -user   => $self->o('hive_db_user'),
+            -pass   => $self->o('hive_db_password'),            
+            -dbname => $ENV{'USER'}.'_'.$self->o('pipeline_name'),
+            -driver => 'mysql',
+        },
+        
+        # PROTEIN FEATURES PART
+        # set this flag to include LRG translations in the analysis
+        include_lrg             => 0,
+
+        # include RefSeq transcripts, and edit with accompanying BAM?
+        include_refseq          => 0,
+        bam                     => '/nfs/production/panda/ensembl/variation/data/dump_vep/interim_GRCh38.p10_knownrefseq_alignments_2017-01-13.bam',
+        
+        # Polyphen specific parameters
+        # location of the software
+        pph_dir                 => '/nfs/production/panda/ensembl/variation/software/polyphen-2.2.2',
+
+        # where we will keep polyphen's working files etc. as the pipeline runs
+        pph_working             => $self->o('species_dir').'/polyphen_working',
+        
+        # specify the Weka classifier models here, if you don't want predictions from 
+        # one of the classifier models set the value to the empty string
+        humdiv_model            => $self->o('pph_dir').'/models/HumDiv.UniRef100.NBd.f11.model',
+        humvar_model            => $self->o('pph_dir').'/models/HumVar.UniRef100.NBd.f11.model',
+
+        # the run type for polyphen (& sift) can be one of FULL to run predictions for
+        # all translations regardless of whether we already have predictions in the
+        # database, NONE to exclude this analysis, or UPDATE to run predictions for any
+        # new or changed translations in the database. The variation database specified 
+        # in the registry above is used to identify translations we already have 
+        # predictions for.
+        pph_run_type            => NONE,
+
+        # set this flag to use compara protein families as the alignments rather than
+        # polyphen's own alignment pipeline
+        pph_use_compara         => 0,
+
+        # the maximum number of workers to run in parallel for polyphen and weka. Weka 
+        # runs much faster then polyphen so you don't need as many workers.
+        pph_max_workers         => 500,
+        weka_max_workers        => 20,
+
+        # Sift specific parameters
+        # location of the software
+        sift_dir                => '/nfs/panda/ensemblgenomes/external/sift',
+        sift_working            => $self->o('species_dir').'/sift_working',
+        
+        # the location of blastpgp etc.
+        ncbi_dir                => '/nfs/panda/ensemblgenomes/external/ncbi-blast-2+/bin',
+        
+        # the protein database used to build alignments if you're not using compara
+        blastdb                 => '/nfs/production/panda/ensembl/variation/data/sift5.2.2/uniref90/uniref90.fasta',
+
+        # the following parameters mean the same as for polyphen
+        sift_run_type           => UPDATE,
+        sift_use_compara        => 0,
+        sift_max_workers        => 500,
+    };
+}
+
+sub resource_classes {
+    my ($self) = @_;
+    return {
+          'default' => { 'LSF' => $self->o('default_lsf_options') },
+          'urgent'  => { 'LSF' => $self->o('urgent_lsf_options')  },
+          'highmem' => { 'LSF' => $self->o('highmem_lsf_options') },
+          'long'    => { 'LSF' => $self->o('long_lsf_options')    },
+          'medmem'  => { 'LSF' => $self->o('medmem_lsf_options') },
+    };
+}
+
+sub beekeeper_extra_cmdline_options {
+    my $self = shift;
+    return "-reg_conf " . $self->o("reg_file");
+}
+
+sub pipeline_wide_parameters {
+  my ($self) = @_;
+
+  return {
+    %{$self->SUPER::pipeline_wide_parameters},
+        run_transcript_effect   => $self->o('run_transcript_effect'),
+        run_variation_class     => $self->o('run_variation_class'),
+  };
+}
+                        
+
+sub pipeline_analyses {
+  my ($self) = @_;
+
+  my @common_params = (
+    ensembl_registry    => $self->o('reg_file'),
+    pipeline_dir => catdir($self->o('pipeline_dir'), '#species#'),
+    fasta_file          => $self->o('fasta_file'),
+    debug_mode          => $self->o('debug_mode'),
+  );
+
+  my @rebuild_tables = qw(transcript_variation variation_hgvs variation_genename);
+  push @rebuild_tables, 'MTMP_transcript_variation' if $self->o('mtmp_table');
+
+  my @analyses;
+  push @analyses, (
+        {   -logic_name => 'species_factory',
+            -module     => 'Bio::EnsEMBL::Production::Pipeline::Production::SpeciesFactory',
+            -parameters => {
+                db_types => [ 'variation' ],
+                species  => $self->o('species'),
+            },
+            -meadow_type       => 'LOCAL',
+            -input_ids  => [{}],
+            -rc_name    => 'default',
+            -flow_into  => {
+                2 => [ 'init_jobs' ],
+            },
+        },
+        {   -logic_name => 'init_jobs',
+            -module     => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::InitJobs',
+            -parameters => {
+                sift_run_type   => $self->o('sift_run_type'),
+                pph_run_type    => $self->o('pph_run_type'),
+                include_lrg     => $self->o('include_lrg'),
+                polyphen_dir    => $self->o('pph_dir'),
+                sift_dir        => $self->o('sift_dir'),                
+                blastdb         => $self->o('blastdb'),
+                include_refseq  => $self->o('include_refseq'),
+                bam             => $self->o('bam'),
+                species_dir     => $self->o('species_dir'),
+                @common_params,
+            },
+            -rc_name    => 'highmem',
+            -flow_into  => {
+                '2->A' => [ 'run_polyphen' ],
+                '3->A' => [ 'run_sift' ],
+                'A->1' => [ 'protein_function_cleanup' ],
+            },
+        },
+
+        {   -logic_name     => 'run_polyphen',
+            -module         => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::RunPolyPhen',
+            -parameters     => {
+                pph_dir     => $self->o('pph_dir'),
+                pph_working => $self->o('pph_working'),
+                use_compara => $self->o('pph_use_compara'),
+                @common_params,
+            },
+            -max_retry_count => 0,
+            -input_ids      => [],
+            -hive_capacity  => $self->o('pph_max_workers'),
+            -rc_name        => 'highmem',
+            -flow_into      => {
+                2   => [ 'run_weka' ],
+            },
+        },
+        
+        {   -logic_name     => 'run_weka',
+            -module         => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::RunWeka',
+            -parameters     => { 
+                pph_dir         => $self->o('pph_dir'),
+                humdiv_model    => $self->o('humdiv_model'),
+                humvar_model    => $self->o('humvar_model'),
+                @common_params,
+            },
+            -max_retry_count => 0,
+            -input_ids      => [],
+            -hive_capacity  => $self->o('weka_max_workers'),
+            -rc_name        => 'default',
+            -flow_into      => {},
+        },
+        
+        {   -logic_name     => 'run_sift',
+            -module         => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::RunSift',
+            -parameters     => {
+                sift_dir        => $self->o('sift_dir'),
+                sift_working    => $self->o('sift_working'),
+                ncbi_dir        => $self->o('ncbi_dir'),
+                blastdb         => $self->o('blastdb'),
+                use_compara     => $self->o('sift_use_compara'),
+                @common_params,
+            },
+            -failed_job_tolerance => 10,
+            -max_retry_count => 0,
+            -input_ids      => [],
+            -hive_capacity  => $self->o('sift_max_workers'),
+            -rc_name        => 'medmem',
+            -flow_into      => {
+              -1 => ['run_sift_highmem'],
+            }
+        },
+
+        {   -logic_name     => 'run_sift_highmem',
+            -module         => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::RunSift',
+            -parameters     => {
+                sift_dir        => $self->o('sift_dir'),
+                sift_working    => $self->o('sift_working'),
+                ncbi_dir        => $self->o('ncbi_dir'),
+                blastdb         => $self->o('blastdb'),
+                use_compara     => $self->o('sift_use_compara'),
+                @common_params,
+            },
+            -input_ids      => [],
+            -rc_name        => 'highmem',
+        },
+
+        {   -logic_name => 'protein_function_cleanup',
+            -module     => 'Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::Cleanup',
+            -parameters => {
+                @common_params,
+            },
+            -meadow_type       => 'LOCAL',
+            -max_retry_count => 0,
+            -rc_name    => 'default',
+            -flow_into      => {
+              1 => ['transcript_effect_start'],
+            }
+        },
+      );
+      
+  push @analyses, (
+    {   -logic_name => 'transcript_effect_start',
+      -module     => 'Bio::EnsEMBL::Hive::RunnableDB::Dummy',
+      -meadow_type       => 'LOCAL',
+      -max_retry_count => 0,
+      -rc_name    => 'default',
+      -flow_into  => {
+        1 => WHEN('#run_transcript_effect#' => 'init_transcript_effect',
+             ELSE 'init_variation_class'),
+      },
+    },
+  );
+
+  push @analyses, (
+    {   -logic_name => 'init_transcript_effect',
+      -module     => 'Bio::EnsEMBL::Variation::Pipeline::InitTranscriptEffect',
+      -parameters => {
+        include_lrg => $self->o('include_lrg'),
+        limit_biotypes => $self->o('limit_biotypes'),
+        mtmp_table => $self->o('mtmp_table'),
+        sort_variation_feature => $self->o('sort_variation_feature'),
+        @common_params,
+      },
+      -hive_capacity  => 5,
+      -max_retry_count => 0,
+      -input_ids  => [],
+      -rc_name    => 'long',
+      -flow_into  => {
+        '2->A' => [ 'transcript_effect' ],
+        '3->B' => [ 'transcript_effect_highmem' ],
+        'A->1' => [ 'finish_transcript_effect' ],
+        'B->1' => [ 'finish_transcript_effect' ],
+      },
+    },
+    {   -logic_name     => 'transcript_effect',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::TranscriptEffect',
+      -parameters     => { 
+        disambiguate_single_nucleotide_alleles => $self->o('disambiguate_single_nucleotide_alleles'),
+        mtmp_table => $self->o('mtmp_table'),
+        max_distance => $self->o('max_distance'),
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => $self->o('transcript_effect_capacity'),
+      -rc_name        => 'default',
+      -flow_into      => {
+        -1 => ['transcript_effect_highmem'],
+      }
+    },
+
+    {   -logic_name     => 'transcript_effect_highmem',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::TranscriptEffect',
+      -parameters     => {
+        disambiguate_single_nucleotide_alleles => $self->o('disambiguate_single_nucleotide_alleles'),
+        mtmp_table => $self->o('mtmp_table'),
+        max_distance => $self->o('max_distance'),
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => $self->o('transcript_effect_capacity'),
+      -rc_name        => 'highmem',
+      -can_be_empty   => 1,
+    },
+
+    {   -logic_name     => 'finish_transcript_effect',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::FinishTranscriptEffect',
+      -parameters     => {
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'highmem',
+      -flow_into      => {
+        1 => ['rebuild_tv_indexes'],
+      },
+    },
+
+    {   -logic_name     => 'rebuild_tv_indexes',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::RebuildIndexes',
+      -parameters     => {
+        tables => \@rebuild_tables,
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'urgent',
+      -flow_into      => {
+        1 => ['check_transcript_variation', 'update_variation_feature'],
+      },
+    },
+
+    {   -logic_name     => 'check_transcript_variation',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::CheckTranscriptVariation',
+      -parameters     => {
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'default',
+      -flow_into      => {},
+    },
+
+    {   -logic_name     => 'update_variation_feature',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::UpdateVariationFeature',
+      -parameters     => {
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'urgent',
+      -flow_into      => {
+        1 => WHEN('#run_variation_class#' => 'init_variation_class'),
+      },
+    }, 
+  );
+
+  push @analyses, (
+    {   -logic_name     => 'init_variation_class',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::InitVariationClass',
+      -parameters     => {
+        num_chunks  => 50,
+
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'default',
+      -flow_into      => {
+        '1->A' => [ 'set_variation_class' ],
+        'A->2' => [ 'finish_variation_class' ],
+      },
+    },
+
+    {   -logic_name     => 'set_variation_class',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::SetVariationClass',
+      -parameters     => {
+        identify_marker_e => $self->o('identify_marker_e'), 
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => $self->o('set_variation_class_capacity'),
+      -rc_name        => 'default',
+      -flow_into      => {},
+    },
+
+    {   -logic_name     => 'finish_variation_class',
+      -module         => 'Bio::EnsEMBL::Variation::Pipeline::FinishVariationClass',
+      -parameters     => {
+        @common_params,
+      },
+      -max_retry_count => 0,
+      -input_ids      => [],
+      -hive_capacity  => 5,
+      -rc_name        => 'urgent',
+      -flow_into      => {},
+    },
+
+  );
+
+  return \@analyses;
+}
+
+1;
+


### PR DESCRIPTION
General fixes for Sift to run more smoothly, in particular to ignore the "failed" runsift jobs that are actually expected (see commits for detail). Tested on Vectorbase databases.