### PR TITLE
fixes for reverse strand HGVSp parsing

### DIFF
--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -280,6 +280,13 @@ my %test_output = (
             "ENSP00000349297.4:p.Pro23_Gly24insArgThrTer",
             "insertion, stop gained part way through inserted seq"
             ],
+      38 => ["NC_000011.9:g.32417913_32417914delinsTT",
+            "TT",
+            "ENST00000530998.1:c.451_452delinsAA",
+            "AA",
+            "ENSP00000435307.1:p.Arg151Lys",
+            "2 base sustitution, stop gained [-1]",
+            ],
 
 );
 
@@ -471,7 +478,10 @@ my %test_input = (
             "ENST00000356839.4:c.68_69insCAGGACGTGAGGCGTGTT",
             "ENSP00000349297.4:p.Pro23_Gly24insArgThrTerGly",
             ],
-
+      38 => ["NC_000011.9:g.32417913_32417914delinsTT",
+             "ENST00000530998.1:c.451_452delinsAA",
+             "ENSP00000435307.1:p.Arg151Lys",
+             ],
 );
 
 my %test_input_shifted = (

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -500,5 +500,11 @@ $spdi_str = 'NC_000012:102009450:GCCCCCC:CT';
 $vf = $vfa->fetch_by_spdi_notation($spdi_str);
 ok($vf->allele_string eq 'GCCCCCC/CT' , "Valid indel"); 
 
+## check ref matching
+my $bad_hgvs = 'ENSP00000434898.1:p.Cys6Ser';
+throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Could not uniquely determine nucleotide change from ENSP00000434898.1:p.Cys6Ser/, 'Throw if HGVS does not match reference';
+my $ok_hgvs = 'ENSP00000293261.2:p.Ser455del';
+$vf = $vfa->fetch_by_hgvs_notation($ok_hgvs);
+ok($vf->allele_string eq 'AGC/-', "HGVSp matches reference");
 done_testing();
 


### PR DESCRIPTION
Fix for HGVSp parsing for reverse strand transcripts. Examples: ENSP00000270861:p.Ser285Ala & RT: 357497