### PR TITLE
Clear up empty consequences

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -172,6 +172,8 @@ sub run {
       # if the variation has no effect on the transcript $tv will be undef
       if ($tv) {#} && ( scalar(@{ $tv->consequence_type }) > 0) ) {
 
+	next if scalar(@{ $tv->consequence_type }) > 0 && ($tv->distance_to_transcript > $max_distance);
+
         # store now or save to store later? Uncomment out the behaviour you want
         # save to store later uses more memory but means you don't have to sort human TV after the run
         

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -172,7 +172,7 @@ sub run {
       # if the variation has no effect on the transcript $tv will be undef
       if ($tv) {#} && ( scalar(@{ $tv->consequence_type }) > 0) ) {
 
-	next if scalar(@{ $tv->consequence_type }) > 0 && ($tv->distance_to_transcript > $max_distance);
+	next if (!scalar(@{ $tv->consequence_type }) && ($tv->distance_to_transcript > $max_distance));
 
         # store now or save to store later? Uncomment out the behaviour you want
         # save to store later uses more memory but means you don't have to sort human TV after the run

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -125,6 +125,9 @@ sub _return_3prime {
   ## If the associated database adaptor has switched HGVS shifting off, don't shift anything
   return if (defined($vf->adaptor) && defined($vf->adaptor->db)) && ($vf->adaptor->db->shift_hgvs_variants_3prime() == 0);
   
+  my $vf_allele_string = $vf->allele_string;
+  return if $vf_allele_string =~ /INS|DEL|HGMD|COSM|CNV/i;
+
   my $tr = $tv->transcript; 
   $self->initialise_unshifted_values;
   

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -347,6 +347,7 @@ sub _after_end {
 
 sub _upstream {
     my ($bvf, $feat, $dist) = @_;
+    $dist += get_max_shift_length($bvf);
     return $feat->strand == 1 ? 
         _before_start($bvf, $feat, $dist) : 
         _after_end($bvf, $feat, $dist);

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -741,7 +741,6 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         start   => $intron_start-3,
         end     => $intron_start-1,
         effects => [qw(coding_sequence_variant splice_donor_variant)],
-        no_shift => 0,
     }, 
     
 
@@ -780,7 +779,6 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $cds_end-1,
         end     => $cds_end+1,
-        no_shift => 0,
         effects => [qw( 3_prime_UTR_variant)],
     }, {
         comment => 'deletion overlapping STOP and 3\' UTR, stop retained, different codon',
@@ -1087,7 +1085,6 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         strand  => -1,
         start   => $cds_end - 1,
         end     => $cds_end - 2,
-        no_shift => 0,
         effects => [qw(protein_altering_variant)],
     }, {
         alleles => '-',
@@ -1175,7 +1172,6 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         strand  => -1,
         start   => $cds_start,
         end     => $cds_start + 2,
-        no_shift => 0,
         effects => [qw(3_prime_UTR_variant coding_sequence_variant)], 
         ## changed for shifting code. Different result is given here than in regular VEP because the transcript
         ## used for the tests is no longer in the gene set, and has the cds_end_NF attribute attached, preventing
@@ -1502,6 +1498,7 @@ my $bvf = $bvfo->base_variation_feature;
 $bvf->{allele_string} = 'COSMIC_MUTATION';
 my $start_retained_cosmic = Bio::EnsEMBL::Variation::Utils::VariationEffect::start_retained_variant($tva->[0], 0, $bvfo, $bvf);
 is($start_retained_cosmic, 0, 'start_retained retuns 0 with COSMIC');
+
 delete($tva->[0]->{_predicate_cache}->{stop_retained});
 my $stop_retained_cosmic = Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_retained($tva->[0], 0, $bvfo, $bvf);
 is($stop_retained_cosmic, 0, 'stop_retained returns 0 with COSMIC');


### PR DESCRIPTION
Shifting code has led to multiple occasions where consequence types within the transcript variation table can be empty. This tidies up many of these:

1) modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm - Prevents shifting for allele strings labelled INSERTION, DELETION, HGMD, COSMIC & CNV
2) Includes variants that start off outside of upstream and shifted into it as upstream
3) Doesn't print variants that return no consequences and are further than the given max_distance away from the transcript (i.e. variants that are shifted out of downstream)

This wont clear up all empty consequences. There are still issues with multi-allelic variants where the second alt allele is shifted into/out of protein_coding regions, but there's no quick fix for that one, so it's likely to be 101.