### PR TITLE
move ggvp data to ensembl ftp

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -256,7 +256,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/gambian_genome_variation_project/release/20200217_biallelic_SNV/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/ggvp/ALL_GGVP.chr###CHR###.shapeit2_integrated_snvindels_v1b_20200120.GRCh38.phased.vcf.gz",
       "sample_prefix": "GGVP:",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",


### PR DESCRIPTION
Because of problems with igsr FTP site it was decided to move files to the ensembl ftp site.
The files have already been copied to ../ensemblftp/data_files/homo_sapiens/GRCh38/variation_genotype/ggvp
We need to wait for the files to be synced before we can merge this PR. PRs for 102 and 103 are coming too.