### PR TITLE
Fix script for generating default vep examples for WEB VEP form

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -710,7 +710,7 @@ sub get_all_MotifFeatureVariations {
   if(!exists($self->{motif_feature_variations})) {
     # We couldn't store motif_feature_variation for human in release/94
     # compute them on the fly instead
-    my $species = lc $self->adaptor->db->species;
+    my $species = lc $self->adaptor->db->species if (defined $self->adaptor->db);
     if($self->dbID && ($species !~ /homo_sapiens|human/)) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;

--- a/modules/t/variationFeature.t
+++ b/modules/t/variationFeature.t
@@ -397,4 +397,23 @@ is_deeply(
 
 $vfa->db->use_vcf(0);
 
+
+# test fake variation feature adapter and fake variation feature
+{
+  my $vfa = Bio::EnsEMBL::Variation::DBSQL::VariationFeatureAdaptor->new_fake('homo_sapiens');
+  my $tmp_vf_fs = Bio::EnsEMBL::Variation::VariationFeature->new_fast({
+    start          => 100000,
+    end            => 100005,
+    allele_string  => 'A/-',
+    strand         => 1,
+    map_weight     => 1,
+    adaptor        => $vfa,
+    slice          => $slice,
+    seq_region_start => $slice->seq_region_start,
+    seq_region_end   => $slice->seq_region_end
+  });
+  my $conseq = join ",", @{$tmp_vf_fs->consequence_type};
+  ok($conseq eq 'intergenic_variant', "fake VariationFeatureAdaptor and VariationFeature");
+}
+
 done_testing();

--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -110,8 +110,11 @@ SPECIES: foreach my $species(@all_species) {
     my $name;
     my $sth = $real_vfa->db->dbc->prepare(qq{
       SELECT variation_name
-      FROM variation_feature
+      FROM variation_feature vf
+        LEFT JOIN failed_variation fv
+        ON vf.variation_id = fv.variation_id
       WHERE consequence_types LIKE ?
+      AND fv.variation_id IS NULL
       LIMIT 1
     });
 
@@ -347,8 +350,8 @@ sub dump_vf {
 sub select_transcript {
   my $trs = shift;
   my $div_bacteria = shift;
-  
-  $div_bacteria |= 0;
+
+  $div_bacteria ||= 0;
 
   # we want a transcript on the fwd strand with an intron that's protein coding
   my $biotype = '';

--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -73,7 +73,7 @@ $reg->load_registry_from_db(
 );
 
 $dir ||= '.';
-$formats ||= 'ensembl,vcf,id,hgvs';
+$formats ||= 'ensembl,vcf,id,hgvs,spdi';
 
 my @formats = split(',', $formats);
 
@@ -576,4 +576,19 @@ sub convert_to_vcf {
       '.', '.', '.'
     ];
   }
+}
+
+sub convert_to_spdi {
+  my $config = shift;
+  my $vf = shift;
+
+  my $tvs = $vf->get_all_TranscriptVariations;
+  my @return;
+  if(defined($tvs)) {
+    push @return, map {values %{$vf->spdi_genomic()}} @$tvs;
+  }
+
+  @return = grep {defined($_)} @return;
+
+  return [$return[0] || undef];
 }

--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -73,7 +73,7 @@ $reg->load_registry_from_db(
 );
 
 $dir ||= '.';
-$formats ||= 'ensembl,vcf,id,hgvs,pileup';
+$formats ||= 'ensembl,vcf,id,hgvs';
 
 my @formats = split(',', $formats);
 


### PR DESCRIPTION
- return example rsIDs of non failed variation
- remove pileup from formats generated by default, format not supported any more
- fix a typo/bug 