### PR TITLE
Update cosmic import

### DIFF
--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -122,7 +122,7 @@ my %attribs_col = ('ID'          => 'id *',
                   );
 
 
-my %display_name = ( 'COSMIC' => 'http://cancer.sanger.ac.uk/cancergenome/projects/cosmic/' );
+my %display_name = ( 'COSMIC' => 'https://cancer.sanger.ac.uk/cosmic/' );
 
 my $add             = '';
 my $study_table     = "study$add";

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -289,7 +289,7 @@ sub get_source_id {
     $dbVar->do(qq{UPDATE IGNORE source SET version=$version where name="$source_name";});
   }
   else {
-    $dbVar->do(qq{INSERT INTO source (name,description,url,version,somatic_status,data_types) VALUES ("$source_name",'Somatic mutations found in human cancers from the COSMIC project - Public version','https://cancer.sanger.ac.uk/cosmic/',$version,'somatic','variation,phenotype_feature');});
+    $dbVar->do(qq{INSERT INTO source (name,description,url,version,somatic_status,data_types) VALUES ("$source_name",'Somatic mutations found in human cancers from the COSMIC project - Public version','https://cancer.sanger.ac.uk/cosmic/',$version,'somatic','variation,variation_synonym,phenotype_feature');});
   }
   my @source_id = @{$dbVar->selectrow_arrayref(qq{SELECT source_id FROM source WHERE name="$source_name";})};
   return $source_id[0];

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -73,7 +73,7 @@ $dbVar->do("DROP TABLE IF EXISTS $temp_table;");
 $dbVar->do("DROP TABLE IF EXISTS $temp_phen_table;");
 $dbVar->do("DROP TABLE IF EXISTS $temp_varSyn_table;");
   
-my @cols = ('name *', 'seq_region_id i*', 'seq_region_start i', 'seq_region_end i', 'class i', 'new_var_id i*');
+my @cols = ('name *', 'seq_region_id i*', 'seq_region_start i', 'seq_region_end i', 'class i');
 create($dbVar, "$temp_table", @cols);
 $dbVar->do("ALTER TABLE $temp_table ADD PRIMARY KEY (name, seq_region_id, seq_region_start, seq_region_end);");
 

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -178,9 +178,11 @@ while (<IN>) {
   $cosmic_ins_sth->bind_param(5,$class_attrib_id,SQL_INTEGER);
   $cosmic_ins_sth->execute();
 
-  $cosmic_syn_ins_sth->bind_param(1,$cosv_id,SQL_VARCHAR);
-  $cosmic_syn_ins_sth->bind_param(2,$cosmic_id,SQL_VARCHAR);
-  $cosmic_syn_ins_sth->execute();
+  if ( $cosmic_id =~ /COSM/ ){
+    $cosmic_syn_ins_sth->bind_param(1,$cosv_id,SQL_VARCHAR);
+    $cosmic_syn_ins_sth->bind_param(2,$cosmic_id,SQL_VARCHAR);
+    $cosmic_syn_ins_sth->execute();
+  }
   
   foreach my $phenotype (@line) {
     next if $phenotype =~ /^Substitution/ || $phenotype =~ /^Insertion/

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -75,15 +75,18 @@ $dbVar->do("DROP TABLE IF EXISTS $temp_varSyn_table;");
   
 my @cols = ('name *', 'seq_region_id i*', 'seq_region_start i', 'seq_region_end i', 'class i', 'new_var_id i*');
 create($dbVar, "$temp_table", @cols);
+$dbVar->do("ALTER TABLE $temp_table ADD PRIMARY KEY (name, seq_region_id, seq_region_start, seq_region_end);");
 
 my @cols_phen = ('name *', 'phenotype_id i*');
 create($dbVar, "$temp_phen_table", @cols_phen);
+$dbVar->do("ALTER TABLE $temp_phen_table ADD PRIMARY KEY (name, phenotype_id);");
 
 my @cols_syn = ('name *', 'old_name *');
 create($dbVar, "$temp_varSyn_table", @cols_syn);
+$dbVar->do("ALTER TABLE $temp_varSyn_table ADD PRIMARY KEY (name, old_name);");
 
 my $cosmic_ins_stmt = qq{
-    INSERT INTO
+    INSERT IGNORE INTO
       $temp_table (
         name,
         seq_region_id,
@@ -102,7 +105,7 @@ my $cosmic_ins_stmt = qq{
 my $cosmic_ins_sth = $dbh->prepare($cosmic_ins_stmt);
 
 my $cosmic_phe_ins_stmt = qq{
-    INSERT INTO
+    INSERT IGNORE INTO
       $temp_phen_table (
         name,
         phenotype_id
@@ -115,7 +118,7 @@ my $cosmic_phe_ins_stmt = qq{
 my $cosmic_phe_ins_sth = $dbh->prepare($cosmic_phe_ins_stmt);
 
 my $cosmic_syn_ins_stmt = qq{
-    INSERT INTO
+    INSERT IGNORE INTO
       $temp_varSyn_table (
         name,
         old_name

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -286,7 +286,7 @@ sub get_source_id {
     $dbVar->do(qq{UPDATE IGNORE source SET version=$version where name="$source_name";});
   }
   else {
-    $dbVar->do(qq{INSERT INTO source (name,description,url,version,somatic_status,data_types) VALUES ("$source_name",'Somatic mutations found in human cancers from the COSMIC project - Public version','http://cancer.sanger.ac.uk/cancergenome/projects/cosmic/',$version,'somatic','variation,phenotype_feature');});
+    $dbVar->do(qq{INSERT INTO source (name,description,url,version,somatic_status,data_types) VALUES ("$source_name",'Somatic mutations found in human cancers from the COSMIC project - Public version','https://cancer.sanger.ac.uk/cosmic/',$version,'somatic','variation,phenotype_feature');});
   }
   my @source_id = @{$dbVar->selectrow_arrayref(qq{SELECT source_id FROM source WHERE name="$source_name";})};
   return $source_id[0];

--- a/scripts/import/remove_cosmic_or_hgmd.pl
+++ b/scripts/import/remove_cosmic_or_hgmd.pl
@@ -140,6 +140,12 @@ $dbh->do(qq{
 print "- 'variation_set_variation' entries deleted\n";
 
 
+# variation_synonym
+$dbh->do(qq{
+    DELETE FROM variation_synonym WHERE source_id = $source_id
+});
+print "- 'variation_synonym' entries deleted\n";
+
 # variation
 $dbh->do(qq{
     DELETE FROM variation WHERE source_id = $source_id


### PR DESCRIPTION
v90 will switch to using COSV id: new stable genomic identifiers, main code changes:

- COSV ids  will be the `variation.name` entries
- the other COSM identifiers + new COSN identifiers will be stored in the `variation_synonym` table