### PR TITLE
fix warning from wierd edge case in VEP

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlap.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlap.pm
@@ -204,7 +204,7 @@ sub dbID {
   unless ($self->{dbID}) {
     # we don't really have a dbID, so concatenate all the dbIDs of our alleles
 
-    $self->{dbID} = join '_', map { $_->dbID } @{ $self->get_all_alternate_VariationFeatureOverlapAlleles };
+    $self->{dbID} = join '_', map { $_->dbID || '' } @{ $self->get_all_alternate_VariationFeatureOverlapAlleles };
   }
 
   return $self->{dbID};


### PR DESCRIPTION
I was getting a warning from local usage of VEP, due to some lines in a VCF file  I was analysing, when using the VEP plugin "CSN".

I tracked the problem down to this bit of code. It seems that if a `VariationFeatureOverlap` does not have  a `dbID`, it is also possible that it has alleles with no `dbID`.

*) This was the warning:
`Use of uninitialized value in join or string at ensembl-vep/Bio/EnsEMBL/Variation/VariationFeatureOverlap.pm line 207, <__ANONIO__> line 4.
`

*) To reproduce, you can run vep as follows (with the CSN plugin):

```
vep --species homo_sapiens --assembly GRCh38 -i test.vcf --format vcf --pick --vcf --stats_file test.vep.vcf.html --cache --offline --fasta Homo_sapiens_assembly38.fasta --buffer_size=5000 --everything --minimal --gencode_basic --plugin CSN
```

*) Using the following `test.vcf` file:

```
##fileformat=VCFv4.2
##contig=<ID=chr2,length=242193529,assembly=38>
#CHROM  POS     ID      REF     ALT     QUAL
chr2    42330203        .       C       CACT    .
```
