### PR TITLE
Ld 93 strand fix

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
@@ -391,7 +391,6 @@ sub _fetch_by_Slice_VCF {
     my %location_to_name;
     my $strict_name_match = 0;
     foreach my $vc (@$collections) {
-      print STDERR $vc->id, "\n";
       my $sample_string = '';
       # skip this collection if it doesn't have the population we want
       if (defined($population)) {

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/LDFeatureContainerAdaptor.pm
@@ -391,15 +391,7 @@ sub _fetch_by_Slice_VCF {
     my %location_to_name;
     my $strict_name_match = 0;
     foreach my $vc (@$collections) {
-      $strict_name_match = $vc->strict_name_match;
-      # if we cannot match variants from VCF by name
-      if (!$strict_name_match) {
-        foreach my $slice (@slices) {
-          my %location_to_name_for_slice =  %{$vc->get_location_to_name_map($slice)};
-          %location_to_name = (%location_to_name, %location_to_name_for_slice);
-        }
-      }
-
+      print STDERR $vc->id, "\n";
       my $sample_string = '';
       # skip this collection if it doesn't have the population we want
       if (defined($population)) {
@@ -410,6 +402,14 @@ sub _fetch_by_Slice_VCF {
           map {$_->name}
           @{$population->get_all_Samples}
         );
+      }
+      $strict_name_match = $vc->strict_name_match;
+      # if we cannot match variants from VCF by name
+      if (!$strict_name_match) {
+        foreach my $slice (@slices) {
+          my %location_to_name_for_slice =  %{$vc->get_location_to_name_map($slice)};
+          %location_to_name = (%location_to_name, %location_to_name_for_slice);
+        }
       }
 
       my $cmd;

--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -1487,6 +1487,7 @@ sub _seek {
   $self->_current($vcf);
   
   # now seek
+  $s = 0 if ($s < 0);
   $vcf->seek($c, $s, $e);
 
   if($self->use_seq_region_synonyms && !defined($vcf->{iterator}->{_tabix_iter}) && (my @synonyms = @{$self->_get_synonyms_by_chr($c)})) {

--- a/modules/t/LDFeatureContainerAdaptor.t
+++ b/modules/t/LDFeatureContainerAdaptor.t
@@ -261,6 +261,13 @@ foreach my $ld_value (@$ld_values) {
   cmp_ok($result->{$variation_name2}->{d_prime}, '==', $d_prime, "fetch_by_VariationFeature d_prime for $variation_name2 and rs1333049 no_id_in_vcf");
 }
 
+# test that API can deal with negative start values if max_snp_distance is causing slice start to be negative
+$ldfca->max_snp_distance(22_125_504); # use VF start and max_snp_distance to create slice with a negative start
+$ldfc = $ldfca->fetch_by_VariationFeature($vf, $population);
+cmp_ok(scalar @{$ldfc->get_all_ld_values}, '==', 6, "No error is thrown if max_snp_distance creates negative start value");
+# reset max snp distance
+$ldfca->max_snp_distance(100_000);
+
 #fetch_by_VariationFeature, population is not defined
 $ldfc = $ldfca->fetch_by_VariationFeature($vf);
 foreach my $ld_value (@$ld_values) {


### PR DESCRIPTION
We introduced looking up data from VCF files which don't have the strict_name_match flag set in the VCF config entry. This was introduced for farm species which have VCF files where the identifier is missing. I added the new code before the test if the VCF collection contained the required population which has been passed for the LD calculation. It then fails in the VCFCollection code which calls the seek method of the VCF parser when using a negative start value. I think Bio::DB::HTS should accept negative coordinates. But that would take longer to get updated because we are not in control of the repository. I also changed the order and check now first if the population is contained. Otherwise we don't need to worry about matching VCF variants to database variants.