### PR TITLE
Fix HGVSp when using 'NM' transcript 

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -1866,14 +1866,15 @@ sub fetch_by_hgvs_notation {
     my @transcripts;
 
     # Fetch xref transcript 
-    if(!defined($transcript) && ($reference =~ /NP/ || $reference =~ /XP/)){
+    # Also fetch transcript erroneously submitted with p. changes - 'NM'
+    if(!defined($transcript) && ($reference =~ /NP/ || $reference =~ /XP/ || $reference =~ /NM/)){
       @transcripts = @{$transcript_adaptor->fetch_all_by_external_name($reference)};
     }
 
     # support some malformed HGVS
     if(!defined($transcript)) {
       # Seeing transcripts erroneously submitted with p. changes
-      if($reference =~ /ENST|NM/){
+      if($reference =~ /ENST/){
          push @transcripts, $transcript_adaptor->fetch_by_stable_id($reference);
       }
       # Fetch as UniProt ID or gene


### PR DESCRIPTION
HGVSp is failing with transcript NM because transcript has to be fetched by external name (example NM_000088.3:p.Val1374Ala) 
http://rest.ensembl.org/variant_recoder/human/NM_000088.3:p.Val1374Ala?content-type=application/json 

Test: http://ebi-cli-003:3000/variant_recoder/human/NM_000088.3:p.Val1374Ala?content-type=application/json