### PR TITLE
most_severeOverlapConsequence set alphabetically for equal ranks

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/AlleleFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/AlleleFeature.pm
@@ -284,9 +284,13 @@ sub most_severe_OverlapConsequence {
             $highest ||= $cons;
             if ($cons->rank < $highest->rank) {
                 $highest = $cons;
+            } elsif (($cons->rank == $highest->rank)
+                          &&
+                     ($cons->SO_term lt $highest->SO_term)) {
+                $highest = $cons;
             }
         }
-        
+
         $self->{_most_severe_consequence} = $highest;
     }
     

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeature.pm
@@ -159,6 +159,10 @@ sub most_severe_OverlapConsequence {
             $highest ||= $cons;
             if ($cons->rank < $highest->rank) {
                 $highest = $cons;
+            } elsif (($cons->rank == $highest->rank)
+                        &&
+                     ($cons->SO_term lt $highest->SO_term)) {
+                $highest = $cons;
             }
         }
         

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlap.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlap.pm
@@ -444,6 +444,10 @@ sub most_severe_OverlapConsequence {
                 $highest ||= $cons;
                 if ($cons->rank < $highest->rank) {
                     $highest = $cons;
+                } elsif (($cons->rank == $highest->rank)
+                            &&
+                         ($cons->SO_term lt $highest->SO_term)) {
+                    $highest = $cons;
                 }
             }
         }
@@ -499,4 +503,3 @@ sub adaptor {
 }
 
 1;
-

--- a/modules/t/alleleFeature.t
+++ b/modules/t/alleleFeature.t
@@ -113,5 +113,20 @@ is($hash->{'1411-1411-1'}->{'allele_string'}, 'C|T', 'Test allele_string');
 is($hash->{'1001-1001-1'}->{'consequence_type'}, 'downstream_gene_variant', 'Test consequence_type');
 is($hash->{'1083-1083-1'}->{'variation_name'}, 'rs73650063', 'Test variation_name');
 
+# test most_severe_OverlapConsequence for consequences with the same rank
+my $oc_1 = Bio::EnsEMBL::Variation::OverlapConsequence->new(
+             -SO_term => 'splice_donor_variant',
+             -rank    => 3);
+
+my $oc_2 = Bio::EnsEMBL::Variation::OverlapConsequence->new(
+              -SO_term => 'splice_acceptor_variant',
+              -rank    => 3);
+
+my $af = Bio::EnsEMBL::Variation::AlleleFeature->new
+  ( -overlap_consequences => [$oc_1, $oc_2]);
+
+my $msc_2_expected = 'splice_acceptor_variant';
+my $msc_2 = $af->most_severe_OverlapConsequence();
+is($msc_2->SO_term, $msc_2_expected, 'allele - most_severe_OverlapConsequence - same rank');
 
 done_testing();

--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -302,5 +302,35 @@ my $tv_store = $trv_ad->fetch_by_dbID($max_tv_id_after);
 ok($tv_store->display_consequence eq 'missense_variant', 'test store');
 $dbh->do(qq{DELETE FROM variation_feature WHERE variation_feature_id=$max_tv_id_after;}) or die $dbh->errstr;
 
-done_testing();
+# test most_severe_OverlapConsequence for consequences with the same rank
+$stable_id = 'ENST00000470094';
+$transcript = $tr_ad->fetch_by_stable_id($stable_id);
 
+my $var_msc = $var_ad->fetch_by_name('rs200814465');
+my $vfs_msc = $vf_ad->fetch_all_by_Variation($var_msc);
+my $new_vf_msc = $vfs_msc->[0];
+my $trvar_msc = Bio::EnsEMBL::Variation::TranscriptVariation->new
+  (-variation_feature => $new_vf_msc,
+   -transcript        => $transcript,
+);
+
+# The expected consequences are:
+#   rank: 12  SO_term: missense_variant
+#   rank: 22  SO_term: NMD_transcript_variant
+# For the test change to the same rank, different description
+for my $allele (@{$trvar_msc->get_all_alternate_BaseVariationFeatureOverlapAlleles}) {
+    for my $cons (@{$allele->get_all_OverlapConsequences }) {
+      if ($cons->SO_term eq 'missense_variant') {
+        $cons->SO_term('test_consequence_z');
+        $cons->rank(3);
+      } elsif ($cons->SO_term eq 'NMD_transcript_variant') {
+        $cons->SO_term ('test_consequence_a');
+        $cons->rank(3);
+      }
+    }
+}
+my $msc_2_expected = 'test_consequence_a';
+my $msc_2 = $trvar_msc->most_severe_OverlapConsequence();
+is($msc_2->SO_term, $msc_2_expected, 'tv - most_severe_OverlapConsequence - same rank');
+
+done_testing();

--- a/modules/t/variationFeature.t
+++ b/modules/t/variationFeature.t
@@ -424,4 +424,20 @@ $vfa->db->use_vcf(0);
   ok($conseq eq 'intergenic_variant', "fake VariationFeatureAdaptor and VariationFeature");
 }
 
+# test most_severe_OverlapConsequence for consequences with the same rank
+my $oc_1 = Bio::EnsEMBL::Variation::OverlapConsequence->new(
+             -SO_term => 'splice_donor_variant',
+             -rank    => 3);
+
+my $oc_2 = Bio::EnsEMBL::Variation::OverlapConsequence->new(
+              -SO_term => 'splice_acceptor_variant',
+              -rank    => 3);
+
+my $vf_msc = Bio::EnsEMBL::Variation::VariationFeature->new
+  ( -overlap_consequences => [$oc_1, $oc_2]);
+
+my $msc_2_expected = 'splice_acceptor_variant';
+my $msc_2 = $vf_msc->most_severe_OverlapConsequence();
+is($msc_2->SO_term, $msc_2_expected, 'vf - most_severe_OverlapConsequence - same rank');
+
 done_testing();


### PR DESCRIPTION
For consequences with the same highest rank, the first alphabetically is returned.
This is a fix for JIRA ENSVAR-2119 (98) and ENSVAR-909 (99)
PR is on postreleasefix/98 and replaces #419