### PR TITLE
HGVS parser fix

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -1788,7 +1788,7 @@ sub fetch_by_hgvs_notation {
     else {
       push @transcripts, $transcript;
     }
-    
+
     throw ("Could not get a Transcript object for '$reference'") unless @transcripts;
 
     my @results;
@@ -1844,24 +1844,33 @@ sub fetch_by_hgvs_notation {
     #Get the Transcript object to convert coordinates
     my $transcript_adaptor = $user_transcript_adaptor || $self->db()->dnadb()->get_TranscriptAdaptor();
     my $transcript = $transcript_adaptor->fetch_by_translation_stable_id($reference);
-    
+
     my @transcripts;
 
-    #try and fetch via gene
+    # support some malformed HGVS
     if(!defined($transcript)) {
-      push @transcripts, @{$self->_get_gene_transcripts($transcript_adaptor, $reference, $multiple_ok)};
+      # Seeing transcripts erroneously submitted with p. changes
+      if($reference =~ /ENST|NM/){
+         push @transcripts, $transcript_adaptor->fetch_by_stable_id($reference);
+      }
+      else{
+        #try and fetch via gene
+        $multiple_ok = 1;  ## for VEP - return all possible here but report 1st with matching ref base
+        push @transcripts, @{$self->_get_gene_transcripts($transcript_adaptor, $reference, $multiple_ok)};
+        $multiple_ok = 0;
+      }
     }
     else {
       push @transcripts, $transcript;
     }
-    
+
     throw ("Could not get a Transcript object for '$reference'") unless @transcripts;
 
     my @results;
     my %errors;
 
     foreach my $transcript(@transcripts) {
-      
+
       my $possible_prot;
       eval {
         $possible_prot = _parse_hgvs_protein_position($description, $reference, $transcript);
@@ -1892,7 +1901,6 @@ sub fetch_by_hgvs_notation {
         }
       }
     }
-
     throw(join("\n", keys %errors)) unless @results;
 
     return $multiple_ok ? \@results : $results[0];
@@ -1969,6 +1977,7 @@ sub _hgvs_from_components {
   
   #Get the reference allele based on the coordinates - need to supply lowest coordinate first to slice->subseq()
   my $refseq_allele;
+
   if($start > $end){ $refseq_allele = $slice->subseq($end,   $start, $strand);}
   else{              $refseq_allele = $slice->subseq($start, $end,  $strand);}
 
@@ -2075,7 +2084,7 @@ sub _pick_likely_transcript {
     $info->{canonical} = $tr->is_canonical ? 0 : 1;
     $info->{biotype} = $tr->biotype eq 'protein_coding' ? 0 : 1;
     $info->{ccds} = (grep {$_->database eq 'CCDS'} @{$tr->get_all_DBEntries}) ? 0 : 1;
-    
+
     # "invert" length so longer is best
     $info->{length} = 0 - $tr->length();
     
@@ -2095,7 +2104,6 @@ sub _pick_likely_transcript {
         }
       }
     }
-    
     push @tr_info, $info;
   }
   
@@ -2104,17 +2112,17 @@ sub _pick_likely_transcript {
   
   # go through each category in order
   foreach my $cat(@order) {
-    
+
     # sort on that category
     @tr_info = sort {$a->{$cat} <=> $b->{$cat}} @tr_info;
     
     # take the first (will have the lowest value of $cat)
     $picked = shift @tr_info;
     my @tmp = ($picked);
-    
+
     # now add to @tmp those vfoas that have the same value of $cat as $picked
     push @tmp, shift @tr_info while @tr_info && $tr_info[0]->{$cat} eq $picked->{$cat};
-    
+
     # if there was only one, return
     return $picked->{tr} if scalar @tmp == 1;
     

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -1855,9 +1855,8 @@ sub fetch_by_hgvs_notation {
       }
       else{
         #try and fetch via gene
-        $multiple_ok = 1;  ## for VEP - return all possible here but report 1st with matching ref base
-        push @transcripts, @{$self->_get_gene_transcripts($transcript_adaptor, $reference, $multiple_ok)};
-        $multiple_ok = 0;
+        # 3rd arg: return all possible transcripts here but for VEP report 1st with matching ref base
+        push @transcripts, @{$self->_get_gene_transcripts($transcript_adaptor, $reference, 1)};
       }
     }
     else {

--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -432,6 +432,7 @@ my %test_input = (
      20 => ["NC_000007.13:g.143175210G>A",
             "ENST00000408916.1:c.245G>A",
             "ENSP00000386201.1:p.Arg82Gln",
+            "ENST00000408916.1:p.Arg82Gln",  ## malformed HGVS seen in some dbs
            ],  
 
      21 => ["NC_000012.11:g.102056227G>A",


### PR DESCRIPTION
If picking a transcript when a gene is supplied in a HGVS-like description, pick one where the reference matches if possible. Also handle transcript p. descriptions