### PR TITLE
Task98/post pipeline updates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -102,7 +102,6 @@ sub resource_classes {
     my ($self) = @_;
     return {
           'default' => { 'LSF' => $self->o('default_lsf_options') },
-          'highmem' => { 'LSF' => $self->o('highmem_lsf_options') },
           'medmem'  => { 'LSF' => $self->o('medmem_lsf_options') },
     };
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/FinishRegulationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/FinishRegulationEffect.pm
@@ -43,7 +43,7 @@ sub run {
   if ($self->param('update_vf') || $self->param('only_update_vf')) {
     my $vdba = $self->get_species_adaptor('variation');
     my $dbc = $vdba->dbc;
-
+    $dbc->reconnect_when_lost(1);
     # pre-clean-up:
     foreach my $table (qw/regulatory_region_consequences variation_feature_overlap_regulation variation_feature_consequences/) {
       $dbc->do(qq{DROP TABLE IF EXISTS $table;})

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/RegulationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/RegulationEffect.pm
@@ -45,8 +45,12 @@ sub run {
     my $disambiguate_sn_alleles = $self->param('disambiguate_single_nucleotide_alleles'); 
 
     my $cdba = $self->get_adaptor($species, 'core');
+    $cdba->dbc->reconnect_when_lost(1);
     my $vdba = $self->get_adaptor($species, 'variation');
+    $vdba->dbc->reconnect_when_lost(1);
     my $fdba = $self->get_adaptor($species, 'funcgen');
+    $fdba->dbc->reconnect_when_lost(1);
+
 
     my $slice_adaptor = $cdba->get_SliceAdaptor; 
     my $regulatory_feature_adaptor = $fdba->get_RegulatoryFeatureAdaptor;
@@ -75,7 +79,10 @@ sub add_regulatory_feature_variations {
   my $disambiguate_sn_alleles = $self->param('disambiguate_single_nucleotide_alleles'); 
 
   my $cdba = $self->get_adaptor($species, 'core');
+  $cdba->dbc->reconnect_when_lost(1);
   my $vdba = $self->get_adaptor($species, 'variation');
+  $vdba->dbc->reconnect_when_lost(1);
+
 
   my $rfva = $vdba->get_RegulatoryFeatureVariationAdaptor;
   $rfva->db->include_failed_variations(1);
@@ -107,7 +114,9 @@ sub add_motif_feature_variations {
 
 
   my $cdba = $self->get_adaptor($species, 'core');
+  $cdba->dbc->reconnect_when_lost(1);
   my $vdba = $self->get_adaptor($species, 'variation');
+  $vdba->dbc->reconnect_when_lost(1);
 
   my $mfva = $vdba->get_MotifFeatureVariationAdaptor;
   $mfva->db->include_failed_variations(1);
@@ -116,7 +125,7 @@ sub add_motif_feature_variations {
   foreach my $motif_feature (@$motif_features) {
     my $slice = $slice_adaptor->fetch_by_Feature($motif_feature) or die "Failed to get slice around motif feature: " . $motif_feature->dbID;
 
-    for my $vf ( @{ $slice->get_all_VariationFeatures }, @{ $slice->get_all_somatic_VariationFeatures } ) {
+    for my $vf ( @{ $slice->get_all_VariationFeatures }) {
       my $mfv = Bio::EnsEMBL::Variation::MotifFeatureVariation->new(
         -motif_feature      => $motif_feature,
         -variation_feature  => $vf,


### PR DESCRIPTION
also don't compute motif variation overlaps for somatic variants because adding cosmic allele strings (COSMIC) into the motif is causing errors because of non supported nucleotide chars.