### PR TITLE
Fix postion for ins in HGVS

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -2002,7 +2002,12 @@ sub hgvs_genomic {
       $hgvs_notation->{ref} ||= '-';
       $hgvs_notation->{alt} ||= '-';
       $hgvs_notation->{type} = 'del' if $hgvs_notation->{alt} eq '-';
-      $hgvs_notation->{type} = 'ins' if $hgvs_notation->{ref} eq '-';
+      if ($hgvs_notation->{ref} eq '-') {
+        $hgvs_notation->{type} = 'ins';
+        ## fix position for ins
+        $hgvs_notation->{start}--;
+        $hgvs_notation->{end} = $hgvs_notation->{start} + 1;
+      }
     }
 
     # Add the name of the reference

--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -745,4 +745,29 @@ ok( $hgvs_genomic_slice->{'T'} eq $hgvs_genomic->{'T'}, "hgvs genomic notation w
 my $hgvs_genomic_no_slice = $variation_feature->hgvs_genomic(); 
 ok( $hgvs_genomic_no_slice->{'T'} eq $hgvs_genomic->{'T'}, "hgvs genomic notation with a slice is the same as get_all_hgvs_notations genomic ('g')");
 
+{
+  # Test trimming of alleles in hgvs_genomic when type is delins
+  # Test delins that is trimmed to an insertion
+  my $vfa = $vdba->get_variationFeatureAdaptor();
+  my $sa = $cdba->get_SliceAdaptor();
+  my $slice = $sa->fetch_by_region('chromosome', 2);
+
+  my $new_vf = Bio::EnsEMBL::Variation::VariationFeature->new(
+   -start => 46746468,
+   -end   => 46746468,
+   -slice => $slice,
+   -allele_string => 'T/TGT',
+   -strand => 1,
+   -map_weight => 1,
+   -adaptor => $vfa,
+   -variation_name => 'newSNP'
+  );
+
+  my $hgvs_expected = 'NC_000002.11:g.46746468_46746469insGT';
+  my $hgvs_genomic = $new_vf->hgvs_genomic();
+
+  is( $hgvs_genomic->{'TGT'}, $hgvs_expected, 'trimming of alleles for delins to ins');
+
+}
+
 done_testing(); 

--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -732,7 +732,7 @@ sub test_output{
 
 # Test hgvs genomic with slice and without slice 
 my $variationfeature_adaptor = $vdba->get_variationFeatureAdaptor; 
-my $slice_adaptor = $cdba->get_Slice;   
+my $slice_adaptor = $cdba->get_SliceAdaptor();
 my $slice = $slice_adaptor->fetch_by_region('chromosome', 2, 1, 665568000);
 my $variation_feature = $variationfeature_adaptor->fetch_by_hgvs_notation( "ENST00000522587.1:c.-101-6514C>T" );  
 my $hgvs_genomic = $variation_feature->get_all_hgvs_notations("", "g");


### PR DESCRIPTION
Fix for ENSVAR-1438
Fix the HGVS where trimming of delins to an ins, gave start position larger than the end position.