### PR TITLE
Task101/ancestral allele pipeline updates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -77,6 +77,8 @@ sub default_options {
 
         reg_file                => $self->o('pipeline_dir') . '/ensembl.registry',
         batch_size => 1_000_000,
+        create_stats => 0,
+        none_dbSNP_only => 0,
         
         
         default_lsf_options => '-qproduction-rh74 -R"select[mem>2000] rusage[mem=2000]" -M2000',
@@ -114,6 +116,9 @@ sub pipeline_analyses {
         pipeline_dir     => $self->o('pipeline_dir'),
         compara_dir      => $self->o('compara_dir'),
         batch_size       => $self->o('batch_size'),
+        create_stats     => $self->o('create_stats'),
+        none_dbSNP_only  => $self->o('none_dbSNP_only'),
+
     );
    
     my @analyses;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
@@ -38,7 +38,9 @@ sub run {
     my $vdba = $self->get_species_adaptor('variation');
     my $dbc = $vdba->dbc;
     $self->update_ancestral_alleles($species_dir, $dbc);
-    $self->compare_previous_release_stats($species_dir, $dbc);
+    if ($self->param('create_stats')) {
+      $self->compare_previous_release_stats($species_dir, $dbc);
+    }
     $self->update_meta($dbc);
   }
 }


### PR DESCRIPTION
I added options to
--only update none dbSNP variants which is useful when we didn't have a new dbSNP import but only updated COSMIC etc
--not to compare stats between releases which is not helpful if ancestral alleles for dbSNP variants haven't changed