### PR TITLE
Sift updates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -181,14 +181,19 @@ sub default_options {
     };
 }
 
-#sub pipeline_create_commands {
-#    my ($self) = @_;
-#    return [
-#        'mysql '.$self->dbconn_2_mysql('pipeline_db', 0).q{-e 'DROP DATABASE IF EXISTS }.$self->o('pipeline_db', '-dbname').q{'},
-#        @{$self->SUPER::pipeline_create_commands}, 
-#        'mysql '.$self->dbconn_2_mysql('pipeline_db', 1).q{-e 'INSERT INTO meta (meta_key, meta_value) VALUES ("hive_output_dir", "}.$self->o('output_dir').q{")'},
-#    ];
-#}
+sub pipeline_create_commands {
+  my ($self) = @_;
+  return [
+    @{$self->SUPER::pipeline_create_commands},  # inheriting database and hive tables' creation
+    $self->db_cmd('CREATE TABLE IF NOT EXISTS failure_reason (
+        translation_md5 char(32) NOT NULL,
+        error_msg varchar(255) NOT NULL,
+        analysis char(32) NOT NULL,
+        PRIMARY KEY (translation_md5),
+        UNIQUE KEY md5_error_analysis  (translation_md5, error_msg, analysis)
+        ) ENGINE=InnoDB DEFAULT CHARSET=latin1;'),
+  ];
+}
 
 sub resource_classes {
     my ($self) = @_;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -138,7 +138,6 @@ sub run {
       }
       else {
         # If we just did not find enough hits, that's ok, just skip this
-        $alignment_ok = 0;
         my $error_file = $fasta_file . ".query.globalX.error";
         if (-s $error_file) {
           open my $error_fh, "<", $error_file or die $!;


### PR DESCRIPTION
Create a failure_reason table and add sift errors: Not enough sequences found by PSI-BLAST search, Less than the minimum number of sequences required.
Other problems that could be added: stack smashing detected (Could that be solved with more memory?), 100% identical with your protein query.
At the moment I'm not writing the table to file. This still needs to be done. Mouse runs very quickly and there is no benefit in discarding the md5s next release.