### PR TITLE
Add missing param to regulation pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/RegulationEffect_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/RegulationEffect_conf.pm
@@ -105,6 +105,7 @@ sub pipeline_wide_parameters {
         debug                                  => $self->o('debug'),
         split_slice                            => $self->o('split_slice'),
         split_slice_length                     => $self->o('split_slice_length'),
+        use_experimentally_validated_mf        => $self->o('use_experimentally_validated_mf'),
     };
 }
 


### PR DESCRIPTION
Regulation pipeline not working for mouse because param not being passed correctly. 