### PR TITLE
revert after datacentre move

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -6,7 +6,7 @@
       "assembly": "GRCh37",
       "type": "remote",
       "strict_name_match": 1,
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/ALL.chr###CHR###.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/ALL.chr###CHR###.phase3_shapeit2_mvncall_integrated_v3plus_nounphased.rsID.genotypes.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -19,7 +19,7 @@
       "assembly": "GRCh38",
       "type": "remote",
       "strict_name_match": 1,
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/ALL.chr###CHR###_GRCh38.genotypes.20170504.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/ALL.chr###CHR###_GRCh38.genotypes.20170504.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -32,7 +32,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/genomes/gnomad.genomes.r2.1.sites.chr###CHR###_noVEP.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/genomes/gnomad.genomes.r2.1.sites.chr###CHR###_noVEP.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X"
@@ -84,7 +84,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.chr###CHR###_noVEP.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.chr###CHR###_noVEP.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -140,7 +140,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r3.0/genomes/gnomad.genomes.r3.0.sites.chr###CHR###_trimmed_info.vcf.bgz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r3.0/genomes/gnomad.genomes.r3.0.sites.chr###CHR###_trimmed_info.vcf.bgz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -201,7 +201,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -256,7 +256,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/TOPMED_GRCh37.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/TOPMED_GRCh37.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -280,7 +280,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/TOPMED_GRCh38_20180418.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/TOPMED_GRCh38_20180418.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -304,7 +304,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/UK10K_COHORT.20160215.sites.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/UK10K_COHORT.20160215.sites.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -333,7 +333,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/UK10K_COHORT.20160215.sites.GRCh38.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/UK10K_COHORT.20160215.sites.GRCh38.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -361,7 +361,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh37/variation_genotype/ESP6500SI-V2-SSA137.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/ESP6500SI-V2-SSA137.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -389,7 +389,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_genotype/ESP6500SI-V2-SSA137_GRCh38.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/ESP6500SI-V2-SSA137_GRCh38.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
@@ -418,7 +418,7 @@
       "species": "bos_taurus",
       "assembly": "ARS-UCD1.2",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/bos_taurus/ARS-UCD1.2/variation_genotype/IRBT_ARS-UCD1_2.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/bos_taurus/ARS-UCD1.2/variation_genotype/IRBT_ARS-UCD1_2.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "X"
@@ -430,7 +430,7 @@
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/IROA.population_sites.OARv3_1.20140307.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/IROA.population_sites.OARv3_1.20140307.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "X"
@@ -442,7 +442,7 @@
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/MOOA.population_sites.OARv3_1.20140328.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/MOOA.population_sites.OARv3_1.20140328.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "X"
@@ -454,7 +454,7 @@
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/###CHR###.filtered_intersect.vcf.gz",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/data_files/ovis_aries/Oar_v3.1/variation_genotype/###CHR###.filtered_intersect.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "X", "MT"
@@ -467,7 +467,7 @@
       "species": "capra_hircus",
       "assembly": "ARS1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/capra_hircus/ARS1/variation_genotype/NextGenCapraHircusRemappedARS1.vcf.gz",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/data_files/capra_hircus/ARS1/variation_genotype/NextGenCapraHircusRemappedARS1.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29"
@@ -480,7 +480,7 @@
       "species": "mus_musculus",
       "assembly": "GRCm38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/mus_musculus/GRCm38/variation_genotype/mgp.v3.snps.sorted.rsIDdbSNPv137.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/mus_musculus/GRCm38/variation_genotype/mgp.v3.snps.sorted.rsIDdbSNPv137.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "X", "Y"
@@ -492,7 +492,7 @@
       "species": "mus_musculus",
       "assembly": "GRCm38",
       "type": "remote",
-      "filename_template": "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/mus_musculus/GRCm38/variation_genotype/mgp.v3.indels.sorted.rsIDdbSNPv137.vcf.gz",
+      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/mus_musculus/GRCm38/variation_genotype/mgp.v3.indels.sorted.rsIDdbSNPv137.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
         "15", "16", "17", "18", "19", "X", "Y"
@@ -516,7 +516,7 @@
       "species": "equus_caballus",
       "assembly": "EquCab3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/equus_caballus/EquCab3.0/variation_genotype/PRJEB9799_EquCab3_0.vcf.gz",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/data_files/equus_caballus/EquCab3.0/variation_genotype/PRJEB9799_EquCab3_0.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21",
         "22", "23", "24", "25", "26", "27", "28", "29", "30", "31", "X", "MT"
@@ -553,7 +553,7 @@
       "species": "bos_taurus",
       "assembly": "ARS-UCD1.2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -561,7 +561,7 @@
       "species": "canis_familiaris",
       "assembly": "CanFam3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -569,7 +569,7 @@
       "species": "capra_hircus",
       "assembly": "ARS1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -577,7 +577,7 @@
       "species": "chlorocebus_sabaeus",
       "assembly": "ChlSab1.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -585,7 +585,7 @@
       "species": "danio_rerio",
       "assembly": "GRCz11",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
       "annotation_type": "gerp"
     },
     {
@@ -593,7 +593,7 @@
       "species": "equus_caballus",
       "assembly": "EquCab3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -601,8 +601,8 @@
       "species": "felis_catus",
       "assembly": "Felis_catus_9.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/100_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/100_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -610,7 +610,7 @@
       "species": "gallus_gallus",
       "assembly": "GRCg6a",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
       "annotation_type": "gerp"
     },
     {
@@ -618,7 +618,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh37",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/grch37/release-100/compara/conservation_scores/37_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh37.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/grch37/release-100/compara/conservation_scores/37_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh37.bw",
       "annotation_type": "gerp"
     },
     {
@@ -626,7 +626,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
       "annotation_type": "gerp"
     },
     {
@@ -634,7 +634,7 @@
       "species": "macaca_mulatta",
       "assembly": "Mmul_10",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
       "annotation_type": "gerp"
     },
     {
@@ -642,7 +642,7 @@
       "species": "meleagris_gallopavo",
       "assembly": "UMD2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -650,7 +650,7 @@
       "species": "mus_musculus",
       "assembly": "GRCm38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm38.bw",
       "annotation_type": "gerp"
     },
     {
@@ -658,7 +658,7 @@
       "species": "nomascus_leucogenys",
       "assembly": "Nleu_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -666,7 +666,7 @@
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -674,7 +674,7 @@
       "species": "pan_troglodytes",
       "assembly": "Pan_tro_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -682,7 +682,7 @@
       "species": "pongo_abelii",
       "assembly": "PPYG2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -690,7 +690,7 @@
       "species": "rattus_norvegicus",
       "assembly": "Rnor_6.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -698,7 +698,7 @@
       "species": "sus_scrofa",
       "assembly": "Sscrofa11.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/103_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -706,7 +706,7 @@
       "species": "taeniopygia_guttata",
       "assembly": "bTaeGut1_v1.p",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/81_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
       "annotation_type": "gerp"
     },
     {
@@ -714,7 +714,7 @@
       "species": "tetraodon_nigroviridis",
       "assembly": "TETRAODON8",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
       "annotation_type": "gerp"
     },
     {
@@ -722,7 +722,7 @@
       "species": "salmo_salar",
       "assembly": "ICSASG_v2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-100/compara/conservation_scores/82_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -730,7 +730,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ebi.ac.uk/ensemblorg/pub/data_files/homo_sapiens/GRCh38/variation_annotation/CADD_GRCh38_whole_genome_SNVs.tsv.gz",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_annotation/CADD_GRCh38_whole_genome_SNVs.tsv.gz",
       "annotation_type": "cadd"
     }
   ]


### PR DESCRIPTION
After DC migration we can revert to using  ftp.ensembl.org URL