### PR TITLE
compute motif_feature_variations on the fly for human

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -655,7 +655,10 @@ sub get_all_MotifFeatureVariations {
   }
   
   if(!exists($self->{motif_feature_variations})) {
-    if($self->dbID) {
+    # We couldn't store motif_feature_variation for human in release/94
+    # compute them on the fly instead
+    my $species = lc $self->adaptor->db->species, "\n";
+    if($self->dbID && ($species !~ /homo_sapiens|human/)) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;
         my $mfvs = $mfva->fetch_all_by_VariationFeatures([$self]);   

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -657,7 +657,7 @@ sub get_all_MotifFeatureVariations {
   if(!exists($self->{motif_feature_variations})) {
     # We couldn't store motif_feature_variation for human in release/94
     # compute them on the fly instead
-    my $species = lc $self->adaptor->db->species, "\n";
+    my $species = lc $self->adaptor->db->species;
     if($self->dbID && ($species !~ /homo_sapiens|human/)) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -657,10 +657,7 @@ sub get_all_MotifFeatureVariations {
   if(!exists($self->{motif_feature_variations})) {
     # We couldn't store motif_feature_variation for human in release/94
     # compute them on the fly instead
-    my $species = '';
-    if ($self->adaptor) {
-      $species = lc $self->adaptor->db->species;
-    }
+    my $species = lc $self->adaptor->db->species;
     if($self->dbID && ($species !~ /homo_sapiens|human/)) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -657,7 +657,10 @@ sub get_all_MotifFeatureVariations {
   if(!exists($self->{motif_feature_variations})) {
     # We couldn't store motif_feature_variation for human in release/94
     # compute them on the fly instead
-    my $species = lc $self->adaptor->db->species;
+    my $species = '';
+    if ($self->adaptor) {
+      $species = lc $self->adaptor->db->species;
+    }
     if($self->dbID && ($species !~ /homo_sapiens|human/)) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;

--- a/modules/t/motifFeatureVariationAdaptor.t
+++ b/modules/t/motifFeatureVariationAdaptor.t
@@ -63,6 +63,7 @@ my $vf = Bio::EnsEMBL::Variation::VariationFeature->new(
   -_source_id => 1,
   -is_somatic => 0,
   -variation => $v,
+  -adaptor => $vfa,
 );
 $vfa->store($vf);
 

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -396,6 +396,7 @@ my $vf18 = Bio::EnsEMBL::Variation::VariationFeature->new(
   -is_somatic => 0,
   -class_attrib_id => 2,
   -class_SO_term => 'SNV',
+  -adaptor => $vfa,
 );
 
 $vfa->store($vf18);


### PR DESCRIPTION
This will display motif feature variants again. missing at the moment on [staging](http://staging.ensembl.org/Homo_sapiens/Variation/Mappings?db=core;r=3:100100308-100101308;v=rs79156324;vdb=variation;vf=616739697). But the data should be back with this little tweak.