### PR TITLE
Update clinvar import

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -66,7 +66,7 @@ Bio::EnsEMBL::Variation::DBSQL::VariationFeatureAdaptor
     print $vf->seq_region_name(), $vf->seq_region_start(), '-',
           $vf->seq_region_end(), "\n";
   }
-  
+
 =head1 DESCRIPTION
 
 This adaptor provides database connectivity for VariationFeature objects.
@@ -454,6 +454,7 @@ sub fetch_all_somatic_by_Slice {
 }
 
 =head2 fetch_all_somatic_by_Slice_Source
+
   Arg [1]    : Bio::EnsEMBL::Slice $slice the slice from which to obtain features
   Arg [2]    : Bio::EnsEMBL::Variation::Source $source only return somatic mutations for the given source
   Example    : my $vfs = $vfa->fetch_all_somatic_by_Slice_Source($slice, $source);
@@ -462,6 +463,7 @@ sub fetch_all_somatic_by_Slice {
   Exceptions : throw on incorrect argument
   Caller     : Bio::EnsEMBL::Slice
   Status     : Stable
+
 =cut
 
 sub fetch_all_somatic_by_Slice_Source {
@@ -487,6 +489,7 @@ sub fetch_all_somatic_by_Slice_Source {
 
 
 =head2 fetch_all_by_Slice_Source
+
   Arg [1]    : Bio::EnsEMBL::Slice $slice the slice from which to obtain features
   Arg [2]    : Bio::EnsEMBL::Variation::Source $source only return variation features for the given source
   Example    : my $vfs = $vfa->fetch_all_by_Slice_Source($slice, $source);
@@ -495,6 +498,7 @@ sub fetch_all_somatic_by_Slice_Source {
   Exceptions : throw on incorrect argument
   Caller     : Bio::EnsEMBL::Slice
   Status     : Stable
+
 =cut
 
 sub fetch_all_by_Slice_Source {
@@ -2395,7 +2399,7 @@ sub fetch_by_dbID {
 =head2 fetch_all_by_location_identifier
 
   Arg [1]    : string $location_identifier
-  Example    : $vf = $adaptor->fetch_by_dbID('1:230710048:A_G');
+  Example    : $vf = $adaptor->fetch_all_by_location_identifier('1:230710048:A_G');
   Description: Fetches VariationFeatures by location identifier.
                Primarily used to fetch variants from VCFCollections
                as optional 4th component is source_name or

--- a/scripts/import/clinvar_post_process.pl
+++ b/scripts/import/clinvar_post_process.pl
@@ -231,7 +231,7 @@ sub update_variation{
 	$assoc{$l->[0]}{C} = 1  if $l->[1] =~ /pathogenic|drug-response|histocompatibility/i && $l->[1] !~ /non/;
 
       $l->[1]  =~ s/\//\,/ ; # convert 'pathogenic/likely pathogenic' to 'pathogenic,likely pathogenic'
-      $l->[1]  =~ s/\,\s+/\,/ ; # convert 'likely benign, other' to 'likely benign, other'
+      $l->[1]  =~ s/\,\s+/\,/ ; # convert 'likely benign, other' to 'likely benign,other'
       #replace 'conflicting interpretations of pathogenicity' with 'uncertain significance'
         #for the purpose of variation, variation_feature clin_sig entry
       $l->[1]  =~ s/conflicting interpretations of pathogenicity/uncertain significance/g;

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -1271,7 +1271,7 @@ sub usage{
     die "\n\tUsage: import_clinvar_xml -data_file [ClinVar xml] -registry [registry file] -assembly [GRCh37/GRCh38]
 
 \t\toptions: -structvar  (only import ClinVar statuses for structural variations)
-\t\toptions: -clean      ( delete old phenotype_feature, phenotype_feature_attrib, variation_set_variation (OMIM set), clinical_significance and synonym data)
+\t\toptions: -clean      ( delete old phenotype_feature, phenotype_feature_attrib, variation(ClinVar), variation_feture (ClinVar), variation_set_variation (OMIM set), clinical_significance and synonym data)
 \n\n";
 
 }

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -758,7 +758,8 @@ sub import_phenotype_feature{
   $record->{disease} = $default_pheno if $record->{disease} eq "not specified";
 
   ## check for new clin_sig
-  if ( ! defined $known_clinsig{$record->{Desc}} ) {
+  my $found = check_known_clinsig($record->{Desc});
+  if ( ! $found ){
     warn "clin_sig not known: >". $record->{Desc} ."< feature: ". $feature_object->name ."\n";
   }
 
@@ -1291,6 +1292,25 @@ sub clean_old_data{
 
 }
 
+sub check_known_clinsig {
+  my $current_clinsig = shift;
+
+  my $tmpClinsig = $current_clinsig;
+  $tmpClinsig  =~ s/\//\,/ ; # convert 'pathogenic/likely pathogenic' to 'pathogenic,likely pathogenic'
+  $tmpClinsig  =~ s/\,\s+/\,/ ; # convert 'likely benign, other' to 'likely benign,other'
+  #replace 'conflicting interpretations of pathogenicity' with 'uncertain significance'
+    #for the purpose of variation, variation_feature clin_sig entry
+  $tmpClinsig  =~ s/conflicting interpretations of pathogenicity/uncertain significance/g;
+  #similar replace of 'association not found' to 'other'
+  $tmpClinsig  =~ s/association not found/other/g;
+  my @tmpClinsigs = split(",", $tmpClinsig);
+  my $found = 1;
+  foreach my $clinsig (@tmpClinsigs) {
+     $found = 0 if ( ! defined $known_clinsig{ $clinsig } ) ;
+  }
+
+  return $found;
+}
 
 sub usage{
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -82,6 +82,7 @@ my $dba = $reg->get_DBAdaptor('homo_sapiens','variation');
 ## only merging records by name, so include fails
 $dba->include_failed_variations(1);
 my $dbh = $dba->dbc;
+$dbh->reconnect_when_lost(1);
 
 my $variation_adaptor     = $dba->get_VariationAdaptor('human', 'variation', );
 my $var_feat_adaptor      = $dba->get_VariationFeatureAdaptor('human', 'variation', );
@@ -92,6 +93,7 @@ my $pheno_feat_adaptor    = $reg->get_adaptor('homo_sapiens', 'variation', 'phen
 my $phenotype_adaptor     = $reg->get_adaptor('homo_sapiens', 'variation', 'phenotype');
 
 my $slice_adaptor         = $reg->get_adaptor('homo_sapiens', 'core', 'slice');
+$slice_adaptor->dbc->reconnect_when_lost(1);
 
 ## fetch ClinVar source object
 my $omimstr= 'OMIM';
@@ -684,7 +686,7 @@ sub import{
         @{$record->{feature_info}}{qw/hgvs_g Chr start end gene/} = @{$record->{feature_info}->{$rsID}}{qw/hgvs_g Chr start end gene/};
       }
 
-      ($feature_object,  $feat, $alt_allele) = get_variant($record, $rs);
+      ($feature_object, $feat, $alt_allele) = get_variant($record, $rs);
       next unless defined $feature_object;
 
       add_clinvar_data($feature_object, $feat, $alt_allele, $record);
@@ -989,7 +991,7 @@ sub get_variant{
     my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $dbSNP, $record->{inheritance_type});
     return ($new_var_ob,  $var_feat, $alt_allele);
 
-  } else {
+  } elsif (defined $ref_allele && defined $alt_allele ) {
     # try to match existing rsIDs in variation DB on location and allele string
     my $location_str = $record->{feature_info}->{Chr} . ":".
                     $record->{feature_info}->{start} . ":".
@@ -1000,7 +1002,11 @@ sub get_variant{
       return ($var_feats->[0]->variation(), $var_feats, $alt_allele);
     } else {
       warn "no variation feature found for $location_str\n" if $DEBUG ==1;
+      return undef;
     }
+  } else {
+    warn "No ref or alt allele found \n" if $DEBUG == 1;
+    return undef;
   }
 
 }

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -241,7 +241,7 @@ sub process_clinvar_set {
       if( exists $record{feature_info}->{dbSNP} && $record{feature_info}->{dbSNP}->[0] =~/\d+/ ){
          warn "Importing Var :  $record{feature_info}->{dbSNP}->[0] ($record{Acc})\n" if $DEBUG == 1;
          import( \%record);
-      } elsif (exists $record{feature_info}{Chr}) {
+      } elsif (exists $record{feature_info}{Chr} && exists $record{feature_info}{start}) {
         warn "Importing Var based on location+allele_ref\n";
         import( \%record, 1);
       }
@@ -742,6 +742,9 @@ sub import_phenotype_feature{
   my $feat           = shift;
   my $alt_allele     = shift;
 
+  # deal with risk alleles longer than varchar 255
+  $alt_allele = '' if defined $alt_allele && length($alt_allele) > 255;
+
   ## deal with non-specified phenos
   $record->{disease} = $default_pheno unless $record->{disease} =~/\w+/;
   $record->{disease} = $default_pheno if $record->{disease} eq "not provided";
@@ -991,7 +994,8 @@ sub get_variant{
     my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $dbSNP, $record->{inheritance_type});
     return ($new_var_ob,  $var_feat, $alt_allele);
 
-  } elsif (defined $ref_allele && defined $alt_allele ) {
+  } elsif (defined $ref_allele && defined $alt_allele &&
+      defined $record->{feature_info}->{Chr} && defined $record->{feature_info}->{start}) {
     # try to match existing rsIDs in variation DB on location and allele string
     my $location_str = $record->{feature_info}->{Chr} . ":".
                     $record->{feature_info}->{start} . ":".
@@ -1005,7 +1009,7 @@ sub get_variant{
       return undef;
     }
   } else {
-    warn "No ref or alt allele found \n" if $DEBUG == 1;
+    warn "No ref or alt allele or location found\n" if $DEBUG == 1;
     return undef;
   }
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -1241,7 +1241,7 @@ sub clean_old_data{
 
   my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name in ('ClinVar', 'OMIM') ) ]);
 
-  my $var_updt_sth       = $dba->dbc->do(qq[ update variation set clinical_significance=\\N ]);
+  my $var_updt_sth       = $dba->dbc->do(qq[ update variation set clinical_significance=NULL ]);
 
 
 }

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -701,8 +701,7 @@ sub import{
     ($feature_object, $feat, $alt_allele) = get_variant($record, undef);
     if (! defined $feature_object){
       warn "no variation found for $record->{Acc}, $record->{clinvar_variant_id}\n";
-      no warnings 'exiting';
-      next;
+      return undef;
     }
 
     add_clinvar_data($feature_object, $feat, $alt_allele, $record);

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -1239,7 +1239,7 @@ sub clean_old_data{
 
   my $phenfeat_del_sth   = $dba->dbc->do(qq[ delete from phenotype_feature where source_id in (select source_id from source where name ='ClinVar') ]);
 
-  my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name ='ClinVar') ]);
+  my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name in ('ClinVar', 'OMIM') ) ]);
 
   my $var_updt_sth       = $dba->dbc->do(qq[ update variation set clinical_significance=\\N ]);
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -130,6 +130,10 @@ my %non_specified_pheno = ("None"=>1,
                      "?" => 1, "." => 1);
 my $haplotype_type = "Haplotype";
 
+## accepted clinsig values:
+my @def_clinsig = ('uncertain significance','not provided','benign','likely benign','likely pathogenic','pathogenic','drug response','histocompatibility','other','confers sensitivity','risk factor','association','protective','affects');
+my %known_clinsig = map { $_ => 1  } @def_clinsig ;
+
 ## handle incomplete runs - takes list of ClinVar RC accessions 
 my %done;
 if (defined $done_file){
@@ -752,6 +756,11 @@ sub import_phenotype_feature{
   $record->{disease} = $default_pheno unless $record->{disease} =~/\w+/;
   $record->{disease} = $default_pheno if $record->{disease} eq "not provided";
   $record->{disease} = $default_pheno if $record->{disease} eq "not specified";
+
+  ## check for new clin_sig
+  if ( ! defined $known_clinsig{$record->{Desc}} ) {
+    warn "clin_sig not known: >". $record->{Desc} ."< feature: ". $feature_object->name ."\n";
+  }
 
   # Remove special characters from the phenotype description and submitter name
   $record->{disease} = replace_char( $record->{disease});

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -1239,10 +1239,19 @@ sub clean_old_data{
 
   my $phenfeat_del_sth   = $dba->dbc->do(qq[ delete from phenotype_feature where source_id in (select source_id from source where name ='ClinVar') ]);
 
-  my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name in ('ClinVar', 'OMIM') ) ]);
+  # remove previously inserted variation from ClinVar + associated records
+  my @tables = qw/variation_synonym failed_variation variation_set_variation/;
+  for my $table (@tables){
+    my $var_recs_del_sth    = $dba->dbc->do(qq[ delete from $table where variation_id in
+                                                    (select variation_id from variation v, source s
+                                                     where v.source_id = s.source_id and s.name ='ClinVar')
+                                                    ]);
+  }
+  my $var_feat_del_sth    = $dba->dbc->do(qq[ delete from variation_feature where source_id in (select source_id from source where name ='ClinVar'); ]);
+  my $var_del_sth        = $dba->dbc->do(qq[ delete from variation where source_id in (select source_id from source where name ='ClinVar'); ]);
+  my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name ='OMIM' ) ]);
 
   my $var_updt_sth       = $dba->dbc->do(qq[ update variation set clinical_significance=NULL ]);
-
 
 }
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -239,6 +239,9 @@ sub process_clinvar_set {
       if( exists $record{feature_info}->{dbSNP} && $record{feature_info}->{dbSNP}->[0] =~/\d+/ ){
          warn "Importing Var :  $record{feature_info}->{dbSNP}->[0] ($record{Acc})\n" if $DEBUG == 1;
          import( \%record);
+      } elsif (exists $record{feature_info}{Chr}) {
+        warn "Importing Var based on location+allele_ref\n";
+        import( \%record, 1);
       }
       else{
     	my $message =  "Not importing var: ";
@@ -387,6 +390,7 @@ sub get_feature{
       foreach my $xref( @{$xref_set} ){
         next unless ref($xref) eq  'HASH';
         if (defined $xref->{Type}) {
+          #save eg: measure_id(15437) -> xref_db(OMIM) -> type(Allelic variant) -> id(612779.003)
           push @{$feature{measureXrefs}{$measure->{ID}}{$xref->{DB}}{$xref->{Type}} }, $xref->{ID} ;
         } else {
           $xref->{DB} eq 'dbVar' ?
@@ -394,17 +398,24 @@ sub get_feature{
           push @{$feature{measureXrefs}{$measure->{ID}}{$xref->{DB}} }, $xref->{ID} ;
         }
       }
+      #TODO: if + haplo push refactor here for non dbSNP ids
       if (defined $feature{measureXrefs}{$measure->{ID}}{$omimstr} &&
-      defined $feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'} &&
-      defined $feature{measureXrefs}{$measure->{ID}}{'dbSNP'}){
-        my %tmpAllelicID;
-        foreach my $allele (@{$feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'}}){
-          foreach my $tmpRS (@{$feature{measureXrefs}{$measure->{ID}}{'dbSNP'}{'rs'}}){
-            push @{$tmpAllelicID{$allele}}, $tmpRS;
+          defined $feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'}) {
+
+          if (defined $feature{measureXrefs}{$measure->{ID}}{'dbSNP'}) {
+            my %tmpAllelicID;
+            foreach my $allele (@{$feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'}}){
+              foreach my $tmpRS (@{$feature{measureXrefs}{$measure->{ID}}{'dbSNP'}{'rs'}}){
+                push @{$tmpAllelicID{$allele}}, $tmpRS;
+              }
+            }
+            # for haplotype entries: allelic variant ids are not real synonyms & this will result in them not being saved
+            $feature{measureXrefs}{$measure->{ID}}{OmimAllele2dbSNP} = \%tmpAllelicID unless $type eq $haplotype_type;
+
+          } else {
+            warn "Multiple OMIM Allelic variant xrefs for $accession! \n" if scalar @{$feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'}} > 1;
+            $feature{$omimstr} = $feature{measureXrefs}{$measure->{ID}}{$omimstr}{'Allelic variant'}->[0];
           }
-        }
-        # for haplotype entries: allelic variant ids are not real synonyms & this will result in them not being saved
-        $feature{measureXrefs}{$measure->{ID}}{OmimAllele2dbSNP} = \%tmpAllelicID unless $type eq $haplotype_type;
       }
       push @{$feature{'haplo'}{'rs'}}, @{$feature{measureXrefs}{$measure->{ID}}{'dbSNP'}{'rs'}} if $type eq $haplotype_type && defined $feature{measureXrefs}{$measure->{ID}}{'dbSNP'};
    }
@@ -659,6 +670,7 @@ sub to_array{
 sub import{
 
   my $record = shift;
+  my $try_match = shift // 0;
 
   my $feature_object;
   my $alt_allele; ## disease associated allele from HGVS
@@ -675,30 +687,49 @@ sub import{
       ($feature_object,  $feat, $alt_allele) = get_variant($record, $rs);
       next unless defined $feature_object;
 
-      ## add phenotype evidence attrib to variation (either existing one or a newly inserted one)
-      $feature_object->add_evidence_value($phenotype_evidence);
-      $variation_adaptor->update($feature_object);
+      add_clinvar_data($feature_object, $feat, $alt_allele, $record);
 
-      ## add synonym
-      add_synonyms($feature_object, $record->{clinvar_variant_id}, $source) if defined $feature_object;
-      add_synonyms($feature_object, $record->{Acc}, $source) if defined $feature_object;
-      add_synonyms($feature_object, $record->{feature_info}{$omimstr}, $omim_source) if defined $feature_object && defined $record->{feature_info}{$omimstr};
-
-      ## add phenotype_feature & attrib (there may not be an alt_allele)
-      import_phenotype_feature($record, $feature_object, 'Variation', $feat, $alt_allele);
     }
   }
-  elsif(defined  $record->{feature_info}->{dbVar}){
+  elsif(!defined $structvar && $try_match ){
+    ($feature_object, $feat, $alt_allele) = get_variant($record, undef);
+    next unless defined $feature_object;
+
+    add_clinvar_data($feature_object, $feat, $alt_allele, $record);
+  }
+  elsif(defined $record->{feature_info}->{dbVar} && defined $structvar){
     ($feature_object, $feat) = get_structural_variant($record);
 
     if ( defined $feature_object){
       ## add phenotype_feature & attrib
       import_phenotype_feature($record, $feature_object, 'StructuralVariation', $feat, $alt_allele);
     }
+  } else{
+    warn "Can't import ". $record->{Acc} ." as no dbSNP or location or SV\n";
   }
-  else{
-      warn "Can't import ". $record->{Acc} ." as no xref\n";
-  }
+
+}
+
+sub add_clinvar_data{
+  my $variation_object = shift;
+  my $feat             = shift;
+  my $alt_allele       = shift;
+  my $record           = shift;
+
+  next unless defined $variation_object;
+
+  ## add phenotype evidence attrib to variation (either existing one or a newly inserted one)
+  $variation_object->add_evidence_value($phenotype_evidence);
+  $variation_adaptor->update($variation_object);
+
+  ## add synonym
+  add_synonyms($variation_object, $record->{clinvar_variant_id}, $source);
+  add_synonyms($variation_object, $record->{Acc}, $source);
+  add_synonyms($variation_object, $record->{feature_info}{$omimstr}, $omim_source) if defined $record->{feature_info}{$omimstr};
+
+  ## add phenotype_feature & attrib (there may not be an alt_allele)
+  import_phenotype_feature($record, $variation_object, 'Variation', $feat, $alt_allele);
+
 }
 
 sub import_phenotype_feature{
@@ -910,10 +941,9 @@ sub get_variant{
   my $record = shift;
   my $rs_id  = shift;
 
-  my $dbSNP  = "rs" . $rs_id;
+  my $dbSNP = defined $rs_id ? "rs" . $rs_id : "rs_NA";
 
   $record->{feature_info}->{hgvs_g} |= "";
-  print "Seeking $dbSNP ". $record->{feature_info}->{hgvs_g} . "\n" if $DEBUG ==1;
   ## need alleles to input for standard variation & for risk allele attribute
   ## take from HGVS string; should there be multiple rsIDs for the same feature_info, they all will use the same one hgvs_g string
   if ($record->{feature_info}->{hgvs_g} !~ /.*:.*/) {
@@ -921,44 +951,58 @@ sub get_variant{
       $record->{feature_info}->{hgvs_g} = $record->{feature_info}->{Chr} . ":" . $record->{feature_info}->{hgvs_g} :
       ($record->{feature_info}->{hgvs_g} = "unknown" . ":" . $record->{feature_info}->{hgvs_g} );
   }
+  print "Seeking $dbSNP ". $record->{feature_info}->{hgvs_g} . "\n" if $DEBUG ==1;
 
   my ($ref_allele, $alt_allele);
   eval{
     ($ref_allele, $alt_allele) = get_hgvs_alleles( $record->{feature_info}->{hgvs_g} ) unless $record->{feature_info}->{hgvs_g} eq "unknown:" ;
   };
   ## not printing bulky error message
-  warn "Problem finding allele for $dbSNP\n" unless $@ eq '';
+  warn "Problem finding allele for hgvs ". $record->{feature_info}->{hgvs_g} ." \n" unless $@ eq '';
 
   unless (defined $ref_allele && defined  $alt_allele && $ref_allele ne $alt_allele){
     print "Ref + Alt alleles not available for $dbSNP (" . $record->{feature_info}->{hgvs_g} . ") \n";
   }
 
+  if (defined $rs_id) {
+    ## look for existing variation object to return
+    my $var_ob = $variation_adaptor->fetch_by_name($dbSNP);
 
-  ## look for existing variation object to return
-  my $var_ob = $variation_adaptor->fetch_by_name($dbSNP);
+    if (defined $var_ob){
+      my @features = $var_ob->get_all_VariationFeatures();
+      return ($var_ob, @features , $alt_allele);
+    }
+    print "No record found for $dbSNP\n" if $DEBUG ==1;
 
-  if (defined $var_ob){
-    my @features = $var_ob->get_all_VariationFeatures();
-    return ($var_ob, @features , $alt_allele);
+    ## ClinVar can be ahead of dbSNP - is there enough data to create a variation record?
+
+    if( !defined $record->{feature_info}->{hgvs_g} || !defined $record->{feature_info}->{Chr} ||
+        !defined $ref_allele || !defined $alt_allele ||
+        (defined $ref_allele && $ref_allele eq '') ||
+        (defined $alt_allele && $alt_allele eq '') ||
+        (defined $ref_allele && defined $alt_allele && $ref_allele eq $alt_allele) ) {
+      warn "Not entering new refSNP: $rs_id as no parsable HGVS available for alleles ($record->{feature_info}->{hgvs_g})\n";
+      return undef;
+    }
+
+    ## enter new records
+    my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $dbSNP, $record->{inheritance_type});
+    return ($new_var_ob,  $var_feat, $alt_allele);
+
+  } else {
+    # try to match existing rsIDs in variation DB on location and allele string
+    my $location_str = $record->{feature_info}->{Chr} . ":".
+                    $record->{feature_info}->{start} . ":".
+                    $ref_allele."_".$alt_allele ;
+    my $var_feats = $var_feat_adaptor->fetch_all_by_location_identifier($location_str);
+
+    if ( scalar @$var_feats > 0 ){ #TODO: check that variation will always have same name for multiple variation features!
+      return ($var_feats->[0]->variation(), $var_feats, $alt_allele);
+    } else {
+      warn "no variation feature found for $location_str\n" if $DEBUG ==1;
+    }
   }
-  print "No record found for $dbSNP\n" if $DEBUG ==1;
 
-
-
-  ## ClinVar can be ahead of dbSNP - is there enough data to create a variation record?
-
-  if( !defined $record->{feature_info}->{hgvs_g} || !defined $record->{feature_info}->{Chr} ||
-      !defined $ref_allele || !defined $alt_allele ||
-      (defined $ref_allele && $ref_allele eq '') ||
-      (defined $alt_allele && $alt_allele eq '') ||
-      (defined $ref_allele && defined $alt_allele && $ref_allele eq $alt_allele) ) {
-    warn "Not entering new refSNP: $rs_id as no parsable HGVS available for alleles ($record->{feature_info}->{hgvs_g})\n";
-    return undef;
-  }
-
-  ## enter new records
-  my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $dbSNP, $record->{inheritance_type});
-  return ($new_var_ob,  $var_feat, $alt_allele);
 }
 
 =head2 enter_var

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -994,7 +994,7 @@ sub get_variant{
     }
 
     ## enter new records
-    my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $dbSNP, $record->{inheritance_type});
+    my ($new_var_ob, $var_feat) = enter_var($record,  $ref_allele, $alt_allele, $rs_id, $record->{inheritance_type});
     return ($new_var_ob,  $var_feat, $alt_allele);
 
   } elsif (defined $ref_allele && defined $alt_allele &&
@@ -1036,8 +1036,15 @@ sub enter_var{
   my $data       = shift;
   my $ref_allele = shift;
   my $alt_allele = shift;
-  my $dbSNP      = shift;
+  my $rs_id      = shift;
   my $inherit    = shift;
+
+  unless (defined $rs_id) {
+    warn "ERROR: no rs_id for ". $data->{feature_info}->{hgvs_g} ."\n";
+    return undef;
+  }
+
+  my $dbSNP = 'rs'.$rs_id;
 
    unless (defined $ref_allele && defined $alt_allele){
      warn "ERROR: missing alleles for $data->{feature_info}->{hgvs_g} / $dbSNP\n";

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -246,7 +246,7 @@ sub process_clinvar_set {
          warn "Importing Var :  $record{feature_info}->{dbSNP}->[0] ($record{Acc})\n" if $DEBUG == 1;
          import( \%record);
       } elsif (exists $record{feature_info}{Chr} && exists $record{feature_info}{start}) {
-        warn "Importing Var based on location+allele_ref\n";
+        warn "Importing Var based on location+allele_ref lookup of existing match in DB\n";
         import( \%record, 1);
       }
       else{

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -699,7 +699,11 @@ sub import{
   }
   elsif(!defined $structvar && $try_match ){
     ($feature_object, $feat, $alt_allele) = get_variant($record, undef);
-    next unless defined $feature_object;
+    if (! defined $feature_object){
+      warn "no variation found for $record->{Acc}, $record->{clinvar_variant_id}\n";
+      no warnings 'exiting';
+      next;
+    }
 
     add_clinvar_data($feature_object, $feat, $alt_allele, $record);
   }

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -1271,6 +1271,7 @@ sub clean_old_data{
   my $synonym_del_sth    = $dba->dbc->do(qq[ delete from variation_synonym where source_id in (select source_id from source where name ='OMIM' ) ]);
 
   my $var_updt_sth       = $dba->dbc->do(qq[ update variation set clinical_significance=NULL ]);
+  my $var_feat_updt_sth  = $dba->dbc->do(qq[ update variation_feature set clinical_significance=NULL ]);
 
 }
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -743,7 +743,10 @@ sub import_phenotype_feature{
   my $alt_allele     = shift;
 
   # deal with risk alleles longer than varchar 255
-  $alt_allele = '' if defined $alt_allele && length($alt_allele) > 255;
+  if ( defined $alt_allele && length($alt_allele) > 255 ) {
+    warn "alt_allele longer than 255 and will be removed from risk_allele: $alt_allele\n";
+    $alt_allele = '';
+  }
 
   ## deal with non-specified phenos
   $record->{disease} = $default_pheno unless $record->{disease} =~/\w+/;
@@ -1002,8 +1005,14 @@ sub get_variant{
                     $ref_allele."_".$alt_allele ;
     my $var_feats = $var_feat_adaptor->fetch_all_by_location_identifier($location_str);
 
-    if ( scalar @$var_feats > 0 ){ #TODO: check that variation will always have same name for multiple variation features!
+    if ( scalar @$var_feats == 1 ){
       return ($var_feats->[0]->variation(), $var_feats, $alt_allele);
+    } elsif (scalar @$var_feats > 1) {
+      # check that variation will always have same name for multiple variation features!
+      warn "multiple variation_features found for $location_str : \n";
+      foreach my $vf (@$var_feats){
+        warn "vf:". $vf->name . " allele string: ". $vf->allele_string . "\n";
+      }
     } else {
       warn "no variation feature found for $location_str\n" if $DEBUG ==1;
       return undef;
@@ -1271,7 +1280,7 @@ sub usage{
     die "\n\tUsage: import_clinvar_xml -data_file [ClinVar xml] -registry [registry file] -assembly [GRCh37/GRCh38]
 
 \t\toptions: -structvar  (only import ClinVar statuses for structural variations)
-\t\toptions: -clean      ( delete old phenotype_feature, phenotype_feature_attrib, variation(ClinVar), variation_feture (ClinVar), variation_set_variation (OMIM set), clinical_significance and synonym data)
+\t\toptions: -clean      ( delete old phenotype_feature, phenotype_feature_attrib, variation(ClinVar), variation_feature (ClinVar), variation_set_variation (sets: ClinVar, OMIM, All phenotypes set ), clinical_significance and synonym data)
 \n\n";
 
 }


### PR DESCRIPTION
- add functionality to match based on location and alleles existing rsIDs in the DB for RCVs without rsIDs
- update clean option to remove previously imported variation/variation_feature from ClinVar
- add try/catch for update sql warnings
- don't store risk_alleles with length > 255: they were being truncated
- handle clinsigs not present in the variation clinsig defined set