### PR TITLE
add ESP GRCh37 VCF

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -348,6 +348,34 @@
         }
       }
     },
+    { "id": "esp_GRCh37",
+      "species": "homo_sapiens",
+      "assembly": "GRCh37",
+      "type": "remote",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/ESP6500SI-V2-SSA137.vcf.gz",
+      "chromosomes": [
+        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+        "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
+      ],
+      "source_name": "NHLBI Exome Sequencing Project",
+      "population_display_group": {
+        "display_group_name": "NHLBI Exome Sequencing Project",
+        "display_group_priority": 2.7
+      },
+      "population_prefix": "ESP6500:",
+      "populations": {
+        "9910000": {
+          "name": "AA",
+          "description": "African American",
+          "_ac": "AA_AC"
+        },
+        "9910001": {
+          "name": "EA",
+          "description": "European American",
+          "_ac": "EA_AC"
+        }
+      }
+    },
     { "id": "esp_GRCh38",
       "species": "homo_sapiens",
       "assembly": "GRCh38",


### PR DESCRIPTION
Add ESP GRCh37 VCF location.
Background: We don't import ESP data into our variation database anymore. Get frequencies from VCF instead.