### PR TITLE
Only push VCF files-to-later-close onto list if successfully opened.

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -1252,9 +1252,11 @@ sub _get_vcf_by_chr {
         delete $self->{files}->{$close};
       }
     
-      $self->{files}->{$chr} = $self->_vcf_parser_obj($file);
-
-      push @{$self->{_open_files}}, $chr;
+      my $vcf_obj = $self->_vcf_parser_obj($file);
+      if(defined $vcf_obj) {
+        $self->{files}->{$chr} = $vcf_obj;
+        push @{$self->{_open_files}}, $chr;
+      }
     }
   }
   
@@ -1277,7 +1279,7 @@ sub _vcf_parser_obj {
 
   # open obect (remote indexes get downloaded)
   my $obj = undef;
-  eval { $obj = Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($file); }; warn $@ if $@;
+  eval { $obj = Bio::EnsEMBL::IO::Parser::VCF4Tabix->open($file); }; warn "$file: $@" if $@;
   # change back
   chdir($cwd);
 


### PR DESCRIPTION
When a VCF open failed, undef was being pushed onto the close list.
At some point in the future, possibly in some other request, when
there were too many files open the code would attempt to close undef
causing an error and crashing that (possibly unrelated) request.

The code which was ultimately erroring as a result of this is just above
the diff, in the same method, lines 1250-1252.

Secondarily, better warning identifying which file open failed
when reporting failure.

(The bug which caused this many erroneous opens in the first place
has been separately identified and fixed in the webteam SOPs).