### PR TITLE
Dont check transcript attributes if ENST transcript

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -147,7 +147,7 @@ sub _return_3prime {
   return unless (defined($tv->cdna_start) && defined($tv->cdna_end) && defined($tv->cds_start) && defined($tv->cds_end)) 
   || (defined($tv->cdna_start_unshifted) && defined($tv->cdna_end_unshifted) && defined($tv->cds_start_unshifted) && defined($tv->cds_end_unshifted));
   
-  return if ($tr->stable_id =~ /ENST/);
+  return if ($tr->stable_id =~ /ENS/);
   my @attribs = @{$tr->get_all_Attributes()};
   
   ## Checks to see if the underlying sequence has been edited

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -111,7 +111,7 @@ sub _return_3prime {
   ## Will create a "shift_hash", containing info on precisely how the variant should be shifted when required
   my $self = shift;
   my $hgvs_only = shift;
- $DB::single = 1; 
+  
   ## Return if we have already calculated a shifting hash for this allele
   return if defined($self->{shift_hash}) || ($self->is_reference && !$hgvs_only);
   
@@ -146,7 +146,7 @@ sub _return_3prime {
 
   return unless (defined($tv->cdna_start) && defined($tv->cdna_end) && defined($tv->cds_start) && defined($tv->cds_end)) 
   || (defined($tv->cdna_start_unshifted) && defined($tv->cdna_end_unshifted) && defined($tv->cds_start_unshifted) && defined($tv->cds_end_unshifted));
- $DB::single = 1; 
+  
   return if ($tr->stable_id =~ /ENST/);
   my @attribs = @{$tr->get_all_Attributes()};
   

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -111,7 +111,7 @@ sub _return_3prime {
   ## Will create a "shift_hash", containing info on precisely how the variant should be shifted when required
   my $self = shift;
   my $hgvs_only = shift;
-  
+ $DB::single = 1; 
   ## Return if we have already calculated a shifting hash for this allele
   return if defined($self->{shift_hash}) || ($self->is_reference && !$hgvs_only);
   
@@ -146,7 +146,8 @@ sub _return_3prime {
 
   return unless (defined($tv->cdna_start) && defined($tv->cdna_end) && defined($tv->cds_start) && defined($tv->cds_end)) 
   || (defined($tv->cdna_start_unshifted) && defined($tv->cdna_end_unshifted) && defined($tv->cds_start_unshifted) && defined($tv->cds_end_unshifted));
-  
+ $DB::single = 1; 
+  return if ($tr->stable_id =~ /ENST/);
   my @attribs = @{$tr->get_all_Attributes()};
   
   ## Checks to see if the underlying sequence has been edited


### PR DESCRIPTION
Skips the attr tests if it's an ENST transcript. 

No test has been added as no output should have changed, should only provide a minor speedup