### PR TITLE
update dbnsfp key used by protein function pipeline

### DIFF
--- a/sql/attrib_entries.sql
+++ b/sql/attrib_entries.sql
@@ -840,7 +840,7 @@ INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (602, 534, '
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (603, 534, 'low');
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (604, 534, 'neutral');
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (605, 481, 'dbnsfp_cadd');
-INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (606, 481, 'dbnsfp_meta_svm');
+INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (606, 481, 'dbnsfp_meta_lr');
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (607, 481, 'dbnsfp_mutation_assessor');
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (608, 481, 'dbnsfp_revel');
 INSERT IGNORE INTO attrib (attrib_id, attrib_type_id, value) VALUES (609, 481, 'cadd');


### PR DESCRIPTION
When I was running the CADD and dbNSFP protein function pipeline on a fresh human database for release 98 I noticed that one of the attribs was still using the old name dbnsfp_meta_svm instead of dbnsfp_meta_lr.