### PR TITLE
Bugfix98/check existing missing alleles

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -949,7 +949,7 @@ sub align_seqs {
 sub trim_sequences {
   my ($ref, $alt, $start, $end, $empty_to_dash, $end_first) = @_;
 
-  throw("Missing reference or alternate sequence") unless $ref && $alt;
+  throw("Missing reference or alternate sequence") unless defined $ref && defined $alt;
 
   $start ||= 0;
   $end ||= $start + (length($ref) - 1);

--- a/modules/t/sequence_utils.t
+++ b/modules/t/sequence_utils.t
@@ -109,6 +109,12 @@ is_deeply(
   'trim_sequences - empty_to_dash'
 );
 
+is_deeply(
+  trim_sequences(qw(A 0)),
+  ['A', 0, 0, 0, 0],
+  'trim_sequences Except 0 as alt allele'
+);
+
 throws_ok {trim_sequences(undef, 'A')} qr/Missing reference or alternate sequence/, 'trim_sequences - no ref';
 throws_ok {trim_sequences('A')} qr/Missing reference or alternate sequence/, 'trim_sequences - no alt';
 throws_ok {trim_sequences()} qr/Missing reference or alternate sequence/, 'trim_sequences - no both';

--- a/modules/t/sequence_utils.t
+++ b/modules/t/sequence_utils.t
@@ -112,7 +112,7 @@ is_deeply(
 is_deeply(
   trim_sequences(qw(A 0)),
   ['A', 0, 0, 0, 0],
-  'trim_sequences Except 0 as alt allele'
+  'trim_sequences Accept 0 as alt allele'
 );
 
 throws_ok {trim_sequences(undef, 'A')} qr/Missing reference or alternate sequence/, 'trim_sequences - no ref';


### PR DESCRIPTION
Deals with bug reported by Andrey for  VEP tool [Missing reference or alternate sequence]
Input like "chr3    146187575       146187575       A/0     +       het" was causing a problem for compare_existing call.