### PR TITLE
Update of file checks and LSF queue for TranscriptVariation pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/CheckTranscriptVariation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/CheckTranscriptVariation.pm
@@ -160,8 +160,7 @@ sub report_results{
 
 
     my $dir =  $self->required_param('pipeline_dir');
-    open my $report, ">$dir/QC_report.txt"||die "Failed to open report file for summary info :$!\n";
-
+    open(my $report, ">$dir/QC_report.txt") or die("Failed to open report file for summary info: $!\n");
 
     my $percent_missense        = format_percent( $new->{missense_variant_count},   $new->{transcript_variation_count} ) ;
     my $percent_synonymous      = format_percent( $new->{synonymous_variant_count}, $new->{transcript_variation_count} ) ;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -103,9 +103,9 @@ sub default_options {
         # reflect their usage, but you may want to change the details (memory
         # requirements, queue parameters etc.) to suit your own data
         
-        default_lsf_options => '-qproduction-rh7 -R"select[mem>2000] rusage[mem=2000]" -M2000',
-        medmem_lsf_options  => '-qproduction-rh7 -R"select[mem>5000] rusage[mem=5000]" -M5000',
-        highmem_lsf_options => '-qproduction-rh7 -R"select[mem>15000] rusage[mem=15000] span[hosts=1]" -M15000 -n4', # this is LSF speak for "give me 15GB of memory"
+        default_lsf_options => '-qproduction-rh74 -R"select[mem>2000] rusage[mem=2000]" -M2000',
+        medmem_lsf_options  => '-qproduction-rh74 -R"select[mem>5000] rusage[mem=5000]" -M5000',
+        highmem_lsf_options => '-qproduction-rh74 -R"select[mem>15000] rusage[mem=15000] span[hosts=1]" -M15000 -n4', # this is LSF speak for "give me 15GB of memory"
 
         # options controlling the number of workers used for the parallelisable analyses
         # these default values seem to work for most species

--- a/scripts/import/ImportUtils.pm
+++ b/scripts/import/ImportUtils.pm
@@ -158,6 +158,22 @@ sub loadfile {
   my $cols = join( ",", @colnames );
 
   my $table_file = "$TMP_DIR/$tablename\_$$\.txt";
+
+  if (! -e $loadfile) {
+    die("File to load ($loadfile) does not exist");
+  }
+
+  # Do not rename the $loadfile to the $table_file
+  # if the $table_file already exists
+  if (-e $table_file) {
+    die("File to rename to for table load exists ($table_file)");
+   }
+
+  my $ret = rename($loadfile, $table_file);
+  if (! $ret) {
+    die("rename of ($loadfile) to ($table_file) for table load fails");
+  }
+
   rename($loadfile, $table_file);
    
 #  my $host = $db->host();


### PR DESCRIPTION
The TranscriptVariation loads file from shared directory. To prevent overwriting files, the file existence is checked before renames occur during loading. ImportUtils is used by other loading scripts and pipelines - will the die cause a problem?
