### PR TITLE
Fix source dbSNP - different versions 

### DIFF
--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -109,11 +109,12 @@ elsif($source_name eq 'dbSNP') {
   my %data; # synonym_name => {rs_name} & {source_id} 
 
   # get data from human_synonym table (in production db) 
+  # some synonyms name are duplicated - from different sources 
   foreach my $result (@{$synonyms_output}){  
-    $data{$result->[1]}{rs_name} = $result->[0]; 
-    $data{$result->[1]}{source_id} = $result->[2]; 
+    $data{$result->[0].' '.$result->[1]}{rs_name} = $result->[0]; 
+    $data{$result->[0].' '.$result->[1]}{source_id} = $result->[2]; 
   }
- 
+
   # get all available sources from production database  
   my $sources = get_all_sources($dba, $prod_dbc);
 
@@ -552,6 +553,8 @@ sub import_synonyms_all_sources {
   
     my $source_id = $data->{$synonym_name}->{source_id};
     my $source = $sources->{$source_id}; 
+    # Clean synonym name before insert in db - remove rsid from name  
+    $synonym_name =~ s/.*\s//g; 
     $var->add_synonym($source->name(), $synonym_name);
     $variation_adaptor->store_synonyms($var); 
 

--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -109,7 +109,7 @@ elsif($source_name eq 'dbSNP') {
   my %data; # synonym_name => {rs_name} & {source_id} 
 
   # get data from human_synonym table (in production db) 
-  # some synonyms name are duplicated - from different sources 
+  # some synonyms names are duplicated - from different sources 
   foreach my $result (@{$synonyms_output}){  
     $data{$result->[0].' '.$result->[1]}{rs_name} = $result->[0]; 
     $data{$result->[0].' '.$result->[1]}{source_id} = $result->[2]; 
@@ -159,11 +159,9 @@ elsif($source_name eq 'UniProt'){
     @ids = keys(%synonym);
   }
 
-  my $variation_ids = $object_type =~ /Variation/ ? get_dbIDs(\@ids,$dba) : {}; 
-
   # Add the synonyms
-    my $variation_set_id = add_set_uniprot($dba,$set,$source_description);
-    add_synonyms_uniprot(\%synonym, $variation_ids, $source_name, $variation_set_id, $dba, $species); 
+  my $variation_set_id = add_set_uniprot($dba,$set,$source_description);
+  add_synonyms_uniprot(\%synonym, $source_name, $variation_set_id, $dba, $species); 
 }
 
 else{
@@ -263,71 +261,6 @@ sub parse_uniprot {
   return \%result;
 }
 
-=head2 get_dbIDs
-
-get variation ids 
-
-=cut 
-
-sub get_dbIDs {
-  my $rs_ids     = shift;
-  my $db_adaptor = shift;
-  
-  my $id_stmt = qq{
-    SELECT
-      DISTINCT
-      v.variation_id,
-      v.name
-    FROM
-      variation v,
-      variation_feature vf
-      
-    WHERE
-      v.name = ? AND
-      v.variation_id=vf.variation_id
-    LIMIT 1
-  };
-  my $syn_stmt = qq{
-    SELECT
-      DISTINCT
-      v.variation_id,
-      v.name
-    FROM
-      variation_feature vf,
-      variation_synonym vs JOIN
-      variation v ON vs.variation_id = v.variation_id
-    WHERE
-      vs.name = ? AND
-      v.variation_id=vf.variation_id
-    LIMIT 1
-  };
-  my $id_sth = $db_adaptor->dbc->prepare($id_stmt);
-  my $syn_sth = $db_adaptor->dbc->prepare($syn_stmt);
-  
-  my %mapping;
-  
-  foreach my $rs_id (@{$rs_ids}) {
-    $id_sth->bind_param(1,$rs_id,SQL_VARCHAR);
-    $id_sth->execute();
-    my ($var_id,$var_name);
-    $id_sth->bind_columns(\$var_id,\$var_name);
-    $id_sth->fetch();
-    
-    # If we couldn't find the rs_id, look in the synonym table
-    if (!defined($var_id)) {
-      $syn_sth->bind_param(1,$rs_id,SQL_VARCHAR);
-      $syn_sth->execute();
-      $syn_sth->bind_columns(\$var_id,\$var_name);
-      $syn_sth->fetch();
-    }
-    warn "$rs_id - no mapping found in variation db\n" unless $var_id ;  
-
-    $mapping{$rs_id} = [$var_id,$var_name] if $var_id && $var_name;
-  }
-  
-  return \%mapping;
-} 
-
 =head2 add_set_uniprot
 
 add UniProt variation set 
@@ -408,7 +341,6 @@ import UniProt synonyms;
 
 sub add_synonyms_uniprot {
   my $synonyms           = shift;
-  my $variation_ids      = shift;
   my $source_name        = shift;
   my $variation_set_id   = shift; 
   my $db_adaptor         = shift;
@@ -450,15 +382,15 @@ sub add_synonyms_uniprot {
   my $update_after_check_sth = $db_adaptor->dbc->prepare($stmt_update_after_check);
   my $update_variation_set_sth = $db_adaptor->dbc->prepare($stmt_update); 
   
-  foreach my $rs_id (keys %{$variation_ids}) {
-    my $variation_id = $variation_ids->{$rs_id}[0];    
+  foreach my $rs_id (keys %{$synonyms}) {
+    my $variation_id = $synonyms->{$rs_id}[0];    
 
     my $variation = $variation_adaptor->fetch_by_name($rs_id);
     unless($variation){
       warn "Variant $rs_id not found\n"; 
       next; 
     }
-    
+
     $variation->add_synonym($source_name, @{$synonyms->{$rs_id}}); 
     $variation_adaptor->store_synonyms($variation); 
     

--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -103,7 +103,8 @@ elsif($source_name eq 'dbSNP') {
       '-driver'  =>  'mysql' 
     ); 
 
-  my $synonyms_output = query_synonyms_data($prod_dbc, 'rs_name,synonym_name,source_id', 'human_synonym'); 
+  my $sql_query = "SELECT rs_name,synonym_name,source_id FROM human_synonym"; 
+  my $synonyms_output = query_synonyms_data($prod_dbc, $sql_query); 
 
   my %data; # synonym_name => {rs_name} & {source_id} 
 
@@ -624,7 +625,10 @@ sub get_all_sources {
 
   my $source_adaptor = $dest_db->get_SourceAdaptor('human', 'variation'); 
 
-  my $source_output = query_synonyms_data($prod_dbc, 'source_id,name,version,description,url', 'source');  
+  # Get sources from production that are linked to human synonym data 
+  my $sql_query = "SELECT source_id,name,version,description,url FROM source WHERE source_id IN
+                   (SELECT DISTINCT(source_id) FROM human_synonym)";
+  my $source_output = query_synonyms_data($prod_dbc, $sql_query);  
 
   foreach my $result_from_source (@{$source_output}) {  
     # my $source_id = $result_from_source->[0]; 
@@ -661,10 +665,9 @@ fetch data from production database
 sub query_synonyms_data {
 
   my $prod_dbc   = shift;
-  my $params     = shift; 
-  my $table_name = shift;
+  my $sql_query  = shift; 
 
-  my $statement = $prod_dbc->prepare("SELECT $params FROM $table_name");  
+  my $statement = $prod_dbc->prepare($sql_query);  
   $statement->execute(); 
   my $source_output = $statement->fetchall_arrayref();  
   $statement->finish(); 


### PR DESCRIPTION
There's one source 'dbSNP151' in production db that was being created in human db when importing synonyms - also, there's no human synonym data for that source in production.  
Changed code to only check for sources with synonym data. 