### PR TITLE
Prf94 production

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FinishDumpPopulation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/FinishDumpPopulation.pm
@@ -53,15 +53,15 @@ sub clean_up_vcf_files {
   my $self = shift;
   my $pipeline_dir = $self->param('pipeline_dir');
   my $tmp_dir = $self->param('tmp_dir');
-  my $human_vcf_dir = "$pipeline_dir/vcf/homo_sapiens/";
+  my $human_vcf_dir = $self->param('vcf_files_dir');
   die "$human_vcf_dir is not a directory" unless (-d $human_vcf_dir);
 
-  opendir(my $dh, "$pipeline_dir/vcf/homo_sapiens") or die $!;
+  opendir(my $dh, "$human_vcf_dir") or die $!;
   my @dir_content = readdir($dh);
   closedir($dh);
   foreach my $file (@dir_content) {
     if ($file =~ m/\.vcf$/) {
-      my $vcf_file = "$pipeline_dir/vcf/homo_sapiens/$file";
+      my $vcf_file = "$human_vcf_dir/$file";
       $self->run_cmd("vcf-sort < $vcf_file | bgzip > $vcf_file.gz");
       $self->run_cmd("rm $vcf_file");
     }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitDumpPopulation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitDumpPopulation.pm
@@ -73,9 +73,6 @@ sub fetch_input {
 
   }
 
-  if ($file_type eq 'vcf') {
-    $self->param('vcf_files_dir', "$pipeline_dir/vcf/homo_sapiens/");
-  }
 }
 
 sub run {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitDumpPopulation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitDumpPopulation.pm
@@ -71,21 +71,10 @@ sub fetch_input {
     my $prefetched_frequencies_dir = $self->param('prefetched_frequencies');
     die "$prefetched_frequencies_dir doesn't exist" unless (-d $prefetched_frequencies_dir);
 
-    my $variation_ids_dir = "$pipeline_dir/variation_ids";
-    make_path($variation_ids_dir) unless (-d $variation_ids_dir);
-    $self->param('variation_ids_dir', $variation_ids_dir);
-
-    my $human_gvf_file_gz = $self->param('pipeline_dir') . '/gvf/Homo_sapiens/Homo_sapiens.gvf.gz';
-    die("$human_gvf_file_gz doesn't exist") unless (-f $human_gvf_file_gz);
-    my $human_gvf_file = $self->param('pipeline_dir') . '/gvf/Homo_sapiens/Homo_sapiens.gvf';
-    system("gunzip $human_gvf_file_gz");
-
-    $self->param('human_gvf_file', $human_gvf_file);
-    $self->param('gvf_files_dir', "$pipeline_dir/gvf/Homo_sapiens/");
   }
 
   if ($file_type eq 'vcf') {
-    $self->param('vcf_files_dir', "$pipeline_dir/vcf/Homo_sapiens/");
+    $self->param('vcf_files_dir', "$pipeline_dir/vcf/homo_sapiens/");
   }
 }
 
@@ -93,7 +82,6 @@ sub run {
   my $self = shift;
   my $file_type = $self->param('file_type');
   if ($file_type eq 'gvf') {
-    $self->divide_variation_ids_by_chrom;
     my $input = $self->get_input_dump_gvf;
     $self->param('input_parameters', $input);
   } elsif ($file_type eq 'vcf') {
@@ -113,7 +101,7 @@ sub get_input_dump_vcf {
   my $script          = '/misc/release/gvf2vcf.pl';
   my $output_dir      = $self->param('pipeline_dir');
   my $connection_args = '--registry ' . $self->param('registry_file');
-  my $species = 'Homo_sapiens';
+  my $species = 'homo_sapiens';
   my @input = ();
 
   foreach my $group (keys %$populations) { 
@@ -144,37 +132,6 @@ sub get_input_dump_vcf {
   return \@input;
 }
 
-sub divide_variation_ids_by_chrom {
-  my $self = shift;
-  my $pipeline_dir = $self->param('pipeline_dir');
-
-  my $variation_ids_dir = $self->param('variation_ids_dir');
-  my $human_gvf_file = $self->param('human_gvf_file');
-
-  my $fh_gvf = FileHandle->new($human_gvf_file, 'r');
-  my $prev_seq_id = undef;
-  my $fh = undef;
-
-  while (<$fh_gvf>) {
-    chomp;
-    if (/^#/) {
-      next;
-    } else {
-      my $line = $_;
-      my $gvf_line = get_gvf_line($line);
-      my $seq_id = $gvf_line->{seq_id};
-      my $variation_id  = $gvf_line->{attributes}->{variation_id};
-      if ("$seq_id" ne "$prev_seq_id" || !$seq_id) {
-        $fh->close() if ($fh);
-        $fh = FileHandle->new("$variation_ids_dir/$seq_id.txt", 'w');
-        $prev_seq_id = $seq_id;
-      }
-      print $fh $variation_id, "\n";
-    }
-  }
-  $fh_gvf->close();
-  $fh->close();
-}
 
 sub get_gvf_line {
   my $line = shift;
@@ -202,27 +159,22 @@ sub get_input_dump_gvf {
   my @input = ();
 
   my $populations = $self->param('populations');
-  my $human_gvf_file = $self->param('human_gvf_file');
-  my $gvf_files_dir = $self->param('gvf_files_dir');
-  my $variation_ids_dir = $self->param('variation_ids_dir');
-
+  my $pipeline_dir = $self->param('pipeline_dir');
+  my $gvf_files_dir = "$pipeline_dir/gvf/homo_sapiens/";
   my $file_type = $self->param('file_type');
   foreach my $group (keys %$populations) {
     foreach my $population_name (keys %{$populations->{$group}}) {
-      $self->warning("$group $population_name");
       my $params = {};
       my $short_name = $populations->{$group}->{$population_name};
       my $file_name = $population_name;
       $file_name =~ s/:/-/;
-
-      $params->{human_gvf_file} = $human_gvf_file;
-      $params->{variation_ids_dir} = $variation_ids_dir;
       $params->{population_name} = $population_name;
       $params->{file_name} = $population_name;
       $params->{population_gvf_file} = "$gvf_files_dir/$file_name.gvf";
       $params->{short_name} = $short_name;
       $params->{file_type} = $file_type;
       $params->{group} = $group;
+      $params->{gvf_files_dir} = $gvf_files_dir;
       push @input, $params;
     }
   }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitFinishDumpPopulation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/InitFinishDumpPopulation.pm
@@ -1,0 +1,53 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2018] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=head1 CONTACT
+
+Please email comments or questions to the public Ensembl
+developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+Questions may also be sent to the Ensembl help desk at
+<http://www.ensembl.org/Help/Contact>.
+
+=cut
+package Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::InitFinishDumpPopulation;
+
+use strict;
+use warnings;
+
+use base ('Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::BaseDataDumpsProcess');
+
+sub run {
+  my $self = shift;
+  my $file_type = $self->param('file_type');
+  my @input = ();
+  foreach my $chrom (1..22, 'X', 'Y', 'MT') {
+    push @input, {chrom => $chrom, file_type => $file_type};
+  }
+  $self->param('input_for_finish_gvf_dumps', \@input);
+}
+
+sub write_output {
+  my $self = shift;
+  $self->dataflow_output_id($self->param('input_for_finish_gvf_dumps'), 2);
+  return;
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
@@ -69,8 +69,8 @@ sub default_options {
         so_file            => '/nfs/panda/ensembl/production/ensprod/obo_files/SO.obo',
 
         tmp_dir           => $self->o('tmp_dir'),
-        gvf_readme => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF',
-        vcf_readme => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF',
+        gvf_readme_human => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF_human',
+        vcf_readme_human => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF_human',
 
         # init_pipeline.pl will create the hive database on this machine, naming it
         # <username>_<pipeline_name>, and will drop any existing database with this
@@ -106,8 +106,8 @@ sub pipeline_wide_parameters {
         so_file          => $self->o('so_file'),    
         gvf_validator    => $self->o('gvf_validator'),
         tmp_dir          => $self->o('tmp_dir'),
-        gvf_readme       => $self->o('gvf_readme'), 
-        vcf_readme       => $self->o('vcf_readme'),
+        gvf_readme_human => $self->o('gvf_readme_human'), 
+        vcf_readme_human => $self->o('vcf_readme_human'),
     };
 }
 
@@ -150,6 +150,7 @@ sub pipeline_analyses {
       -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::FinishDumpPopulation',
       -parameters => {
         'file_type' => 'gvf',
+        'gvf_readme_human' => $self->o('gvf_readme_human'),
       },
       -flow_into => {
         1 => ['init_population_vcf'],
@@ -172,6 +173,7 @@ sub pipeline_analyses {
       -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::FinishDumpPopulation',
       -parameters => {
         'file_type' => 'vcf',
+        'vcf_readme_human' => $self->o('vcf_readme_human'),
       },
     },
   );

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
@@ -69,7 +69,7 @@ sub default_options {
         so_file            => '/nfs/panda/ensembl/production/ensprod/obo_files/SO.obo',
 
         tmp_dir           => $self->o('tmp_dir'),
-
+        vcf_files_dir     => $self->o('pipeline_dir') . '/vcf/homo_sapiens/',
         # init_pipeline.pl will create the hive database on this machine, naming it
         # <username>_<pipeline_name>, and will drop any existing database with this
         # name
@@ -104,6 +104,7 @@ sub pipeline_wide_parameters {
         so_file          => $self->o('so_file'),    
         gvf_validator    => $self->o('gvf_validator'),
         tmp_dir          => $self->o('tmp_dir'),
+        vcf_files_dir    => $self->o('vcf_files_dir'),
     };
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PopulationDumps_conf.pm
@@ -69,8 +69,6 @@ sub default_options {
         so_file            => '/nfs/panda/ensembl/production/ensprod/obo_files/SO.obo',
 
         tmp_dir           => $self->o('tmp_dir'),
-        gvf_readme_human => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF_human',
-        vcf_readme_human => $self->o('ensembl_cvs_root_dir') . '/ensembl-variation/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF_human',
 
         # init_pipeline.pl will create the hive database on this machine, naming it
         # <username>_<pipeline_name>, and will drop any existing database with this
@@ -106,8 +104,6 @@ sub pipeline_wide_parameters {
         so_file          => $self->o('so_file'),    
         gvf_validator    => $self->o('gvf_validator'),
         tmp_dir          => $self->o('tmp_dir'),
-        gvf_readme_human => $self->o('gvf_readme_human'), 
-        vcf_readme_human => $self->o('vcf_readme_human'),
     };
 }
 
@@ -136,7 +132,7 @@ sub pipeline_analyses {
       },
       -flow_into => {
         '2->A' => ['dump_population_gvf'],
-        'A->1' => ['finish_dump_population_gvf']
+        'A->1' => ['init_finish_dump_population_gvf']
       },
     },
     { -logic_name => 'dump_population_gvf',
@@ -146,15 +142,18 @@ sub pipeline_analyses {
         'prefetched_frequencies' => $self->o('prefetched_frequencies'),
       },
     },
-    { -logic_name => 'finish_dump_population_gvf',
-      -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::FinishDumpPopulation',
+    { -logic_name => 'init_finish_dump_population_gvf',
+      -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::InitFinishDumpPopulation',
       -parameters => {
         'file_type' => 'gvf',
-        'gvf_readme_human' => $self->o('gvf_readme_human'),
       },
       -flow_into => {
-        1 => ['init_population_vcf'],
+        '2->A' => ['finish_population_gvf'],
+        'A->1' => ['init_population_vcf']
       },
+    },
+    { -logic_name => 'finish_dump_population_gvf',
+      -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::FinishDumpPopulation',
     },
     { -logic_name => 'init_population_vcf',
       -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::InitDumpPopulation',
@@ -173,7 +172,6 @@ sub pipeline_analyses {
       -module => 'Bio::EnsEMBL::Variation::Pipeline::ReleaseDataDumps::FinishDumpPopulation',
       -parameters => {
         'file_type' => 'vcf',
-        'vcf_readme_human' => $self->o('vcf_readme_human'),
       },
     },
   );

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/ReleaseDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/ReleaseDumps_conf.pm
@@ -61,7 +61,7 @@ sub default_options {
         species => [],
         antispecies => [],
         division    => [],
-        run_all     => 0,
+        run_all     => 1,
 
         pipeline_name      => $self->o('pipeline_name'),
 
@@ -126,6 +126,8 @@ sub pipeline_wide_parameters {
         tmp_dir          => $self->o('tmp_dir'),
         gvf_readme       => $self->o('gvf_readme'), 
         vcf_readme       => $self->o('vcf_readme'),
+        gvf_readme_human => $self->o('gvf_readme_human'), 
+        vcf_readme_human => $self->o('vcf_readme_human'),
         pipeline_wide_analysis_capacity => $self->o('pipeline_wide_analysis_capacity'),        
         debug => $self->o('debug'),
         global_vf_count_in_species => $self->o('global_vf_count_in_species'),
@@ -355,6 +357,8 @@ sub pipeline_analyses {
           -parameters => {
               'gvf_readme' => $self->o('gvf_readme'),
               'vcf_readme' => $self->o('vcf_readme'),
+              'gvf_readme_human' => $self->o('gvf_readme_human'),
+              'vcf_readme_human' => $self->o('vcf_readme_human'),
           }
       },
   );

--- a/scripts/misc/release/gvf2vcf.pl
+++ b/scripts/misc/release/gvf2vcf.pl
@@ -623,6 +623,7 @@ sub print_header {
     my $schema_version = $mca->get_schema_version;
     my $species_name = $mca->get_scientific_name;
     $species_name =~ s/ /_/g;
+    $species_name = lc $species_name;
     my ( $sec, $min, $hr, $mday, $mon, $year ) = localtime;
     $year += 1900;    # correct the year
     $mon++;           # correct the month


### PR DESCRIPTION
changing up the logic of how human population dumps are generated. Human data is dumped by chromosome now. I needed to updated the generation of HapMap and ESP data dumps to join up variation information and frequencies. HapMap and ESP dumps are joined and distributed as one file per population. This won't be needed anymore if we move to only reading frequency data from VCF (next release/95?).

Also a bug fix in species naming in ftp url which was reported by Ben.
