### PR TITLE
Leave ensembl-hive with the branch 'master'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 - export ENSEMBL_BRANCH=master
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-hive.git
+- git clone --branch master          --depth 1 https://github.com/Ensembl/ensembl-hive.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
 - git clone --branch release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git


### PR DESCRIPTION
Forgot that we always use the `master` branch for ensembl-hive in Travis