### PR TITLE
Task101/gene protein hgvs only return match

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2215,15 +2215,13 @@ sub _parse_hgvs_protein_position{
   # check genomic codon is compatible with input HGVS
   my $check_prot   = $codon_table->translate($from_codon_ref);
 
-  my @from_codons;
+  my @from_codons = ();
   ## if the genomic sequence translates to match the input HGVS ref protein, use this
   if ($check_prot eq $from){
     push @from_codons, $from_codon_ref ;
   }
   else{
-    # rev-translate input ref sequence if the genome sequence does not match
     print "Sequence translated from reference ($from_codon_ref -> $check_prot) does not match input sequence ($from)\n" if $DEBUG ==1;
-    @from_codons   = $codon_table->revtranslate($from);
   }
 
   # rev-translate alt sequence

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -1886,7 +1886,8 @@ sub fetch_by_hgvs_notation {
     if(!defined($transcript)) {
       # Seeing transcripts erroneously submitted with p. changes
       if($reference =~ /ENST/){
-         push @transcripts, $transcript_adaptor->fetch_by_stable_id($reference);
+         my $given_transcript = $transcript_adaptor->fetch_by_stable_id($reference);
+         push @transcripts, $given_transcript if defined $given_transcript;
       }
       # Fetch as UniProt ID or gene
       else {
@@ -2191,7 +2192,6 @@ sub _pick_likely_transcript {
 sub _parse_hgvs_protein_position{
 
   my ($description, $reference, $transcript ) = @_;
-
   ## only supporting the parsing of hgvs substitutions [eg. Met213Ile]
   my ($from, $pos, $to) = $description =~ /^(\w+?)(\d+)(\w+?|\*)$/; 
 
@@ -2221,7 +2221,7 @@ sub _parse_hgvs_protein_position{
     push @from_codons, $from_codon_ref ;
   }
   else{
-    print "Sequence translated from reference ($from_codon_ref -> $check_prot) does not match input sequence ($from)\n" if $DEBUG ==1;
+    throw("Sequence translated from reference ($from_codon_ref -> $check_prot) does not match input sequence ($from)");
   }
 
   # rev-translate alt sequence

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -506,7 +506,8 @@ ok($vf->allele_string eq 'N/G', "LRG - Valid insertion 'LRG_293:69534:N:G'");
 
 ## check ref matching
 my $bad_hgvs = 'ENSP00000434898.1:p.Cys6Ser';
-throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Could not determine nucleotide change from peptide change C -> S/, 'Throw if HGVS does not match reference';
+throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Sequence translated from reference \(TCT -> S\) does not match input sequence \(C\)/, 'Throw if HGVS does not match reference';
+
 my $ok_hgvs = 'ENSP00000293261.2:p.Ser455del';
 $vf = $vfa->fetch_by_hgvs_notation($ok_hgvs);
 ok($vf->allele_string eq 'AGC/-', "HGVSp matches reference");

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -506,7 +506,7 @@ ok($vf->allele_string eq 'N/G', "LRG - Valid insertion 'LRG_293:69534:N:G'");
 
 ## check ref matching
 my $bad_hgvs = 'ENSP00000434898.1:p.Cys6Ser';
-throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Could not uniquely determine nucleotide change from ENSP00000434898.1:p.Cys6Ser/, 'Throw if HGVS does not match reference';
+throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Could not determine nucleotide change from peptide change C -> S/, 'Throw if HGVS does not match reference';
 my $ok_hgvs = 'ENSP00000293261.2:p.Ser455del';
 $vf = $vfa->fetch_by_hgvs_notation($ok_hgvs);
 ok($vf->allele_string eq 'AGC/-', "HGVSp matches reference");

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -508,8 +508,9 @@ ok($vf->allele_string eq 'N/G', "LRG - Valid insertion 'LRG_293:69534:N:G'");
 my $bad_hgvs = 'ENSP00000434898.1:p.Cys6Ser';
 throws_ok {$vfa->fetch_by_hgvs_notation($bad_hgvs); }qr/Sequence translated from reference \(TCT -> S\) does not match input sequence \(C\)/, 'Throw if HGVS does not match reference';
 
+throws_ok {$vfa->fetch_by_hgvs_notation('ENST00000470094.1:c.59A>G'); }qr/Reference allele extracted from ENST00000470094:32954035-32954035 \(G\) does not match reference allele given by HGVS notation ENST00000470094\.1:c\.59A>G \(A\)/, 'Throws if reference allele does not match';
+
 my $ok_hgvs = 'ENSP00000293261.2:p.Ser455del';
 $vf = $vfa->fetch_by_hgvs_notation($ok_hgvs);
 ok($vf->allele_string eq 'AGC/-', "HGVSp matches reference");
 done_testing();
-


### PR DESCRIPTION
when trying to get results for ENSP00000327895:p.K108T (or ENST00000330287:p.Lys108Thr, F8:p.Lys108Thr):
--get nucleotide triplet from transcript at protein position 108
--this will return a different amino acid from K
--at the moment we would rev-translate from given ref amino acid and try to calculate the mutation path to amino acid T
--this leads to wrong results: NC_000023.10:g.154088879T>G
--I suggest we don't rev-translate in this case.