### PR TITLE
Update bio db hts vs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 - cpanm -v --installdeps --notest .
 - cpanm -n Devel::Cover::Report::Coveralls
 - export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-6-1
-- cpanm Ensembl/Bio-DB-HTS-2.9.tar.gz
+- cpanm https://cpan.metacpan.org/authors/id/R/RI/RISHIDEV/Bio-DB-HTS-2.9.tar.gz
 - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 - cpanm -v --installdeps --notest .
 - cpanm -n Devel::Cover::Report::Coveralls
 - export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-6-1
-- cpanm Bio::DB::HTS@2.9
+- cpanm Ensembl/Bio-DB-HTS-2.9.tar.gz
 - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 - cpanm -v --installdeps --notest .
 - cpanm -n Devel::Cover::Report::Coveralls
 - export PERL5LIB=$PWD/bioperl-live-bioperl-release-1-6-1
-- cpanm Bio::DB::HTS
+- cpanm Bio::DB::HTS@2.9
 - cp travisci/MultiTestDB.conf.travisci  modules/t/MultiTestDB.conf
 jobs:
   include:


### PR DESCRIPTION
I tried different ways to tell travis to install version 2.9. Let me know if you have a better suggestion. 
There is a newer version of Bio::DB::HTS v2.10 which causes problems with ensembl-io/release/92.
(https://www.ebi.ac.uk/panda/jira/browse/ENSCORESW-2690)
Alessandro made changes to both Bio::DB::HTS and ensembl-io to be able to handle empty tabix query results done on unknown seq regions. Related to 
https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-3657

