### PR TITLE
cpanfile: require Bio::DB::HTS

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,3 +1,4 @@
+requires 'Bio::DB::HTS';
 requires 'JSON';
 requires 'Sereal';
 requires 'Set::IntervalTree';


### PR DESCRIPTION
Without Bio::DB::HTS it is not possible to use e.g. VCFCollectionAdaptor. Given VCF support has to be explicitly enabled one could argue whether this is a mandatory or optional dependency, I have opted for the former because the adaptor always gets installed but have got no strict preference either way.

This is related to ENSCORESW-2717 but is by no means specific to the Ensembl VM, for example I ran into exactly the same problem while setting up a custom Ensembl environment on my workstation.

One possible problem here is that htslib detection in Bio::DB::HTS is currently somewhat fragile. It might improve soon though, I for one have submitted some PRs which address parts of the problem.