### PR TITLE
update hive dbname

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -93,7 +93,7 @@ sub default_options {
             -port   => $self->o('hive_db_port'),
             -user   => $self->o('hive_db_user'),
             -pass   => $self->o('hive_db_password'),            
-            -dbname => $ENV{'USER'}.'_'.$self->o('pipeline_name'),
+            -dbname => $ENV{'USER'} . '_ehive_' . $self->o('pipeline_name') . '_' . $self->o('ensembl_release'),
             -driver => 'mysql',
             -reconnect_when_lost => 1
         },


### PR DESCRIPTION
I decided not add species and assembly because for all non human species for which we can compute ancestral alleles we can run the pipeline together. We can add more information into the pipeline_name parameter if needed.