### PR TITLE
stop calculating mfv on the fly

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -729,10 +729,7 @@ sub get_all_MotifFeatureVariations {
   }
 
   if(!exists($self->{motif_feature_variations})) {
-    # We couldn't store motif_feature_variation for human in release/94
-    # compute them on the fly instead
-    my $species = lc $self->adaptor->db->species if (defined $self->adaptor->db);
-    if($self->dbID && ($species !~ /homo_sapiens|human/)) {
+    if($self->dbID) {
       if (my $db = $self->adaptor->db) {
         my $mfva = $db->get_MotifFeatureVariationAdaptor;
         my $mfvs = $mfva->fetch_all_by_VariationFeatures([$self]);


### PR DESCRIPTION
Removing the check if the species is human ensures that motif_feature_variants are no longer calculated on the fly. https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2860