### PR TITLE
remove dist and group

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ env:
   global:
     secure: O28fOP56ZKwOl8ftpEaL+6DUxyD7JHAg4KIA7nrOUXR1cHr9F2q0+EFtZWJb9gzhfpr5wALSfHwXfSZslCp9mX61BAzHMQxUT1ArLibJWsjA8r7/6lcm2RP4WgfH8nEIF/83gaAJrxs6Qmt4dmtDHA7qhk+X/xDCYqbtUU3sldw=
 sudo: false
-dist: trusty
-group: deprecated
+
 addons:
   apt:
     packages:


### PR DESCRIPTION
Removing dist and group from the travis file prevents the error `DBI connect('mysql_local_infile=1;port=3306;host=127.0.0.1','root',...) failed: Can't connect to MySQL server on '127.0.0.1' (111) `(https://travis-ci.org/Ensembl/ensembl-variation/jobs/469510857)