### PR TITLE
HGVS insertion with incomplete description is not supported

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -101,12 +101,11 @@ use Scalar::Util qw(looks_like_number);
 
 our @ISA = ('Bio::EnsEMBL::Variation::DBSQL::BaseAdaptor', 'Bio::EnsEMBL::DBSQL::BaseFeatureAdaptor');
 our $MAX_VARIATION_SET_ID = 64;
-our $DEBUG =0;
 
 
 ## Used for the itterator function
 my $DEFAULT_ITERATOR_CACHE_SIZE = 10_000;
-
+our $DEBUG =0;
 
 sub store {
     my ($self, $vf) = @_;
@@ -1778,8 +1777,10 @@ sub fetch_by_hgvs_notation {
     throw ("HGVS notation for variation with unknown location is not supported");
   }
 
-  # Imprecise insertions are not supported
-  if($description =~ m/\(.+\_.+\)ins/) {
+  # Imprecise insertions are not supported:
+  # NC_000013.11:g.(99982241_99982249)insTC - insertion of TC at an unknown position between 99982241-99982249
+  # NC_000013.11:g.99982241_99982242ins56 or NC_000013.11:g.99982241_99982242ins(56) - insertion of not specified nucleotides
+  if($description =~ m/\(.+\_.+\)ins|ins\(?\d+\)?/g) {
     throw ("HGVS notation for insertion \'$description\' is not supported");
   }
 

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -101,11 +101,10 @@ use Scalar::Util qw(looks_like_number);
 
 our @ISA = ('Bio::EnsEMBL::Variation::DBSQL::BaseAdaptor', 'Bio::EnsEMBL::DBSQL::BaseFeatureAdaptor');
 our $MAX_VARIATION_SET_ID = 64;
-
+our $DEBUG =0;
 
 ## Used for the itterator function
 my $DEFAULT_ITERATOR_CACHE_SIZE = 10_000;
-our $DEBUG =0;
 
 sub store {
     my ($self, $vf) = @_;

--- a/modules/t/hgvs_parser.t
+++ b/modules/t/hgvs_parser.t
@@ -813,7 +813,9 @@ ok( $hgvs_genomic_3->{'-'} eq 'NC_000019.9:g.48836478_48836480del', "hgvs genomi
 #ok( $hgvs_genomic_4->{'T'} eq 'NC_000021.8:g.26170678N>A', "RefSeq transcript");
 
 my $hgvs_ins = "NC_000003.11:g.(10191482_10191493)insT";
-dies_ok { $vf_adaptor->fetch_by_hgvs_notation( $hgvs_ins ) } 'fetch_by_hgvs_notation Throw unsupported insertion';
+dies_ok { $vf_adaptor->fetch_by_hgvs_notation( $hgvs_ins ) } 'fetch_by_hgvs_notation Throw unsupported insertion: uncertain position';
+my $hgvs_ins_2 = "NC_000003.11:g.10191482_10191483ins56";
+dies_ok { $vf_adaptor->fetch_by_hgvs_notation( $hgvs_ins_2 ) } 'fetch_by_hgvs_notation Throw unsupported insertion: incomplete description';
 my $hgvs_u = "NC_000002.11:g.(?_46746507)(?46746514)del";
 dies_ok { $vf_adaptor->fetch_by_hgvs_notation( $hgvs_u ) } 'Throw on unsupported HGVS notation';
 


### PR DESCRIPTION
ENSVAR-2536
g.99982241_99982242ins56 returns `input: "NC_000013.11:g.99982241_99982242ins56"` -> this insertion is incomplete and should throw a message. 
This PR extends an existing check to include this example. 