### PR TITLE
check that allele string exists

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -816,7 +816,7 @@ sub start_retained_variant {
     $bvfo ||= $bvfoa->base_variation_feature_overlap;
     $bvf  ||= $bvfo->base_variation_feature;
     
-    return 0 if ($bvf->allele_string eq 'COSMIC_MUTATION' || $bvf->allele_string eq 'HGMD_MUTATION');
+    return 0 if ($bvf->allele_string && ($bvf->allele_string eq 'COSMIC_MUTATION' || $bvf->allele_string eq 'HGMD_MUTATION'));
 
     my $pre = $bvfoa->_pre_consequence_predicates;
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1104,7 +1104,7 @@ sub stop_retained {
         $bvfo ||= $bvfoa->base_variation_feature_overlap;
         $bvf  ||= $bvfo->base_variation_feature;
 
-        return 0 if ($bvf->allele_string eq 'COSMIC_MUTATION' || $bvf->allele_string eq 'HGMD_MUTATION');
+        return 0 if ($bvf->allele_string && ($bvf->allele_string eq 'COSMIC_MUTATION' || $bvf->allele_string eq 'HGMD_MUTATION'));
 
         $cache->{stop_retained} = 0;
 


### PR DESCRIPTION
SVs don't have an allele string and a warning was printed for uninitialised value in comparison in the start_retained_variant  predicate. I create the same PR for postreleasefix/100.