### PR TITLE
Mbarba/sift fixes release 93

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -81,7 +81,6 @@ sub fetch_input {
     push @transcripts, @{$self->get_refseq_transcripts} if $self->param('include_refseq');
 
     # store a table mapping each translation stable ID to its corresponding MD5
-
     $var_dba->dbc->do(qq{DROP TABLE IF EXISTS translation_mapping});
 
     $var_dba->dbc->do(qq{
@@ -92,6 +91,12 @@ sub fetch_input {
             KEY md5_idx (md5)
         )
     });
+  
+    # Also truncate the protein_function_prediction + _attrib tables if in sift FULL mode
+    if ($sift_run_type == FULL) {
+      $var_dba->dbc->do(qq/TRUNCATE protein_function_predictions/);
+      $var_dba->dbc->do(qq/TRUNCATE protein_function_predictions_attrib/);
+    }
 
     my $add_mapping_sth = $var_dba->dbc->prepare(qq{
         INSERT IGNORE INTO translation_mapping (stable_id, md5) VALUES (?,?)

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -275,7 +275,7 @@ sub pipeline_analyses {
                 @common_params,
             },
             -failed_job_tolerance => 10,
-            -max_retry_count => 5,
+            -max_retry_count => 0,
             -input_ids      => [],
             -hive_capacity  => $self->o('sift_max_workers'),
             -rc_name        => 'medmem',

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -84,6 +84,7 @@ sub run {
   # fetch our protein 
 
   my $peptide = $self->get_protein_sequence($translation_md5);
+  $self->dbc and $self->dbc->disconnect_if_idle();
 
   my $alignment_ok = 1;
 
@@ -263,6 +264,8 @@ sub run {
         or die "Failed to get matrix adaptor";
     
       $pfpma->store($pred_matrix);
+      $var_dba->dbc and $var_dba->dbc->disconnect_if_idle();
+      $self->dbc and $self->dbc->disconnect_if_idle();
     }
   }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -136,6 +136,18 @@ sub run {
         $alignment_ok = 1;
       }
       else {
+        # If we just did not find enough hits, that's ok, just skip this
+        my $error_file = $fasta_file . ".query.globalX.error";
+        if (-s $error_file) {
+          open my $error_fh, "<", $error_file or die $!;
+          my $error_msg = <$error_fh>;
+          close $error_fh;
+          chomp $error_msg;
+          if ($error_msg =~ /Not enough sequences \(only \d\) found by the PSI-BLAST search!|PSI-BLAST found no hits/) {
+            return;
+          }
+          die("Failed to run $translation_md5 with $flat_cmd: error $exit_code. Message: [$error_msg]. Stderr: [$stderr]\n");
+        }
         # the alignment failed for some reason, what to do?
         die "Alignment for $translation_md5 failed - cmd: $flat_cmd: $stderr";
         $alignment_ok = 0;
@@ -176,7 +188,23 @@ sub run {
     my $cmd = "$sift_dir/bin/info_on_seqs $aln_file $subs_file $res_file";
     my ($exit_code, $stderr, $flat_cmd) = $self->run_system_command($cmd);
 
-    die("Failed to run $flat_cmd: $stderr\n") unless $exit_code == 0;
+    if ($exit_code != 0) {
+      # If there was not enough sequences selected, skip it
+      my $error_file = "protein.alignedfasta.error";
+      if (-s $error_file) {
+        open my $error_fh, "<", $error_file or die $!;
+        my $error_msg = <$error_fh>;
+        close $error_fh;
+        chomp $error_msg;
+        if ($error_msg =~ /\d sequence\(s\) were chosen\. Less than the minimum number of sequences required/) {
+          return;
+        }
+        die("Failed to run $translation_md5 with $flat_cmd: error $exit_code. Message: [$error_msg]. Stderr: [$stderr]\n");
+      }
+      
+      # Otherwise die with a reason
+      die("Failed to run for $translation_md5 with $flat_cmd: error $exit_code = [$stderr]\n");
+    }
 
     $self->dbc->disconnect_when_inactive(0);
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -460,7 +460,7 @@ sub polyphen_prediction {
     
     $self->{$analysis}->{prediction} = $polyphen_prediction if $polyphen_prediction;
     
-    unless ($self->{$analysis}->{prediction}) {
+    unless (defined $self->{$analysis}->{prediction}) {
         my ($prediction, $score) = $self->_protein_function_prediction($analysis);
         $self->{$analysis}->{score} = $score;
         $self->{$analysis}->{prediction} = $prediction;
@@ -490,7 +490,7 @@ sub polyphen_score {
     
     $self->{$analysis}->{score} = $polyphen_score if defined $polyphen_score;
 
-    unless ($self->{$analysis}->{score}) {
+    unless (defined $self->{$analysis}->{score}) {
         my ($prediction, $score) = $self->_protein_function_prediction($analysis);
         $self->{$analysis}->{score} = $score;
         $self->{$analysis}->{prediction} = $prediction;
@@ -516,7 +516,7 @@ sub sift_prediction {
     
     $self->{sift_prediction} = $sift_prediction if $sift_prediction;
     
-    unless ($self->{sift_prediction}) {
+    unless (defined $self->{sift_prediction}) {
         my ($prediction, $score) = $self->_protein_function_prediction('sift');
         $self->{sift_score} = $score;
         $self->{sift_prediction} = $prediction unless $self->{sift_prediction};
@@ -541,7 +541,7 @@ sub sift_score {
 
     $self->{sift_score} = $sift_score if defined $sift_score;
 
-    unless ($self->{sift_score}) {
+    unless (defined $self->{sift_score}) {
         my ($prediction, $score) = $self->_protein_function_prediction('sift');
         $self->{sift_score} = $score;
         $self->{sift_prediction} = $prediction;


### PR DESCRIPTION
General fixes for Sift to run more smoothly, in particular to ignore the "failed" runsift jobs that are actually expected (see commits for detail). Tested on Vectorbase databases.