### PR TITLE
catch error

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/CADDAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/CADDAnnotation.pm
@@ -151,7 +151,7 @@ sub _seek_by_VariationFeature {
     throw('Bio::EnsEMBL::Variation::VariationFeature arg expected');
   }
   my $parser = $self->_file_parser_obj();
-  if ( $parser->seek($vf->seq_region_name, $vf->seq_region_start, $vf->seq_region_end)) {
+  if ($parser && $parser->seek($vf->seq_region_name, $vf->seq_region_start, $vf->seq_region_end)) {
     return $parser;
   }
 }
@@ -164,8 +164,8 @@ sub _file_parser_obj {
   chdir($self->tmpdir);
 
   # open object (remote indexes get downloaded) locally, therefore we change the current directory to point to the tmp directory
-  my $obj = Bio::EnsEMBL::IO::Parser::CADDTabix->open($self->filename_template);
-
+  my $obj;
+  eval { $obj = Bio::EnsEMBL::IO::Parser::CADDTabix->open($self->filename_template); }; warn $@ if $@; 
   # change back
   chdir($cwd);
 

--- a/modules/Bio/EnsEMBL/Variation/CADDAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/CADDAnnotation.pm
@@ -164,7 +164,7 @@ sub _file_parser_obj {
   chdir($self->tmpdir);
 
   # open object (remote indexes get downloaded) locally, therefore we change the current directory to point to the tmp directory
-  my $obj;
+  my $obj = undef;
   eval { $obj = Bio::EnsEMBL::IO::Parser::CADDTabix->open($self->filename_template); }; warn $@ if $@; 
   # change back
   chdir($cwd);

--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -1124,8 +1124,8 @@ sub _vcf_parser_obj {
   chdir($self->tmpdir);
 
   # open obect (remote indexes get downloaded)
-  my $obj = Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($file);
-
+  my $obj = undef;
+  eval { $obj = Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($file); }; warn $@ if $@;
   # change back
   chdir($cwd);
 


### PR DESCRIPTION
This PR catches the error thrown by Bio::DB::HTS::Tabix as reported on the service channel by Emily (Request: /Homo_sapiens/Variation/Explore?db=core;v=rs17502934
Reference: 6e02dd8bc8
Error: Couldn't find index for file /nfs/public/relea). It is not confirmed if this is only for the CADD files that are read from FTP. We might need to move the files to a local directory like we do for VCF files.