### PR TITLE
Adding 'variation' subdirectory for non-vertebrates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/BaseDataDumpsProcess.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/BaseDataDumpsProcess.pm
@@ -42,7 +42,7 @@ sub data_dir {
   # If division is defined append the pipeline_dir
   if ($species_division)
   {
-    $data_dump_dir = $data_dump_dir."/".$species_division;
+    $data_dump_dir = $data_dump_dir."/".$species_division."/variation";
   }
   return $data_dump_dir;
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PreRunChecks.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/PreRunChecks.pm
@@ -90,7 +90,7 @@ sub create_species_dir_tree {
     # If division is defined.
     if ( scalar(@division) ) {
       foreach my $division (@division) {
-        $pipeline_dir=$pipeline_dir."/".$division;
+        $pipeline_dir=$pipeline_dir."/".$division."/variation";
         $dump_dir = "$pipeline_dir/$file_type/";
         make_path($dump_dir) unless (-d $dump_dir);
       }


### PR DESCRIPTION
For non-vertebrate dumps, we want to have a 'variation' subdirectory to be consistent with vertebrate dumps. But since the division is added to the path in the code, it is not possible to append a further subdirectory by passing parameters when initialising the pipeline. So it's necessary to add the subdirectory in the code.

This has been tested by running the pipeline to completion; the resultant directory structure is as desired.
