### PR TITLE
Task/patch 96 97 b update

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Variation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Variation.pm
@@ -820,7 +820,7 @@ sub ancestral_allele {
   if (!$self->{'ancestral_allele'}) {
     my %ancestral_alleles;
     foreach my $vf (@{$self->get_all_VariationFeatures}) {
-      $ancestral_alleles{$vf->ancestral_allele} = 1;
+      $ancestral_alleles{$vf->ancestral_allele} = 1 if (defined $vf->ancestral_allele);
     }
     if (scalar keys %ancestral_alleles == 1) {
       my ($aa) = keys %ancestral_alleles;

--- a/modules/t/variationAdaptor.t
+++ b/modules/t/variationAdaptor.t
@@ -266,4 +266,8 @@ throws_ok { $va->store_synonyms($var) } qr/No source found for name turnip/, 'Th
 
 $var = $va->fetch_by_name('rs1267742856');
 ok(! defined $var->ancestral_allele, "No ancestral_allele if mappings have different ancestral allelels");
+
+$var = $va->fetch_by_name('rs191996219');
+ok(! defined $var->ancestral_allele, "No ancestral_allele returns undef");
+
 done_testing();


### PR DESCRIPTION
There were problems in ensembl-rest and ensembl-vep with undef turned into empty strings. This is a fix to return undef if there is no ancestral allele for the variant feature.