### PR TITLE
Task/motif name update 96

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/MotifFeatureVariationAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/MotifFeatureVariationAdaptor.pm
@@ -100,7 +100,7 @@ sub store {
             allele_string,
             somatic,
             consequence_types,
-            motif_name,
+            binding_matrix_stable_id,
             motif_start,
             motif_end,
             motif_score_delta,
@@ -320,7 +320,7 @@ sub _objs_from_sth {
         $allele_string,
         $somatic,
         $consequence_types,
-        $motif_name,
+        $binding_matrix_stable_id,
         $motif_start,
         $motif_end,
         $motif_score_delta,
@@ -335,7 +335,7 @@ sub _objs_from_sth {
         \$allele_string,
         \$somatic,
         \$consequence_types,
-        \$motif_name,
+        \$binding_matrix_stable_id,
         \$motif_start,
         \$motif_end,
         \$motif_score_delta,
@@ -355,7 +355,7 @@ sub _objs_from_sth {
                 _feature_stable_id           => $feature_stable_id,
                 regulatory_feature_stable_id => $feature_stable_id,
                 motif_feature_id             => $motif_feature_id,
-                motif_name                   => $motif_name,
+                binding_matrix_stable_id     => $binding_matrix_stable_id,
                 adaptor                      => $self,
             });
             
@@ -406,7 +406,7 @@ sub _columns {
         allele_string
         somatic 
         consequence_types 
-        motif_name
+        binding_matrix_stable_id
         motif_start
         motif_end
         motif_score_delta

--- a/modules/Bio/EnsEMBL/Variation/MotifFeatureVariation.pm
+++ b/modules/Bio/EnsEMBL/Variation/MotifFeatureVariation.pm
@@ -121,6 +121,29 @@ sub motif_name {
   return $self->{motif_name};
 }
 
+=head2 binding_matrix_stable_id
+
+  Arg [1]    : string $stable_id (optional)
+               The new value to set the binding_matrix_stable_id attribute to
+  Example    : $binding_matrix_stable_id = $motif_feature_variation->binding_matrix_stable_id()
+  Description: Getter/Setter for the binding_matrix_stable_id attribute. This is the
+               stable id of the binding matrix associated with this feature.
+  Returntype : string
+  Exceptions : none
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub binding_matrix_stable_id {
+  my $self = shift;
+  $self->{binding_matrix_stable_id} = shift if(@_);
+  unless ($self->{binding_matrix_stable_id}) {
+    $self->{binding_matrix_stable_id} = $self->motif_feature->binding_matrix->stable_id;
+  }
+  return $self->{binding_matrix_stable_id};
+}
+
 sub _motif_feature_seq {
     my $self = shift;
     my $mf = $self->motif_feature;

--- a/modules/t/motifFeatureVariationAdaptor.t
+++ b/modules/t/motifFeatureVariationAdaptor.t
@@ -83,6 +83,9 @@ if ($mfv && (scalar(@{$mfv->consequence_type}) > 0) ) {
 my $consequence_types = join(',', sort @{$mfv->consequence_type});
 ok($consequence_types eq 'TF_binding_site_variant', 'Print consequence types for motif_feature_variation');
 
+my $binding_matrix_stable_id = $mfv->binding_matrix_stable_id;
+ok($binding_matrix_stable_id eq 'ENSPFM0402', 'Compare binding_matrix_stable_id');
+
 my $motif_name = $mfv->motif_name;
 ok($motif_name eq 'ENSM00000000001', 'Compare motif name');
 my $feature_stable_id = $mfv->feature_stable_id;

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/table.sql
@@ -185,7 +185,7 @@ CREATE TABLE `motif_feature_variation` (
   `allele_string` text,
   `somatic` tinyint(1) NOT NULL DEFAULT '0',
   `consequence_types` set('TF_binding_site_variant','TFBS_ablation','TFBS_fusion','TFBS_amplification','TFBS_translocation') DEFAULT NULL,
-  `motif_name` text,
+  `binding_matrix_stable_id` varchar(60) DEFAULT NULL,
   `motif_start` int(11) unsigned DEFAULT NULL,
   `motif_end` int(11) unsigned DEFAULT NULL,
   `motif_score_delta` float DEFAULT NULL,

--- a/sql/patch_95_96_c.sql
+++ b/sql/patch_95_96_c.sql
@@ -1,0 +1,20 @@
+-- Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+-- Copyright [2016-2018] EMBL-European Bioinformatics Institute
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--      http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+ALTER TABLE `motif_feature_variation` CHANGE `motif_name` `binding_matrix_stable_id` VARCHAR(60) DEFAULT NULL;
+
+# patch identifier
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_95_96_c.sql|Rename motif_name to binding_matrix_stable_id.');

--- a/sql/table.sql
+++ b/sql/table.sql
@@ -1513,7 +1513,7 @@ PRIMARY KEY (variation_id, gene_name));
 @column allele_string               Shows the reference sequence and variant sequence of this allele.
 @column somatic                     Flags if the associated variation is known to be somatic.
 @column consequence_types		        The consequence(s) of the variant allele on this motif_feature.<br /> The list of consequence descriptions is available <a href="/info/genome/variation/prediction/predicted_data.html#consequences">here</a>.
-@column motif_name                  The display label of the motif.
+@column binding_matrix_stable_id    The stable id of the binding matrix.
 @column motif_start                 The start position of the variation in the motif.
 @column motif_end                   The end position of the variation in the motif.
 @column motif_score_delta           The deviation from the score (that is derived from alignment software (e.g. MOODS)) caused by the variation.
@@ -1536,7 +1536,7 @@ CREATE TABLE IF NOT EXISTS motif_feature_variation (
                                           'TFBS_amplification',
                                           'TFBS_translocation'
                                         ),
-    motif_name                          VARCHAR(60) DEFAULT NULL,
+    binding_matrix                      VARCHAR(60) DEFAULT NULL,
     motif_start                         INT(11) UNSIGNED,
     motif_end                           INT(11) UNSIGNED,
     motif_score_delta                   FLOAT DEFAULT NULL,
@@ -1828,6 +1828,7 @@ INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'schema_type',
 # Patch IDs for new release
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_95_96_a.sql|schema version');
 INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_95_96_b.sql|modify index on variation_synonym');
+INSERT INTO meta (species_id, meta_key, meta_value) VALUES (NULL, 'patch', 'patch_95_96_c.sql|Rename motif_name to binding_matrix_stable_id.');
 
 /**
 @header  Failed tables


### PR DESCRIPTION
This looks bigger than it is. It really is just renaming the motif_name column to binding_matrix_stable_id in the motif_feature_variation table. https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-1444