### PR TITLE
Updates to allow test to be run with database intact

### DIFF
--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -300,7 +300,7 @@ $sth->execute;
 my ($max_tv_id_after) = $sth->fetchrow_array;
 $sth->finish();
 
-# When records are deleted, the autoincrement of the table is not changed.
+# When records are deleted, the auto_increment of the table is not changed.
 # When running with database intact, the max_tv_id_after should be
 # greater than before but not necessarily one greater
 ok($max_tv_id_after > $max_tv_id_before, 'get max transcript_variation_id');

--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -296,11 +296,13 @@ $sth->execute;
 my ($max_tv_id_after) = $sth->fetchrow_array;
 $sth->finish();
 
-ok($max_tv_id_after == $max_tv_id_before + 1, 'get max transcript_variation_id');
+# When records are deleted, the autoincrement of the table is not changed.
+# When running with database intact, the max_tv_id_after should be
+# greater than before but not necessarily one greater
+ok($max_tv_id_after > $max_tv_id_before, 'get max transcript_variation_id');
 
 my $tv_store = $trv_ad->fetch_by_dbID($max_tv_id_after);
 ok($tv_store->display_consequence eq 'missense_variant', 'test store');
-$dbh->do(qq{DELETE FROM variation_feature WHERE variation_feature_id=$max_tv_id_after;}) or die $dbh->errstr;
+$dbh->do(qq{DELETE FROM transcript_variation WHERE transcript_variation_id=$max_tv_id_after;}) or die $dbh->errstr;
 
 done_testing();
-

--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -282,17 +282,14 @@ $sth->finish();
 my $transcript_id_store = 'ENST00000470094';
 my $transcript_store = $tr_ad->fetch_by_stable_id($transcript_id_store);
 my $vf_store = $vf_ad->fetch_by_dbID(23700405);
-my @vfs = ($vf_store);
-foreach my $vf (@vfs) {
-  my $tv = Bio::EnsEMBL::Variation::TranscriptVariation->new(
+my $tv = Bio::EnsEMBL::Variation::TranscriptVariation->new(
     -transcript     => $transcript_store,
-    -variation_feature  => $vf,
+    -variation_feature  => $vf_store,
     -adaptor      => $trv_ad,
     -disambiguate_single_nucleotide_alleles => 0,
     -no_transfer    => 1,
-  );
-  $trv_ad->store($tv);
-}
+);
+$trv_ad->store($tv);
 
 sleep(10);
 

--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -269,8 +269,12 @@ foreach my $trans_varns (@{$trans_vars_ns}){
 }
 
 #store
+
+#make a backup of the current transcript_variation table before the store test
+$multi->save('variation', 'transcript_variation');
+
 my $dbh = $vf_ad->dbc->db_handle;
-my $sth = $dbh->prepare(qq/SELECT MAX(transcript_variation_id) FROM transcript_variation/); 
+my $sth = $dbh->prepare(qq/SELECT MAX(transcript_variation_id) FROM transcript_variation/);
 $sth->execute;
 my ($max_tv_id_before) = $sth->fetchrow_array;
 $sth->finish();
@@ -303,6 +307,7 @@ ok($max_tv_id_after > $max_tv_id_before, 'get max transcript_variation_id');
 
 my $tv_store = $trv_ad->fetch_by_dbID($max_tv_id_after);
 ok($tv_store->display_consequence eq 'missense_variant', 'test store');
-$dbh->do(qq{DELETE FROM transcript_variation WHERE transcript_variation_id=$max_tv_id_after;}) or die $dbh->errstr;
 
+# restore the transcript_variation table from before store test
+$multi->restore('variation', 'transcript_variation');
 done_testing();


### PR DESCRIPTION
Fix for ENSVAR-2338
Also update to only use a single vf when testing store as only single vf returned by fetch_by_dbID