### PR TITLE
SequenceOntologyMapper deprecation update

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeature.pm
@@ -56,6 +56,7 @@ use warnings;
 package Bio::EnsEMBL::Variation::BaseVariationFeature;
 
 use Bio::EnsEMBL::Feature;
+use Bio::EnsEMBL::Variation::Utils::Constants qw($SO_ACC_MAPPER);
 
 our @ISA = ('Bio::EnsEMBL::Feature');
 
@@ -345,6 +346,29 @@ sub _get_prev_base {
   }
 
   return $prev_base;
+}
+
+
+=head2 feature_so_acc
+
+  Example     : $feat = $feat->feature_so_acc;
+  Description : This method returns a string containing the SO accession number of the feature class.
+                Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returns     : string (Sequence Ontology accession number)
+  Exceptions  : Thrown if caller feature SO acc is undefined in $SO_ACC_MAPPER constant
+=cut
+
+sub feature_so_acc {
+  my ($self) = @_;
+
+  my $ref = ref $self;
+  my $so_acc = $SO_ACC_MAPPER->{$ref};
+
+  unless ($so_acc ) {
+    throw( "SO acc for ${ref} is not defined. Please update %SO_ACC_MAPPER in Bio::EnsEMBL::Variation::Utils::Config");
+  }
+
+  return $so_acc;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
@@ -78,7 +78,7 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning deprecate);
 use Bio::EnsEMBL::Utils::Argument  qw(rearrange);
 use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 use Bio::EnsEMBL::Slice;
-use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES); 
+use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES $SO_ACC_MAPPER);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(MAX_DISTANCE_FROM_TRANSCRIPT);
 use Bio::EnsEMBL::Variation::StructuralVariationOverlap;
 use Bio::EnsEMBL::Variation::TranscriptStructuralVariation;
@@ -86,7 +86,6 @@ use Bio::EnsEMBL::Variation::IntergenicStructuralVariation;
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
 
-use constant SO_ACC => 'SO:0001537';
 
 =head2 new
 
@@ -1210,6 +1209,29 @@ sub _finish_annotation {
   $self->{$_.'_structural_variations'} ||= {} for qw(transcript regulation);
   $self->{regulation_structural_variations}->{$_} ||= [] for qw(ExternalFeature MotifFeature RegulatoryFeature);
   $self->get_IntergenicStructuralVariation(1);
+}
+
+
+=head2 feature_so_acc
+
+  Example     : $feat = $feat->feature_so_acc;
+  Description : This method returns a string containing the SO accession number of the VariationFeature.
+                Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returns     : string (Sequence Ontology accession number)
+  Exceptions  : Thrown if caller feature SO acc is undefined in $SO_ACC_MAPPER constant
+=cut
+
+sub feature_so_acc {
+  my ($self) = @_;
+
+  my $ref = ref $self;
+  my $so_acc = $SO_ACC_MAPPER->{$ref};
+
+  unless ($so_acc ) {
+    throw( "SO acc for ${ref} is not defined. Please update %SO_ACC_MAPPER in Bio::EnsEMBL::Variation::Utils::Config");
+  }
+
+  return $so_acc;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
@@ -86,6 +86,8 @@ use Bio::EnsEMBL::Variation::IntergenicStructuralVariation;
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
 
+use constant SO_ACC => 'SO:0001537';
+
 =head2 new
 
   Arg [-dbID] :

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
@@ -78,14 +78,13 @@ use Bio::EnsEMBL::Utils::Exception qw(throw warning deprecate);
 use Bio::EnsEMBL::Utils::Argument  qw(rearrange);
 use Bio::EnsEMBL::Utils::Scalar qw(assert_ref);
 use Bio::EnsEMBL::Slice;
-use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES $SO_ACC_MAPPER);
+use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(MAX_DISTANCE_FROM_TRANSCRIPT);
 use Bio::EnsEMBL::Variation::StructuralVariationOverlap;
 use Bio::EnsEMBL::Variation::TranscriptStructuralVariation;
 use Bio::EnsEMBL::Variation::IntergenicStructuralVariation;
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
-
 
 =head2 new
 
@@ -1209,29 +1208,6 @@ sub _finish_annotation {
   $self->{$_.'_structural_variations'} ||= {} for qw(transcript regulation);
   $self->{regulation_structural_variations}->{$_} ||= [] for qw(ExternalFeature MotifFeature RegulatoryFeature);
   $self->get_IntergenicStructuralVariation(1);
-}
-
-
-=head2 feature_so_acc
-
-  Example     : $feat = $feat->feature_so_acc;
-  Description : This method returns a string containing the SO accession number of the VariationFeature.
-                Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returns     : string (Sequence Ontology accession number)
-  Exceptions  : Thrown if caller feature SO acc is undefined in $SO_ACC_MAPPER constant
-=cut
-
-sub feature_so_acc {
-  my ($self) = @_;
-
-  my $ref = ref $self;
-  my $so_acc = $SO_ACC_MAPPER->{$ref};
-
-  unless ($so_acc ) {
-    throw( "SO acc for ${ref} is not defined. Please update %SO_ACC_MAPPER in Bio::EnsEMBL::Variation::Utils::Config");
-  }
-
-  return $so_acc;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
@@ -1245,8 +1245,8 @@ our @ATTRIB_SETS = (
 
 # Used for the feature_so_acc functionality implemented by Bio::EnsEMBL::Feature
 our %SO_ACC_MAPPER = (
-  'Bio::EnsEMBL::Variation::VariationFeature'           => "SO:0001537",
-  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => "SO:0001060"
+  'Bio::EnsEMBL::Variation::VariationFeature'           => "SO:0001060",
+  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => "SO:0001537"
 );
 
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
@@ -30,6 +30,7 @@ our @EXPORT_OK = qw(
     @FEATURE_TYPES 
     $OVERLAP_CONSEQUENCE_CLASS
     $MAX_ATTRIB_CODE_LENGTH
+    %SO_ACC_MAPPER
 );
 
 our $OVERLAP_CONSEQUENCE_CLASS = 'Bio::EnsEMBL::Variation::OverlapConsequence';
@@ -1241,5 +1242,12 @@ our @ATTRIB_SETS = (
     @OVERLAP_CONSEQUENCES,
     @FEATURE_TYPES
 );
+
+# Used for the feature_so_acc functionality implemented by Bio::EnsEMBL::Feature
+our %SO_ACC_MAPPER = (
+  'Bio::EnsEMBL::Variation::VariationFeature'           => "SO:0001537",
+  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => "SO:0001060"
+);
+
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -995,8 +995,8 @@ our %OVERLAP_CONSEQUENCES = (
 );
 
 our $SO_ACC_MAPPER = {
-  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001060',
-  'Bio::EnsEMBL::Variation::VariationFeature' => 'SO:0001537'
+  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001537',
+  'Bio::EnsEMBL::Variation::VariationFeature' => 'SO:0001060'
 }
 ;
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -9,9 +9,9 @@ use warnings;
 
 use base qw(Exporter);
 
-our @EXPORT_OK = qw(%OVERLAP_CONSEQUENCES %VARIATION_CLASSES $DEFAULT_OVERLAP_CONSEQUENCE SO_TERM_INDEL ATTRIB_TYPE_ALLELE_ACCESSION_ID SO_TERM_CODING_SEQUENCE_VARIANT SO_TERM_STOP_RETAINED_VARIANT SO_TERM_COMPLEX_STRUCTURAL_ALTERATION SO_TERM_ALU_INSERTION SO_TERM_SPLICE_ACCEPTOR_VARIANT SO_TERM_PROTEIN_ALTERING_VARIANT SO_TERM_TANDEM_REPEAT SO_TERM_INTERCHROMOSOMAL_BREAKPOINT ATTRIB_TYPE_VARIATION_NAMES SO_TERM_FEATURE_ELONGATION SO_TERM_TRANSCRIPT_ABLATION SO_TERM_TF_BINDING_SITE_VARIANT ATTRIB_TYPE_DISPLAY_TERM SO_TERM_INTRON_VARIANT SO_TERM_STOP_GAINED ATTRIB_TYPE_REVIEW_STATUS SO_TERM_SPLICE_DONOR_VARIANT ATTRIB_TYPE_SIFT_PREDICTION SO_TERM_START_LOST SO_TERM_FEATURE_TRUNCATION ATTRIB_TYPE_VARIANCE SO_TERM_COMPLEX_SUBSTITUTION ATTRIB_TYPE_BASED_ON SO_TERM_INTRACHROMOSOMAL_BREAKPOINT SO_TERM_SPLICE_REGION_VARIANT SO_TERM_TFBS_ABLATION ATTRIB_TYPE_ODDS_RATIO SO_TERM_REGULATORY_REGION_AMPLIFICATION SO_TERM_MISSENSE_VARIANT SO_TERM_SNV ATTRIB_TYPE_EXTERNAL_ID SO_TERM_STRUCTURAL_VARIANT SO_TERM_PROBE ATTRIB_TYPE_DBSNP_CLIN_SIG ATTRIB_TYPE_LOD_SCORE SO_TERM_SEQUENCE_ALTERATION SO_TERM_REGULATORY_REGION_VARIANT SO_TERM_START_RETAINED_VARIANT ATTRIB_TYPE_MARKER_ACCESSION_ID SO_TERM_SUBSTITUTION ATTRIB_TYPE_DGVA_CLIN_SIG SO_TERM_NON_CODING_TRANSCRIPT_EXON_VARIANT SO_TERM_NOVEL_SEQUENCE_INSERTION SO_TERM_INCOMPLETE_TERMINAL_CODON_VARIANT SO_TERM_DUPLICATION SO_TERM_TFBS_AMPLIFICATION SO_TERM_5_PRIME_UTR_VARIANT ATTRIB_TYPE_CONSERVATION_SCORE ATTRIB_TYPE_PROT_FUNC_ANALYSIS ATTRIB_TYPE_STRAIN_ID SO_TERM_TANDEM_DUPLICATION ATTRIB_TYPE_P_VALUE ATTRIB_TYPE_ASSOCIATED_GENE SO_TERM_MOBILE_ELEMENT_INSERTION SO_TERM_MATURE_MIRNA_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_VARIANT SO_TERM_DOWNSTREAM_GENE_VARIANT SO_TERM_INFRAME_INSERTION SO_TERM_INSERTION SO_TERM_SHORT_TANDEM_REPEAT_VARIATION SO_TERM_NMD_TRANSCRIPT_VARIANT ATTRIB_TYPE_SO_TERM ATTRIB_TYPE_SAMPLE_ID SO_TERM_INTERGENIC_VARIANT SO_TERM_SYNONYMOUS_VARIANT ATTRIB_TYPE_SHORT_NAME SO_TERM_TRANSLOCATION ATTRIB_TYPE_INHERITANCE_TYPE SO_TERM_COPY_NUMBER_VARIATION ATTRIB_TYPE_POLYPHEN_PREDICTION SO_TERM_REGULATORY_REGION_ABLATION SO_TERM_INVERSION SO_TERM_LOSS_OF_HETEROZYGOSITY SO_TERM_STOP_LOST ATTRIB_TYPE_RANK SO_TERM_INTERCHROMOSOMAL_TRANSLOCATION SO_TERM_3_PRIME_UTR_VARIANT SO_TERM_UPSTREAM_GENE_VARIANT SO_TERM_INTRACHROMOSOMAL_TRANSLOCATION ATTRIB_TYPE_CLINVAR_CLIN_SIG ATTRIB_TYPE_SO_ACCESSION ATTRIB_TYPE_ALLELE_SYMBOL SO_TERM_COPY_NUMBER_LOSS SO_TERM_MOBILE_ELEMENT_DELETION ATTRIB_TYPE_SEQUENCE_NUMBER ATTRIB_TYPE_NCBI_TERM SO_TERM_DELETION ATTRIB_TYPE_FEATURE_SO_TERM SO_TERM_FRAMESHIFT_VARIANT SO_TERM_COPY_NUMBER_GAIN ATTRIB_TYPE_RISK_ALLELE ATTRIB_TYPE_BETA_COEF ATTRIB_TYPE_EVIDENCE SO_TERM_INFRAME_DELETION SO_TERM_GENETIC_MARKER SO_TERM_TRANSCRIPT_AMPLIFICATION SO_TERM_SEQUENCE_VARIANT);
+our @EXPORT_OK = qw(%OVERLAP_CONSEQUENCES %VARIATION_CLASSES $DEFAULT_OVERLAP_CONSEQUENCE $SO_ACC_MAPPER SO_TERM_START_LOST ATTRIB_TYPE_ALLELE_SYMBOL SO_TERM_TRANSCRIPT_AMPLIFICATION SO_TERM_SEQUENCE_ALTERATION ATTRIB_TYPE_POLYPHEN_PREDICTION ATTRIB_TYPE_RANK SO_TERM_STOP_RETAINED_VARIANT SO_TERM_NMD_TRANSCRIPT_VARIANT SO_TERM_INTERGENIC_VARIANT SO_TERM_INCOMPLETE_TERMINAL_CODON_VARIANT SO_TERM_TRANSCRIPT_ABLATION SO_TERM_FEATURE_ELONGATION SO_TERM_GENETIC_MARKER ATTRIB_TYPE_SO_ACCESSION SO_TERM_INTRACHROMOSOMAL_TRANSLOCATION ATTRIB_TYPE_SIFT_PREDICTION SO_TERM_REGULATORY_REGION_VARIANT SO_TERM_INDEL SO_TERM_COPY_NUMBER_LOSS SO_TERM_INTRON_VARIANT SO_TERM_SPLICE_ACCEPTOR_VARIANT SO_TERM_STOP_LOST ATTRIB_TYPE_EVIDENCE ATTRIB_TYPE_PROT_FUNC_ANALYSIS SO_TERM_INSERTION SO_TERM_TFBS_ABLATION SO_TERM_FRAMESHIFT_VARIANT ATTRIB_TYPE_ODDS_RATIO SO_TERM_REGULATORY_REGION_ABLATION SO_TERM_MISSENSE_VARIANT SO_TERM_START_RETAINED_VARIANT SO_TERM_TF_BINDING_SITE_VARIANT SO_TERM_MOBILE_ELEMENT_INSERTION SO_TERM_MATURE_MIRNA_VARIANT ATTRIB_TYPE_DISPLAY_TERM SO_TERM_LOSS_OF_HETEROZYGOSITY SO_TERM_INTERCHROMOSOMAL_TRANSLOCATION SO_TERM_COPY_NUMBER_VARIATION SO_TERM_SHORT_TANDEM_REPEAT_VARIATION ATTRIB_TYPE_BASED_ON ATTRIB_TYPE_SEQUENCE_NUMBER SO_TERM_PROTEIN_ALTERING_VARIANT SO_TERM_TRANSLOCATION SO_TERM_MOBILE_ELEMENT_DELETION SO_TERM_DELETION SO_TERM_TANDEM_REPEAT SO_TERM_ALU_INSERTION SO_TERM_INTERCHROMOSOMAL_BREAKPOINT ATTRIB_TYPE_ASSOCIATED_GENE ATTRIB_TYPE_MARKER_ACCESSION_ID ATTRIB_TYPE_LOD_SCORE ATTRIB_TYPE_STRAIN_ID SO_TERM_3_PRIME_UTR_VARIANT SO_TERM_COPY_NUMBER_GAIN SO_TERM_INVERSION ATTRIB_TYPE_P_VALUE SO_TERM_SEQUENCE_VARIANT SO_TERM_TFBS_AMPLIFICATION SO_TERM_SNV ATTRIB_TYPE_INHERITANCE_TYPE ATTRIB_TYPE_REVIEW_STATUS ATTRIB_TYPE_VARIANCE SO_TERM_SPLICE_DONOR_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_EXON_VARIANT SO_TERM_COMPLEX_SUBSTITUTION SO_TERM_FEATURE_TRUNCATION ATTRIB_TYPE_BETA_COEF ATTRIB_TYPE_SO_TERM ATTRIB_TYPE_SAMPLE_ID SO_TERM_SUBSTITUTION SO_TERM_CODING_SEQUENCE_VARIANT ATTRIB_TYPE_DBSNP_CLIN_SIG SO_TERM_COMPLEX_STRUCTURAL_ALTERATION SO_TERM_SYNONYMOUS_VARIANT ATTRIB_TYPE_VARIATION_NAMES SO_TERM_INTRACHROMOSOMAL_BREAKPOINT ATTRIB_TYPE_SHORT_NAME ATTRIB_TYPE_CONSERVATION_SCORE SO_TERM_PROBE ATTRIB_TYPE_NCBI_TERM SO_TERM_DOWNSTREAM_GENE_VARIANT SO_TERM_SPLICE_REGION_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_VARIANT ATTRIB_TYPE_ALLELE_ACCESSION_ID SO_TERM_NOVEL_SEQUENCE_INSERTION SO_TERM_5_PRIME_UTR_VARIANT SO_TERM_REGULATORY_REGION_AMPLIFICATION ATTRIB_TYPE_FEATURE_SO_TERM SO_TERM_STOP_GAINED SO_TERM_DUPLICATION ATTRIB_TYPE_EXTERNAL_ID SO_TERM_INFRAME_INSERTION ATTRIB_TYPE_DGVA_CLIN_SIG SO_TERM_UPSTREAM_GENE_VARIANT ATTRIB_TYPE_RISK_ALLELE SO_TERM_STRUCTURAL_VARIANT ATTRIB_TYPE_CLINVAR_CLIN_SIG SO_TERM_INFRAME_DELETION SO_TERM_TANDEM_DUPLICATION);
 
-our %EXPORT_TAGS = ( attrib_types => [qw(ATTRIB_TYPE_ALLELE_ACCESSION_ID ATTRIB_TYPE_SO_TERM ATTRIB_TYPE_SAMPLE_ID ATTRIB_TYPE_VARIATION_NAMES ATTRIB_TYPE_SHORT_NAME ATTRIB_TYPE_DISPLAY_TERM ATTRIB_TYPE_INHERITANCE_TYPE ATTRIB_TYPE_REVIEW_STATUS ATTRIB_TYPE_SIFT_PREDICTION ATTRIB_TYPE_VARIANCE ATTRIB_TYPE_POLYPHEN_PREDICTION ATTRIB_TYPE_BASED_ON ATTRIB_TYPE_RANK ATTRIB_TYPE_ODDS_RATIO ATTRIB_TYPE_EXTERNAL_ID ATTRIB_TYPE_SO_ACCESSION ATTRIB_TYPE_CLINVAR_CLIN_SIG ATTRIB_TYPE_DBSNP_CLIN_SIG ATTRIB_TYPE_LOD_SCORE ATTRIB_TYPE_ALLELE_SYMBOL ATTRIB_TYPE_MARKER_ACCESSION_ID ATTRIB_TYPE_SEQUENCE_NUMBER ATTRIB_TYPE_DGVA_CLIN_SIG ATTRIB_TYPE_NCBI_TERM ATTRIB_TYPE_FEATURE_SO_TERM ATTRIB_TYPE_RISK_ALLELE ATTRIB_TYPE_CONSERVATION_SCORE ATTRIB_TYPE_BETA_COEF ATTRIB_TYPE_PROT_FUNC_ANALYSIS ATTRIB_TYPE_STRAIN_ID ATTRIB_TYPE_EVIDENCE ATTRIB_TYPE_P_VALUE ATTRIB_TYPE_ASSOCIATED_GENE)], SO_consequence_terms => [qw(SO_TERM_NON_CODING_TRANSCRIPT_VARIANT SO_TERM_DOWNSTREAM_GENE_VARIANT SO_TERM_CODING_SEQUENCE_VARIANT SO_TERM_STOP_RETAINED_VARIANT SO_TERM_INFRAME_INSERTION SO_TERM_NMD_TRANSCRIPT_VARIANT SO_TERM_PROTEIN_ALTERING_VARIANT SO_TERM_SPLICE_ACCEPTOR_VARIANT SO_TERM_INTERGENIC_VARIANT SO_TERM_FEATURE_ELONGATION SO_TERM_TRANSCRIPT_ABLATION SO_TERM_SYNONYMOUS_VARIANT SO_TERM_TF_BINDING_SITE_VARIANT SO_TERM_INTRON_VARIANT SO_TERM_STOP_GAINED SO_TERM_SPLICE_DONOR_VARIANT SO_TERM_FEATURE_TRUNCATION SO_TERM_REGULATORY_REGION_ABLATION SO_TERM_START_LOST SO_TERM_TFBS_ABLATION SO_TERM_SPLICE_REGION_VARIANT SO_TERM_STOP_LOST SO_TERM_REGULATORY_REGION_AMPLIFICATION SO_TERM_3_PRIME_UTR_VARIANT SO_TERM_UPSTREAM_GENE_VARIANT SO_TERM_MISSENSE_VARIANT SO_TERM_REGULATORY_REGION_VARIANT SO_TERM_START_RETAINED_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_EXON_VARIANT SO_TERM_INCOMPLETE_TERMINAL_CODON_VARIANT SO_TERM_FRAMESHIFT_VARIANT SO_TERM_TFBS_AMPLIFICATION SO_TERM_5_PRIME_UTR_VARIANT SO_TERM_INFRAME_DELETION SO_TERM_SEQUENCE_VARIANT SO_TERM_TRANSCRIPT_AMPLIFICATION SO_TERM_MATURE_MIRNA_VARIANT)], SO_class_terms => [qw(SO_TERM_INTERCHROMOSOMAL_TRANSLOCATION SO_TERM_INDEL SO_TERM_SNV SO_TERM_STRUCTURAL_VARIANT SO_TERM_ALU_INSERTION SO_TERM_INTRACHROMOSOMAL_TRANSLOCATION SO_TERM_COMPLEX_STRUCTURAL_ALTERATION SO_TERM_INSERTION SO_TERM_SHORT_TANDEM_REPEAT_VARIATION SO_TERM_PROBE SO_TERM_COPY_NUMBER_LOSS SO_TERM_SEQUENCE_ALTERATION SO_TERM_TANDEM_REPEAT SO_TERM_INTERCHROMOSOMAL_BREAKPOINT SO_TERM_MOBILE_ELEMENT_DELETION SO_TERM_SUBSTITUTION SO_TERM_NOVEL_SEQUENCE_INSERTION SO_TERM_DELETION SO_TERM_COPY_NUMBER_GAIN SO_TERM_DUPLICATION SO_TERM_TRANSLOCATION SO_TERM_COPY_NUMBER_VARIATION SO_TERM_TANDEM_DUPLICATION SO_TERM_GENETIC_MARKER SO_TERM_COMPLEX_SUBSTITUTION SO_TERM_INVERSION SO_TERM_LOSS_OF_HETEROZYGOSITY SO_TERM_INTRACHROMOSOMAL_BREAKPOINT SO_TERM_MOBILE_ELEMENT_INSERTION)],  );
+our %EXPORT_TAGS = ( attrib_types => [qw(ATTRIB_TYPE_P_VALUE ATTRIB_TYPE_STRAIN_ID ATTRIB_TYPE_REVIEW_STATUS ATTRIB_TYPE_SO_ACCESSION ATTRIB_TYPE_INHERITANCE_TYPE ATTRIB_TYPE_ALLELE_SYMBOL ATTRIB_TYPE_POLYPHEN_PREDICTION ATTRIB_TYPE_RANK ATTRIB_TYPE_LOD_SCORE ATTRIB_TYPE_ASSOCIATED_GENE ATTRIB_TYPE_MARKER_ACCESSION_ID ATTRIB_TYPE_EVIDENCE ATTRIB_TYPE_ODDS_RATIO ATTRIB_TYPE_BETA_COEF ATTRIB_TYPE_PROT_FUNC_ANALYSIS ATTRIB_TYPE_SIFT_PREDICTION ATTRIB_TYPE_VARIANCE ATTRIB_TYPE_NCBI_TERM ATTRIB_TYPE_VARIATION_NAMES ATTRIB_TYPE_SHORT_NAME ATTRIB_TYPE_CONSERVATION_SCORE ATTRIB_TYPE_SO_TERM ATTRIB_TYPE_SAMPLE_ID ATTRIB_TYPE_DBSNP_CLIN_SIG ATTRIB_TYPE_EXTERNAL_ID ATTRIB_TYPE_DGVA_CLIN_SIG ATTRIB_TYPE_FEATURE_SO_TERM ATTRIB_TYPE_SEQUENCE_NUMBER ATTRIB_TYPE_RISK_ALLELE ATTRIB_TYPE_CLINVAR_CLIN_SIG ATTRIB_TYPE_DISPLAY_TERM ATTRIB_TYPE_BASED_ON ATTRIB_TYPE_ALLELE_ACCESSION_ID)], SO_consequence_terms => [qw(SO_TERM_INTRON_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_EXON_VARIANT SO_TERM_SPLICE_DONOR_VARIANT SO_TERM_REGULATORY_REGION_VARIANT SO_TERM_FRAMESHIFT_VARIANT SO_TERM_TFBS_ABLATION SO_TERM_FEATURE_TRUNCATION SO_TERM_SPLICE_ACCEPTOR_VARIANT SO_TERM_STOP_LOST SO_TERM_TRANSCRIPT_AMPLIFICATION SO_TERM_START_LOST SO_TERM_TRANSCRIPT_ABLATION SO_TERM_INCOMPLETE_TERMINAL_CODON_VARIANT SO_TERM_SEQUENCE_VARIANT SO_TERM_FEATURE_ELONGATION SO_TERM_TFBS_AMPLIFICATION SO_TERM_3_PRIME_UTR_VARIANT SO_TERM_NMD_TRANSCRIPT_VARIANT SO_TERM_STOP_RETAINED_VARIANT SO_TERM_INTERGENIC_VARIANT SO_TERM_NON_CODING_TRANSCRIPT_VARIANT SO_TERM_5_PRIME_UTR_VARIANT SO_TERM_REGULATORY_REGION_AMPLIFICATION SO_TERM_DOWNSTREAM_GENE_VARIANT SO_TERM_MATURE_MIRNA_VARIANT SO_TERM_SPLICE_REGION_VARIANT SO_TERM_INFRAME_DELETION SO_TERM_STOP_GAINED SO_TERM_PROTEIN_ALTERING_VARIANT SO_TERM_UPSTREAM_GENE_VARIANT SO_TERM_INFRAME_INSERTION SO_TERM_MISSENSE_VARIANT SO_TERM_CODING_SEQUENCE_VARIANT SO_TERM_REGULATORY_REGION_ABLATION SO_TERM_START_RETAINED_VARIANT SO_TERM_SYNONYMOUS_VARIANT SO_TERM_TF_BINDING_SITE_VARIANT)], SO_class_terms => [qw(SO_TERM_TANDEM_DUPLICATION SO_TERM_INSERTION SO_TERM_STRUCTURAL_VARIANT SO_TERM_MOBILE_ELEMENT_DELETION SO_TERM_TRANSLOCATION SO_TERM_DUPLICATION SO_TERM_COMPLEX_SUBSTITUTION SO_TERM_SHORT_TANDEM_REPEAT_VARIATION SO_TERM_NOVEL_SEQUENCE_INSERTION SO_TERM_COPY_NUMBER_VARIATION SO_TERM_INTERCHROMOSOMAL_TRANSLOCATION SO_TERM_COPY_NUMBER_LOSS SO_TERM_INDEL SO_TERM_LOSS_OF_HETEROZYGOSITY SO_TERM_INTRACHROMOSOMAL_TRANSLOCATION SO_TERM_GENETIC_MARKER SO_TERM_SNV SO_TERM_PROBE SO_TERM_INTRACHROMOSOMAL_BREAKPOINT SO_TERM_INVERSION SO_TERM_COPY_NUMBER_GAIN SO_TERM_MOBILE_ELEMENT_INSERTION SO_TERM_COMPLEX_STRUCTURAL_ALTERATION SO_TERM_SEQUENCE_ALTERATION SO_TERM_SUBSTITUTION SO_TERM_ALU_INSERTION SO_TERM_INTERCHROMOSOMAL_BREAKPOINT SO_TERM_TANDEM_REPEAT SO_TERM_DELETION)],  );
 
 use Bio::EnsEMBL::Variation::OverlapConsequence;
 
@@ -118,880 +118,886 @@ use constant SO_TERM_PROTEIN_ALTERING_VARIANT => 'protein_altering_variant';
 
 our %VARIATION_CLASSES = (
 'SNV' => {
-  'somatic_display_term' => 'somatic SNV',
   'SO_accession' => 'SO:0001483',
-  'display_term' => 'SNP'
+  'display_term' => 'SNP',
+  'somatic_display_term' => 'somatic SNV'
 }
 ,
 'substitution' => {
-  'somatic_display_term' => 'somatic substitution',
   'SO_accession' => 'SO:1000002',
-  'display_term' => 'substitution'
+  'display_term' => 'substitution',
+  'somatic_display_term' => 'somatic substitution'
 }
 ,
 'insertion' => {
-  'somatic_display_term' => 'somatic insertion',
   'SO_accession' => 'SO:0000667',
-  'display_term' => 'insertion'
+  'display_term' => 'insertion',
+  'somatic_display_term' => 'somatic insertion'
 }
 ,
 'deletion' => {
-  'somatic_display_term' => 'somatic deletion',
   'SO_accession' => 'SO:0000159',
-  'display_term' => 'deletion'
+  'display_term' => 'deletion',
+  'somatic_display_term' => 'somatic deletion'
 }
 ,
 'indel' => {
-  'somatic_display_term' => 'somatic indel',
   'SO_accession' => 'SO:1000032',
-  'display_term' => 'indel'
+  'display_term' => 'indel',
+  'somatic_display_term' => 'somatic indel'
 }
 ,
 'tandem_repeat' => {
-  'somatic_display_term' => 'somatic tandem repeat',
   'SO_accession' => 'SO:0000705',
-  'display_term' => 'tandem repeat'
+  'display_term' => 'tandem repeat',
+  'somatic_display_term' => 'somatic tandem repeat'
 }
 ,
 'sequence_alteration' => {
-  'somatic_display_term' => 'somatic sequence alteration',
   'SO_accession' => 'SO:0001059',
-  'display_term' => 'sequence alteration'
+  'display_term' => 'sequence alteration',
+  'somatic_display_term' => 'somatic sequence alteration'
 }
 ,
 'genetic_marker' => {
-  'somatic_display_term' => 'somatic genetic marker',
   'SO_accession' => 'SO:0001645',
-  'display_term' => 'genetic marker'
+  'display_term' => 'genetic marker',
+  'somatic_display_term' => 'somatic genetic marker'
 }
 ,
 'structural_variant' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic SV',
   'SO_accession' => 'SO:0001537',
-  'display_term' => 'SV'
+  'display_term' => 'SV',
+  'somatic_display_term' => 'somatic SV',
+  'type' => 'sv'
 }
 ,
 'copy_number_variation' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic CNV',
   'SO_accession' => 'SO:0001019',
-  'display_term' => 'CNV'
+  'display_term' => 'CNV',
+  'somatic_display_term' => 'somatic CNV',
+  'type' => 'sv'
 }
 ,
 'probe' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic CNV_PROBE',
   'SO_accession' => 'SO:0000051',
-  'display_term' => 'CNV_PROBE'
+  'display_term' => 'CNV_PROBE',
+  'somatic_display_term' => 'somatic CNV_PROBE',
+  'type' => 'sv'
 }
 ,
 'copy_number_gain' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic gain',
   'SO_accession' => 'SO:0001742',
-  'display_term' => 'gain'
+  'display_term' => 'gain',
+  'somatic_display_term' => 'somatic gain',
+  'type' => 'sv'
 }
 ,
 'copy_number_loss' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic loss',
   'SO_accession' => 'SO:0001743',
-  'display_term' => 'loss'
+  'display_term' => 'loss',
+  'somatic_display_term' => 'somatic loss',
+  'type' => 'sv'
 }
 ,
 'inversion' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic inversion',
   'SO_accession' => 'SO:1000036',
-  'display_term' => 'inversion'
+  'display_term' => 'inversion',
+  'somatic_display_term' => 'somatic inversion',
+  'type' => 'sv'
 }
 ,
 'complex_structural_alteration' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic complex alteration',
   'SO_accession' => 'SO:0001784',
-  'display_term' => 'complex alteration'
+  'display_term' => 'complex alteration',
+  'somatic_display_term' => 'somatic complex alteration',
+  'type' => 'sv'
 }
 ,
 'tandem_duplication' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic tandem duplication',
   'SO_accession' => 'SO:1000173',
-  'display_term' => 'tandem duplication'
+  'display_term' => 'tandem duplication',
+  'somatic_display_term' => 'somatic tandem duplication',
+  'type' => 'sv'
 }
 ,
 'mobile_element_insertion' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic mobile element insertion',
   'SO_accession' => 'SO:0001837',
-  'display_term' => 'mobile element insertion'
+  'display_term' => 'mobile element insertion',
+  'somatic_display_term' => 'somatic mobile element insertion',
+  'type' => 'sv'
 }
 ,
 'mobile_element_deletion' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic mobile element deletion',
   'SO_accession' => 'SO:0002066',
-  'display_term' => 'mobile element deletion'
+  'display_term' => 'mobile element deletion',
+  'somatic_display_term' => 'somatic mobile element deletion',
+  'type' => 'sv'
 }
 ,
 'interchromosomal_breakpoint' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic interchromosomal breakpoint',
   'SO_accession' => 'SO:0001873',
-  'display_term' => 'interchromosomal breakpoint'
+  'display_term' => 'interchromosomal breakpoint',
+  'somatic_display_term' => 'somatic interchromosomal breakpoint',
+  'type' => 'sv'
 }
 ,
 'intrachromosomal_breakpoint' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic intrachromosomal breakpoint',
   'SO_accession' => 'SO:0001874',
-  'display_term' => 'intrachromosomal breakpoint'
+  'display_term' => 'intrachromosomal breakpoint',
+  'somatic_display_term' => 'somatic intrachromosomal breakpoint',
+  'type' => 'sv'
 }
 ,
 'translocation' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic translocation',
   'SO_accession' => 'SO:0000199',
-  'display_term' => 'translocation'
+  'display_term' => 'translocation',
+  'somatic_display_term' => 'somatic translocation',
+  'type' => 'sv'
 }
 ,
 'duplication' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic duplication',
   'SO_accession' => 'SO:1000035',
-  'display_term' => 'duplication'
+  'display_term' => 'duplication',
+  'somatic_display_term' => 'somatic duplication',
+  'type' => 'sv'
 }
 ,
 'novel_sequence_insertion' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic novel sequence insertion',
   'SO_accession' => 'SO:0001838',
-  'display_term' => 'novel sequence insertion'
+  'display_term' => 'novel sequence insertion',
+  'somatic_display_term' => 'somatic novel sequence insertion',
+  'type' => 'sv'
 }
 ,
 'interchromosomal_translocation' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic interchromosomal translocation',
   'SO_accession' => 'SO:0002060',
-  'display_term' => 'interchromosomal translocation'
+  'display_term' => 'interchromosomal translocation',
+  'somatic_display_term' => 'somatic interchromosomal translocation',
+  'type' => 'sv'
 }
 ,
 'intrachromosomal_translocation' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic intrachromosomal translocation',
   'SO_accession' => 'SO:0002061',
-  'display_term' => 'intrachromosomal translocation'
+  'display_term' => 'intrachromosomal translocation',
+  'somatic_display_term' => 'somatic intrachromosomal translocation',
+  'type' => 'sv'
 }
 ,
 'Alu_insertion' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic alu insertion',
   'SO_accession' => 'SO:0002063',
-  'display_term' => 'Alu insertion'
+  'display_term' => 'Alu insertion',
+  'somatic_display_term' => 'somatic alu insertion',
+  'type' => 'sv'
 }
 ,
 'complex_substitution' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic complex substitution',
   'SO_accession' => 'SO:1000005',
-  'display_term' => 'complex substitution'
+  'display_term' => 'complex substitution',
+  'somatic_display_term' => 'somatic complex substitution',
+  'type' => 'sv'
 }
 ,
 'short_tandem_repeat_variation' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic short tandem repeat variation',
   'SO_accession' => 'SO:0002096',
-  'display_term' => 'short tandem repeat variation'
+  'display_term' => 'short tandem repeat variation',
+  'somatic_display_term' => 'somatic short tandem repeat variation',
+  'type' => 'sv'
 }
 ,
 'loss_of_heterozygosity' => {
-  'type' => 'sv',
-  'somatic_display_term' => 'somatic loss of heterozygosity',
   'SO_accession' => 'SO:0001786',
-  'display_term' => 'loss of heterozygosity'
+  'display_term' => 'loss of heterozygosity',
+  'somatic_display_term' => 'somatic loss of heterozygosity',
+  'type' => 'sv'
 }
 ,
 );
 
 our $DEFAULT_OVERLAP_CONSEQUENCE = Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'is_default' => 1,
+  'SO_accession' => 'SO:0001628',
+  'SO_term' => 'intergenic_variant',
+  'description' => 'A sequence variant located in the intergenic region, between genes',
+  'display_term' => 'INTERGENIC',
+  'impact' => 'MODIFIER',
   'include' => {
                  'within_feature' => 0
                },
-  'description' => 'A sequence variant located in the intergenic region, between genes',
-  'SO_accession' => 'SO:0001628',
-  'SO_term' => 'intergenic_variant',
-  'tier' => '4',
+  'is_default' => 1,
   'label' => 'intergenic variant',
   'rank' => '38',
-  'impact' => 'MODIFIER',
-  'display_term' => 'INTERGENIC'
+  'tier' => '4'
 }
 );
 
 
 our %OVERLAP_CONSEQUENCES = (
 'sequence_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
+  'SO_accession' => 'SO:0001060',
+  'SO_term' => 'sequence_variant',
+  'description' => 'A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration',
+  'display_term' => 'SEQUENCE_VARIANT',
+  'impact' => 'MODIFIER',
   'include' => {
                  'within_feature' => 0
                },
-  'description' => 'A sequence_variant is a non exact copy of a sequence_feature or genome exhibiting one or more sequence_alteration',
-  'SO_accession' => 'SO:0001060',
-  'SO_term' => 'sequence_variant',
-  'tier' => '4',
   'label' => 'sequence variant',
   'rank' => '39',
-  'display_term' => 'SEQUENCE_VARIANT',
-  'impact' => 'MODIFIER'
+  'tier' => '4'
 }
 ),
 'intergenic_variant' => $DEFAULT_OVERLAP_CONSEQUENCE,
 'upstream_gene_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001631',
+  'SO_term' => 'upstream_gene_variant',
+  'description' => 'A sequence variant located 5\' of a gene',
+  'display_term' => 'UPSTREAM',
+  'feature_SO_term' => 'transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
   'include' => {
                  'within_feature' => 0
                },
-  'feature_SO_term' => 'transcript',
-  'description' => 'A sequence variant located 5\' of a gene',
-  'SO_accession' => 'SO:0001631',
-  'SO_term' => 'upstream_gene_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::upstream',
   'label' => 'upstream gene variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::upstream',
   'rank' => '24',
-  'impact' => 'MODIFIER',
-  'display_term' => 'UPSTREAM',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'downstream_gene_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001632',
+  'SO_term' => 'downstream_gene_variant',
+  'description' => 'A sequence variant located 3\' of a gene',
+  'display_term' => 'DOWNSTREAM',
+  'feature_SO_term' => 'transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
   'include' => {
                  'within_feature' => 0
                },
-  'feature_SO_term' => 'transcript',
-  'description' => 'A sequence variant located 3\' of a gene',
-  'SO_accession' => 'SO:0001632',
-  'SO_term' => 'downstream_gene_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::downstream',
   'label' => 'downstream gene variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::downstream',
   'rank' => '25',
-  'impact' => 'MODIFIER',
-  'display_term' => 'DOWNSTREAM',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'splice_donor_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'NCBI_term' => 'splice-5',
+  'SO_accession' => 'SO:0001575',
+  'SO_term' => 'splice_donor_variant',
+  'description' => 'A splice variant that changes the 2 base region at the 5\' end of an intron',
+  'display_term' => 'ESSENTIAL_SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'intron_boundary' => 1
                },
-  'NCBI_term' => 'splice-5',
-  'feature_SO_term' => 'primary_transcript',
-  'description' => 'A splice variant that changes the 2 base region at the 5\' end of an intron',
-  'SO_accession' => 'SO:0001575',
-  'tier' => '3',
-  'SO_term' => 'splice_donor_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::donor_splice_site',
   'label' => 'splice donor variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::donor_splice_site',
   'rank' => '3',
-  'impact' => 'HIGH',
-  'display_term' => 'ESSENTIAL_SPLICE_SITE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'splice_acceptor_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'NCBI_term' => 'splice-3',
+  'SO_accession' => 'SO:0001574',
+  'SO_term' => 'splice_acceptor_variant',
+  'description' => 'A splice variant that changes the 2 base region at the 3\' end of an intron',
+  'display_term' => 'ESSENTIAL_SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'intron_boundary' => 1
                },
-  'NCBI_term' => 'splice-3',
-  'feature_SO_term' => 'primary_transcript',
-  'description' => 'A splice variant that changes the 2 base region at the 3\' end of an intron',
-  'SO_accession' => 'SO:0001574',
-  'tier' => '3',
-  'SO_term' => 'splice_acceptor_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::acceptor_splice_site',
   'label' => 'splice acceptor variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::acceptor_splice_site',
   'rank' => '3',
-  'impact' => 'HIGH',
-  'display_term' => 'ESSENTIAL_SPLICE_SITE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'splice_region_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'SO_accession' => 'SO:0001630',
+  'SO_term' => 'splice_region_variant',
+  'description' => 'A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron',
+  'display_term' => 'SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
   'include' => {
                  'intron_boundary' => 1
                },
-  'feature_SO_term' => 'primary_transcript',
-  'description' => 'A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron',
-  'SO_accession' => 'SO:0001630',
-  'SO_term' => 'splice_region_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_region',
   'label' => 'splice region variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_region',
   'rank' => '13',
-  'impact' => 'LOW',
-  'display_term' => 'SPLICE_SITE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'intron_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'NCBI_term' => 'intron',
+  'SO_accession' => 'SO:0001627',
+  'SO_term' => 'intron_variant',
+  'description' => 'A transcript variant occurring within an intron',
+  'display_term' => 'INTRONIC',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
   'include' => {
                  'intron' => 1
                },
-  'NCBI_term' => 'intron',
-  'feature_SO_term' => 'primary_transcript',
-  'description' => 'A transcript variant occurring within an intron',
-  'SO_accession' => 'SO:0001627',
-  'tier' => '3',
-  'SO_term' => 'intron_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_intron',
   'label' => 'intron variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_intron',
   'rank' => '21',
-  'impact' => 'MODIFIER',
-  'display_term' => 'INTRONIC',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 '5_prime_UTR_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'utr' => 1,
-                 'exon' => 1
-               },
   'NCBI_term' => 'untranslated_5',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A UTR variant of the 5\' UTR',
   'SO_accession' => 'SO:0001623',
-  'tier' => '3',
   'SO_term' => '5_prime_UTR_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_5_prime_utr',
-  'label' => '5 prime UTR variant',
-  'rank' => '18',
-  'impact' => 'MODIFIER',
+  'description' => 'A UTR variant of the 5\' UTR',
   'display_term' => '5PRIME_UTR',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'exon' => 1,
+                 'utr' => 1
+               },
+  'label' => '5 prime UTR variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_5_prime_utr',
+  'rank' => '18',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 '3_prime_UTR_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'utr' => 1,
-                 'exon' => 1
-               },
   'NCBI_term' => 'untranslated_3',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A UTR variant of the 3\' UTR',
   'SO_accession' => 'SO:0001624',
-  'tier' => '3',
   'SO_term' => '3_prime_UTR_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_3_prime_utr',
-  'label' => '3 prime UTR variant',
-  'rank' => '19',
-  'impact' => 'MODIFIER',
+  'description' => 'A UTR variant of the 3\' UTR',
   'display_term' => '3PRIME_UTR',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'exon' => 1,
+                 'utr' => 1
+               },
+  'label' => '3 prime UTR variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_3_prime_utr',
+  'rank' => '19',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'synonymous_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'NCBI_term' => 'cds-synon',
+  'SO_accession' => 'SO:0001819',
+  'SO_term' => 'synonymous_variant',
+  'description' => 'A sequence variant where there is no resulting change to the encoded amino acid',
+  'display_term' => 'SYNONYMOUS_CODING',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
   'include' => {
                  'coding' => 1
                },
-  'NCBI_term' => 'cds-synon',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant where there is no resulting change to the encoded amino acid',
-  'SO_accession' => 'SO:0001819',
-  'tier' => '3',
-  'SO_term' => 'synonymous_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::synonymous_variant',
   'label' => 'synonymous variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::synonymous_variant',
   'rank' => '15',
-  'impact' => 'LOW',
-  'display_term' => 'SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'missense_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
-  'include' => {
-                 'increase_length' => 0,
-                 'decrease_length' => 0,
-                 'coding' => 1
-               },
   'NCBI_term' => 'missense',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant, that changes one or more bases, resulting in a different amino acid sequence but where the length is preserved',
   'SO_accession' => 'SO:0001583',
-  'tier' => '3',
   'SO_term' => 'missense_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::missense_variant',
-  'label' => 'missense variant',
-  'rank' => '12',
-  'impact' => 'MODERATE',
+  'description' => 'A sequence variant, that changes one or more bases, resulting in a different amino acid sequence but where the length is preserved',
   'display_term' => 'NON_SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODERATE',
+  'include' => {
+                 'coding' => 1,
+                 'decrease_length' => 0,
+                 'increase_length' => 0
+               },
+  'label' => 'missense variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::missense_variant',
+  'rank' => '12',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'inframe_insertion' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'insertion' => 1,
-                 'coding' => 1
-               },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'An inframe non synonymous variant that inserts bases into in the coding sequence',
   'SO_accession' => 'SO:0001821',
   'SO_term' => 'inframe_insertion',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::inframe_insertion',
-  'label' => 'inframe insertion',
-  'rank' => '10',
-  'impact' => 'MODERATE',
+  'description' => 'An inframe non synonymous variant that inserts bases into in the coding sequence',
   'display_term' => 'NON_SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODERATE',
+  'include' => {
+                 'coding' => 1,
+                 'insertion' => 1
+               },
+  'label' => 'inframe insertion',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::inframe_insertion',
+  'rank' => '10',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'inframe_deletion' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'deletion' => 1,
-                 'coding' => 1
-               },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'An inframe non synonymous variant that deletes bases from the coding sequence',
   'SO_accession' => 'SO:0001822',
   'SO_term' => 'inframe_deletion',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::inframe_deletion',
-  'label' => 'inframe deletion',
-  'rank' => '11',
-  'impact' => 'MODERATE',
+  'description' => 'An inframe non synonymous variant that deletes bases from the coding sequence',
   'display_term' => 'NON_SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODERATE',
+  'include' => {
+                 'coding' => 1,
+                 'deletion' => 1
+               },
+  'label' => 'inframe deletion',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::inframe_deletion',
+  'rank' => '11',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'stop_gained' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'NCBI_term' => 'nonsense',
+  'SO_accession' => 'SO:0001587',
+  'SO_term' => 'stop_gained',
+  'description' => 'A sequence variant whereby at least one base of a codon is changed, resulting in a premature stop codon, leading to a shortened transcript',
+  'display_term' => 'STOP_GAINED',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'coding' => 1
                },
-  'NCBI_term' => 'nonsense',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant whereby at least one base of a codon is changed, resulting in a premature stop codon, leading to a shortened transcript',
-  'SO_accession' => 'SO:0001587',
-  'tier' => '3',
-  'SO_term' => 'stop_gained',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_gained',
   'label' => 'stop gained',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_gained',
   'rank' => '4',
-  'impact' => 'HIGH',
-  'display_term' => 'STOP_GAINED',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'stop_lost' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001578',
+  'SO_term' => 'stop_lost',
+  'description' => 'A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript',
+  'display_term' => 'STOP_LOST',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant where at least one base of the terminator codon (stop) is changed, resulting in an elongated transcript',
-  'SO_accession' => 'SO:0001578',
-  'SO_term' => 'stop_lost',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_lost',
   'label' => 'stop lost',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_lost',
   'rank' => '6',
-  'impact' => 'HIGH',
-  'display_term' => 'STOP_LOST',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'stop_retained_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'SO_accession' => 'SO:0001567',
+  'SO_term' => 'stop_retained_variant',
+  'description' => 'A sequence variant where at least one base in the terminator codon is changed, but the terminator remains',
+  'display_term' => 'SYNONYMOUS_CODING',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant where at least one base in the terminator codon is changed, but the terminator remains',
-  'SO_accession' => 'SO:0001567',
-  'SO_term' => 'stop_retained_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_retained',
   'label' => 'stop retained variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_retained',
   'rank' => '15',
-  'impact' => 'LOW',
-  'display_term' => 'SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'start_lost' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0002012',
+  'SO_term' => 'start_lost',
+  'description' => 'A codon variant that changes at least one base of the canonical start codon',
+  'display_term' => 'NON_SYNONYMOUS_CODING',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A codon variant that changes at least one base of the canonical start codon',
-  'SO_accession' => 'SO:0002012',
-  'SO_term' => 'start_lost',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::start_lost',
   'label' => 'start lost',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::start_lost',
   'rank' => '7',
-  'impact' => 'HIGH',
-  'display_term' => 'NON_SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'start_retained_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0002019',
+  'SO_term' => 'start_retained_variant',
+  'description' => 'A sequence variant where at least one base in the start codon is changed, but the start remains',
+  'display_term' => 'SYNONYMOUS_CODING',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant where at least one base in the start codon is changed, but the start remains',
-  'SO_accession' => 'SO:0002019',
-  'SO_term' => 'start_retained_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::start_retained_variant',
   'label' => 'start retained variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::start_retained_variant',
   'rank' => '15',
-  'impact' => 'LOW',
-  'display_term' => 'SYNONYMOUS_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'frameshift_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'snp' => 0,
-                 'coding' => 1
-               },
   'NCBI_term' => 'frameshift',
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant which causes a disruption of the translational reading frame, because the number of nucleotides inserted or deleted is not a multiple of three',
   'SO_accession' => 'SO:0001589',
-  'tier' => '3',
   'SO_term' => 'frameshift_variant',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::frameshift',
-  'label' => 'frameshift variant',
-  'rank' => '5',
-  'impact' => 'HIGH',
+  'description' => 'A sequence variant which causes a disruption of the translational reading frame, because the number of nucleotides inserted or deleted is not a multiple of three',
   'display_term' => 'FRAMESHIFT_CODING',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
+  'include' => {
+                 'coding' => 1,
+                 'snp' => 0
+               },
+  'label' => 'frameshift variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::frameshift',
+  'rank' => '5',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'incomplete_terminal_codon_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'SO_accession' => 'SO:0001626',
+  'SO_term' => 'incomplete_terminal_codon_variant',
+  'description' => 'A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed',
+  'display_term' => 'PARTIAL_CODON',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant where at least one base of the final codon of an incompletely annotated transcript is changed',
-  'SO_accession' => 'SO:0001626',
-  'SO_term' => 'incomplete_terminal_codon_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::partial_codon',
   'label' => 'incomplete terminal codon variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::partial_codon',
   'rank' => '14',
-  'impact' => 'LOW',
-  'display_term' => 'PARTIAL_CODON',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 'NMD_transcript_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'within_feature' => 1,
-                 'nonsense_mediated_decay' => 1
-               },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A variant in a transcript that is the target of NMD',
   'SO_accession' => 'SO:0001621',
   'SO_term' => 'NMD_transcript_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_nmd_transcript',
-  'label' => 'NMD transcript variant',
-  'rank' => '22',
-  'impact' => 'MODIFIER',
+  'description' => 'A variant in a transcript that is the target of NMD',
   'display_term' => 'NMD_TRANSCRIPT',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'nonsense_mediated_decay' => 1,
+                 'within_feature' => 1
+               },
+  'label' => 'NMD transcript variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_nmd_transcript',
+  'rank' => '22',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'non_coding_transcript_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'within_feature' => 1,
-                 'protein_coding' => 0
-               },
-  'feature_SO_term' => 'ncRNA',
-  'description' => 'A transcript variant of a non coding RNA gene',
   'SO_accession' => 'SO:0001619',
   'SO_term' => 'non_coding_transcript_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_non_coding_gene',
-  'label' => 'non coding transcript variant',
-  'rank' => '23',
-  'impact' => 'MODIFIER',
+  'description' => 'A transcript variant of a non coding RNA gene',
   'display_term' => 'WITHIN_NON_CODING_GENE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'ncRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'protein_coding' => 0,
+                 'within_feature' => 1
+               },
+  'label' => 'non coding transcript variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_non_coding_gene',
+  'rank' => '23',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'non_coding_transcript_exon_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'within_feature' => 1,
-                 'exon' => 1,
-                 'protein_coding' => 0
-               },
-  'feature_SO_term' => 'ncRNA',
-  'description' => 'A sequence variant that changes non-coding exon sequence in a non-coding transcript',
   'SO_accession' => 'SO:0001792',
   'SO_term' => 'non_coding_transcript_exon_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::non_coding_exon_variant',
-  'label' => 'non coding transcript exon variant',
-  'rank' => '20',
-  'impact' => 'MODIFIER',
+  'description' => 'A sequence variant that changes non-coding exon sequence in a non-coding transcript',
   'display_term' => 'WITHIN_NON_CODING_GENE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'ncRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'exon' => 1,
+                 'protein_coding' => 0,
+                 'within_feature' => 1
+               },
+  'label' => 'non coding transcript exon variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::non_coding_exon_variant',
+  'rank' => '20',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'mature_miRNA_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'within_feature' => 1,
-                 'nonsense_mediated_decay' => 0,
-                 'protein_coding' => 0
-               },
-  'feature_SO_term' => 'miRNA',
-  'description' => 'A transcript variant located with the sequence of the mature miRNA',
   'SO_accession' => 'SO:0001620',
   'SO_term' => 'mature_miRNA_variant',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_mature_miRNA',
-  'label' => 'mature miRNA variant',
-  'rank' => '17',
-  'impact' => 'MODIFIER',
+  'description' => 'A transcript variant located with the sequence of the mature miRNA',
   'display_term' => 'WITHIN_MATURE_miRNA',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'feature_SO_term' => 'miRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'nonsense_mediated_decay' => 0,
+                 'protein_coding' => 0,
+                 'within_feature' => 1
+               },
+  'label' => 'mature miRNA variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_mature_miRNA',
+  'rank' => '17',
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'coding_sequence_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001580',
+  'SO_term' => 'coding_sequence_variant',
+  'description' => 'A sequence variant that changes the coding sequence',
+  'display_term' => 'CODING_UNKNOWN',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence variant that changes the coding sequence',
-  'SO_accession' => 'SO:0001580',
-  'SO_term' => 'coding_sequence_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::coding_unknown',
   'label' => 'coding sequence variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::coding_unknown',
   'rank' => '16',
-  'impact' => 'MODIFIER',
-  'display_term' => 'CODING_UNKNOWN',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'regulatory_region_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'feature_SO_term' => 'regulatory_region',
-  'description' => 'A sequence variant located within a regulatory region',
   'SO_accession' => 'SO:0001566',
   'SO_term' => 'regulatory_region_variant',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_regulatory_feature',
-  'label' => 'regulatory region variant',
-  'rank' => '36',
-  'impact' => 'MODIFIER',
+  'description' => 'A sequence variant located within a regulatory region',
   'display_term' => 'REGULATORY_REGION',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature'
+  'feature_SO_term' => 'regulatory_region',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature',
+  'impact' => 'MODIFIER',
+  'label' => 'regulatory region variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_regulatory_feature',
+  'rank' => '36',
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'TF_binding_site_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'feature_SO_term' => 'TF_binding_site',
-  'description' => 'A sequence variant located within a transcription factor binding site',
   'SO_accession' => 'SO:0001782',
   'SO_term' => 'TF_binding_site_variant',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_motif_feature',
-  'label' => 'TF binding site',
-  'rank' => '30',
-  'impact' => 'MODIFIER',
+  'description' => 'A sequence variant located within a transcription factor binding site',
   'display_term' => 'REGULATORY_REGION',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature'
+  'feature_SO_term' => 'TF_binding_site',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature',
+  'impact' => 'MODIFIER',
+  'label' => 'TF binding site',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::within_motif_feature',
+  'rank' => '30',
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'transcript_ablation' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001893',
+  'SO_term' => 'transcript_ablation',
+  'description' => 'A feature ablation whereby the deleted region includes a transcript feature',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'complete_overlap' => 1,
                  'deletion' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A feature ablation whereby the deleted region includes a transcript feature',
-  'SO_accession' => 'SO:0001893',
-  'SO_term' => 'transcript_ablation',
-  'tier' => '1',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'label' => 'transcript ablation',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'rank' => '1',
-  'impact' => 'HIGH',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '1',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'transcript_amplification' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001889',
+  'SO_term' => 'transcript_amplification',
+  'description' => 'A feature amplification of a region containing a transcript',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'HIGH',
   'include' => {
                  'complete_overlap' => 1,
                  'increase_length' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A feature amplification of a region containing a transcript',
-  'SO_accession' => 'SO:0001889',
-  'SO_term' => 'transcript_amplification',
-  'tier' => '1',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'label' => 'transcript amplification',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'rank' => '8',
-  'impact' => 'HIGH',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '1',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'TFBS_ablation' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001895',
+  'SO_term' => 'TFBS_ablation',
+  'description' => 'A feature ablation whereby the deleted region includes a transcription factor binding site',
+  'feature_SO_term' => 'TF_binding_site',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature',
+  'impact' => 'MODERATE',
   'include' => {
                  'complete_overlap' => 1,
                  'deletion' => 1
                },
-  'feature_SO_term' => 'TF_binding_site',
-  'description' => 'A feature ablation whereby the deleted region includes a transcription factor binding site',
-  'SO_accession' => 'SO:0001895',
-  'SO_term' => 'TFBS_ablation',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'label' => 'TFBS ablation',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'rank' => '26',
-  'impact' => 'MODERATE',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature'
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'TFBS_amplification' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001892',
+  'SO_term' => 'TFBS_amplification',
+  'description' => 'A feature amplification of a region containing a transcription factor binding site',
+  'feature_SO_term' => 'TF_binding_site',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature',
+  'impact' => 'MODIFIER',
   'include' => {
                  'complete_overlap' => 1,
                  'increase_length' => 1
                },
-  'feature_SO_term' => 'TF_binding_site',
-  'description' => 'A feature amplification of a region containing a transcription factor binding site',
-  'SO_accession' => 'SO:0001892',
-  'SO_term' => 'TFBS_amplification',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'label' => 'TFBS amplification',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'rank' => '28',
-  'impact' => 'MODIFIER',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::MotifFeature'
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'regulatory_region_ablation' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001894',
+  'SO_term' => 'regulatory_region_ablation',
+  'description' => 'A feature ablation whereby the deleted region includes a regulatory region',
+  'feature_SO_term' => 'TF_binding_site',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature',
+  'impact' => 'MODERATE',
   'include' => {
                  'complete_overlap' => 1,
                  'deletion' => 1
                },
-  'feature_SO_term' => 'TF_binding_site',
-  'description' => 'A feature ablation whereby the deleted region includes a regulatory region',
-  'SO_accession' => 'SO:0001894',
-  'SO_term' => 'regulatory_region_ablation',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'label' => 'regulatory region ablation',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_ablation',
   'rank' => '31',
-  'impact' => 'MODERATE',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature'
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'regulatory_region_amplification' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+  'SO_accession' => 'SO:0001891',
+  'SO_term' => 'regulatory_region_amplification',
+  'description' => 'A feature amplification of a region containing a regulatory region',
+  'feature_SO_term' => 'TF_binding_site',
+  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature',
+  'impact' => 'MODIFIER',
   'include' => {
                  'complete_overlap' => 1,
                  'increase_length' => 1
                },
-  'feature_SO_term' => 'TF_binding_site',
-  'description' => 'A feature amplification of a region containing a regulatory region',
-  'SO_accession' => 'SO:0001891',
-  'SO_term' => 'regulatory_region_amplification',
-  'tier' => '2',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'label' => 'regulatory region amplification',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_amplification',
   'rank' => '33',
-  'impact' => 'MODIFIER',
-  'feature_class' => 'Bio::EnsEMBL::Funcgen::RegulatoryFeature'
+  'tier' => '2',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'feature_elongation' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'sv' => 1,
-                 'increase_length' => 1
-               },
-  'feature_SO_term' => 'sequence_feature',
-  'description' => 'A sequence variant that causes the extension of a genomic feature, with regard to the reference sequence',
   'SO_accession' => 'SO:0001907',
   'SO_term' => 'feature_elongation',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_elongation',
-  'label' => 'feature elongation',
-  'rank' => '36',
+  'description' => 'A sequence variant that causes the extension of a genomic feature, with regard to the reference sequence',
+  'feature_SO_term' => 'sequence_feature',
+  'feature_class' => 'Bio::EnsEMBL::Feature',
   'impact' => 'MODIFIER',
-  'feature_class' => 'Bio::EnsEMBL::Feature'
+  'include' => {
+                 'increase_length' => 1,
+                 'sv' => 1
+               },
+  'label' => 'feature elongation',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_elongation',
+  'rank' => '36',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'feature_truncation' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
-  'include' => {
-                 'sv' => 1,
-                 'decrease_length' => 1
-               },
-  'feature_SO_term' => 'sequence_feature',
-  'description' => 'A sequence variant that causes the reduction of a genomic feature, with regard to the reference sequence',
   'SO_accession' => 'SO:0001906',
   'SO_term' => 'feature_truncation',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_truncation',
-  'label' => 'feature truncation',
-  'rank' => '37',
+  'description' => 'A sequence variant that causes the reduction of a genomic feature, with regard to the reference sequence',
+  'feature_SO_term' => 'sequence_feature',
+  'feature_class' => 'Bio::EnsEMBL::Feature',
   'impact' => 'MODIFIER',
-  'feature_class' => 'Bio::EnsEMBL::Feature'
+  'include' => {
+                 'decrease_length' => 1,
+                 'sv' => 1
+               },
+  'label' => 'feature truncation',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::feature_truncation',
+  'rank' => '37',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'protein_altering_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature',
+  'SO_accession' => 'SO:0001818',
+  'SO_term' => 'protein_altering_variant',
+  'description' => 'A sequence_variant which is predicted to change the protein encoded in the coding sequence',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODERATE',
   'include' => {
                  'coding' => 1
                },
-  'feature_SO_term' => 'mRNA',
-  'description' => 'A sequence_variant which is predicted to change the protein encoded in the coding sequence',
-  'SO_accession' => 'SO:0001818',
-  'SO_term' => 'protein_altering_variant',
-  'tier' => '3',
-  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::protein_altering_variant',
   'label' => 'protein altering variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::protein_altering_variant',
   'rank' => '12',
-  'impact' => 'MODERATE',
-  'feature_class' => 'Bio::EnsEMBL::Transcript'
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
 }
 ),
 );
+
+our $SO_ACC_MAPPER = {
+  'Bio::EnsEMBL::Variation::StructuralVariationFeature' => 'SO:0001060',
+  'Bio::EnsEMBL::Variation::VariationFeature' => 'SO:0001537'
+}
+;
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -103,7 +103,7 @@ use Bio::EnsEMBL::Variation::Utils::Sequence qw(ambiguity_code hgvs_variant_nota
 use Bio::EnsEMBL::Variation::Utils::Sequence;
 use Bio::EnsEMBL::Variation::Variation;
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(MAX_DISTANCE_FROM_TRANSCRIPT);
-use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES); 
+use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES $SO_ACC_MAPPER);
 use Bio::EnsEMBL::Variation::RegulatoryFeatureVariation;
 use Bio::EnsEMBL::Variation::MotifFeatureVariation;
 use Bio::EnsEMBL::Variation::ExternalFeatureVariation;
@@ -118,7 +118,6 @@ use Data::Dumper;
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
 
-use constant SO_ACC => 'SO:0001060';
 
 our $DEBUG = 0;
 =head2 new
@@ -2221,6 +2220,29 @@ sub reset_consequence_data {
     overlap_consequences
     _most_severe_consequence
   );
+}
+
+
+=head2 feature_so_acc
+
+  Example     : $feat = $feat->feature_so_acc;
+  Description : This method returns a string containing the SO accession number of the VariationFeature.
+                Overrides Bio::EnsEMBL::Feature::feature_so_acc
+  Returns     : string (Sequence Ontology accession number)
+  Exceptions  : Thrown if caller feature SO acc is undefined in $SO_ACC_MAPPER constant
+=cut
+
+sub feature_so_acc {
+  my ($self) = @_;
+
+  my $ref = ref $self;
+  my $so_acc = $SO_ACC_MAPPER->{$ref};
+
+  unless ($so_acc ) {
+    throw( "SO acc for ${ref} is not defined. Please update %SO_ACC_MAPPER in Bio::EnsEMBL::Variation::Utils::Config");
+  }
+
+  return $so_acc;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -103,7 +103,7 @@ use Bio::EnsEMBL::Variation::Utils::Sequence qw(ambiguity_code hgvs_variant_nota
 use Bio::EnsEMBL::Variation::Utils::Sequence;
 use Bio::EnsEMBL::Variation::Variation;
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(MAX_DISTANCE_FROM_TRANSCRIPT);
-use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES $SO_ACC_MAPPER);
+use Bio::EnsEMBL::Variation::Utils::Constants qw($DEFAULT_OVERLAP_CONSEQUENCE %VARIATION_CLASSES);
 use Bio::EnsEMBL::Variation::RegulatoryFeatureVariation;
 use Bio::EnsEMBL::Variation::MotifFeatureVariation;
 use Bio::EnsEMBL::Variation::ExternalFeatureVariation;
@@ -117,7 +117,6 @@ use Data::Dumper;
 
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
-
 
 our $DEBUG = 0;
 =head2 new
@@ -2220,29 +2219,6 @@ sub reset_consequence_data {
     overlap_consequences
     _most_severe_consequence
   );
-}
-
-
-=head2 feature_so_acc
-
-  Example     : $feat = $feat->feature_so_acc;
-  Description : This method returns a string containing the SO accession number of the VariationFeature.
-                Overrides Bio::EnsEMBL::Feature::feature_so_acc
-  Returns     : string (Sequence Ontology accession number)
-  Exceptions  : Thrown if caller feature SO acc is undefined in $SO_ACC_MAPPER constant
-=cut
-
-sub feature_so_acc {
-  my ($self) = @_;
-
-  my $ref = ref $self;
-  my $so_acc = $SO_ACC_MAPPER->{$ref};
-
-  unless ($so_acc ) {
-    throw( "SO acc for ${ref} is not defined. Please update %SO_ACC_MAPPER in Bio::EnsEMBL::Variation::Utils::Config");
-  }
-
-  return $so_acc;
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -118,6 +118,8 @@ use Data::Dumper;
 
 our @ISA = ('Bio::EnsEMBL::Variation::BaseVariationFeature');
 
+use constant SO_ACC => 'SO:0001060';
+
 our $DEBUG = 0;
 =head2 new
 

--- a/modules/t/structuralVariationFeature.t
+++ b/modules/t/structuralVariationFeature.t
@@ -115,6 +115,7 @@ ok($svf->source->name() eq $source_name,     'svf -> source' );
 ok($svf->source_name eq $source_name,               'svf -> source_name');
 ok($svf->source_description eq $source_description, 'svf -> source_description');
 ok($svf->source_version eq $source_version,         'svf -> source_version');
+is($svf->feature_so_acc, 'SO:0001537', 'StructuralVariationFeature feature SO acc is correct (structural variant)');
 
 
 # test getter/setters

--- a/modules/t/variationFeature.t
+++ b/modules/t/variationFeature.t
@@ -118,6 +118,7 @@ my $oc = Bio::EnsEMBL::Variation::OverlapConsequence->new(-SO_term => 'missense_
 ok($vf->add_OverlapConsequence($oc), 'add_OverlapConsequence');
 ok($vf->get_all_evidence_values()->[0] eq 'Cited', 'get_all_evidence_values');
 ok($vf->get_all_clinical_significance_states()->[0] eq $clin_sign->[0], 'get_all_clinical_significance_states');
+is($vf->feature_so_acc, 'SO:0001060', 'VariationFeature feature SO acc is correct (sequence variant)');
 
 # test getter/setters
 

--- a/scripts/misc/create_config_consts.pl
+++ b/scripts/misc/create_config_consts.pl
@@ -68,6 +68,7 @@ our @VARIATION_CLASSES;
 our @OVERLAP_CONSEQUENCES; 
 our @FEATURE_TYPES;
 our $OVERLAP_CONSEQUENCE_CLASS;
+our %SO_ACC_MAPPER;
 
 eval {
     $config->import(qw(
@@ -75,6 +76,7 @@ eval {
         @VARIATION_CLASSES
         @OVERLAP_CONSEQUENCES 
         @FEATURE_TYPES
+        %SO_ACC_MAPPER
         $OVERLAP_CONSEQUENCE_CLASS
     ));
 };
@@ -171,6 +173,11 @@ for my $cons_set (@OVERLAP_CONSEQUENCES) {
 
 $cons_code = $default_consequence_code. "\n". "\n" . $cons_code .");\n";
 
+
+
+my $feat_so_acc = "our \$SO_ACC_MAPPER = " . Dumper(\%SO_ACC_MAPPER) . ";\n";
+
+
 # avoid any duplicate exports by putting all constants to export into a single hash
 
 my $all_to_export;
@@ -181,7 +188,7 @@ for my $type (keys %$to_export) {
     }
 }
 
-$hdr .= 'our @EXPORT_OK = qw(%OVERLAP_CONSEQUENCES %VARIATION_CLASSES $DEFAULT_OVERLAP_CONSEQUENCE '.(join ' ', keys %$all_to_export).');';
+$hdr .= 'our @EXPORT_OK = qw(%OVERLAP_CONSEQUENCES %VARIATION_CLASSES $DEFAULT_OVERLAP_CONSEQUENCE $SO_ACC_MAPPER '.(join ' ', keys %$all_to_export).');';
 
 $hdr .= "\n\n";
 
@@ -195,4 +202,4 @@ $hdr .= " );\n\n";
 
 $hdr .= "use $OVERLAP_CONSEQUENCE_CLASS;\n";
 
-print $hdr, "\n", $code, "\n", $class_code, "\n", $cons_code, "\n1;\n";
+print $hdr, "\n", $code, "\n", $class_code, "\n", $cons_code, "\n", $feat_so_acc, "\n1;\n";

--- a/scripts/misc/create_config_consts.pl
+++ b/scripts/misc/create_config_consts.pl
@@ -39,6 +39,7 @@ use Getopt::Long;
 use Data::Dumper;
 
 $Data::Dumper::Terse = 1;
+$Data::Dumper::Sortkeys = 1;
 
 my $config;
 my $help;


### PR DESCRIPTION
`Bio::EnsEMBL::Utils::SequenceOntologyMapper` is being deprecated with https://github.com/Ensembl/ensembl/pull/246
That functionality is being replaced with Bio::EnsEMBL::Feature::feature_so_acc, and all features will be able to use that method provided they declare a constant SO_ACC.
I'm making sure all the 'features' that were supported on SequenceOntologyMapper are compliant so that pipelines that use it can be updated seamlessly.
VariationFeature and StructuralVariationFeature are some of the features that require SO_ACC.