### PR TITLE
update gerp score filenames

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -632,7 +632,7 @@
       "species": "bos_taurus",
       "assembly": "ARS-UCD1.2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -640,7 +640,7 @@
       "species": "canis_familiaris",
       "assembly": "CanFam3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -648,7 +648,7 @@
       "species": "capra_hircus",
       "assembly": "ARS1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -656,7 +656,7 @@
       "species": "chlorocebus_sabaeus",
       "assembly": "ChlSab1.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -664,7 +664,7 @@
       "species": "danio_rerio",
       "assembly": "GRCz11",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
       "annotation_type": "gerp"
     },
     {
@@ -672,7 +672,7 @@
       "species": "equus_caballus",
       "assembly": "EquCab3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -680,7 +680,7 @@
       "species": "felis_catus",
       "assembly": "Felis_catus_9.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -688,7 +688,7 @@
       "species": "gallus_gallus",
       "assembly": "GRCg6a",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
       "annotation_type": "gerp"
     },
     {
@@ -704,7 +704,7 @@
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
       "annotation_type": "gerp"
     },
     {
@@ -712,7 +712,7 @@
       "species": "macaca_mulatta",
       "assembly": "Mmul_10",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
       "annotation_type": "gerp"
     },
     {
@@ -720,15 +720,15 @@
       "species": "meleagris_gallopavo",
       "assembly": "UMD2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
       "annotation_type": "gerp"
     },
     {
       "id": "90_mammals.gerp_conservation_score",
       "species": "mus_musculus",
-      "assembly": "GRCm38",
+      "assembly": "GRCm39",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm39.bw",
       "annotation_type": "gerp"
     },
     {
@@ -736,7 +736,7 @@
       "species": "nomascus_leucogenys",
       "assembly": "Nleu_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -744,7 +744,7 @@
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -752,7 +752,7 @@
       "species": "ovis_aries_rambouillet",
       "assembly": "Oar_rambouillet_v1.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries_rambouillet.Oar_rambouillet_v1.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries_rambouillet.Oar_rambouillet_v1.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -760,7 +760,7 @@
       "species": "pan_troglodytes",
       "assembly": "Pan_tro_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -768,7 +768,7 @@
       "species": "pongo_abelii",
       "assembly": "PPYG2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
       "annotation_type": "gerp"
     },
     {
@@ -776,7 +776,7 @@
       "species": "rattus_norvegicus",
       "assembly": "Rnor_6.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
       "annotation_type": "gerp"
     },
     {
@@ -784,7 +784,7 @@
       "species": "sus_scrofa",
       "assembly": "Sscrofa11.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
       "annotation_type": "gerp"
     },
     {
@@ -792,7 +792,7 @@
       "species": "taeniopygia_guttata",
       "assembly": "bTaeGut1_v1.p",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
       "annotation_type": "gerp"
     },
     {
@@ -800,7 +800,7 @@
       "species": "tetraodon_nigroviridis",
       "assembly": "TETRAODON8",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
       "annotation_type": "gerp"
     },
     {
@@ -808,7 +808,7 @@
       "species": "salmo_salar",
       "assembly": "ICSASG_v2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-103/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
       "annotation_type": "gerp"
     },
     {

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -628,67 +628,67 @@
       "filename_template" : "ftp://ftp.ebi.ac.uk/pub/databases/eva/PRJEB22988/Svardal_et_al_2017_vervet_monkey_SNPs_imputed_phased.vcf.gz"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "bos_taurus",
       "assembly": "ARS-UCD1.2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.bos_taurus.ARS-UCD1.2.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "canis_familiaris",
       "assembly": "CanFam3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.canis_familiaris.CanFam3.1.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "capra_hircus",
       "assembly": "ARS1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.capra_hircus.ARS1.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "chlorocebus_sabaeus",
       "assembly": "ChlSab1.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.chlorocebus_sabaeus.ChlSab1.1.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "86_fish.gerp_conservation_score",
+      "id": "65_fish.gerp_conservation_score",
       "species": "danio_rerio",
       "assembly": "GRCz11",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/86_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.danio_rerio.GRCz11.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "equus_caballus",
       "assembly": "EquCab3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.equus_caballus.EquCab3.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "felis_catus",
       "assembly": "Felis_catus_9.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.felis_catus.Felis_catus_9.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "95_amniotes.gerp_conservation_score",
+      "id": "65_amniotes.gerp_conservation_score",
       "species": "gallus_gallus",
       "assembly": "GRCg6a",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/95_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.gallus_gallus.GRCg6a.bw",
       "annotation_type": "gerp"
     },
     {
@@ -700,115 +700,115 @@
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "homo_sapiens",
       "assembly": "GRCh38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.homo_sapiens.GRCh38.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "macaca_mulatta",
       "assembly": "Mmul_10",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.macaca_mulatta.Mmul_10.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "95_amniotes.gerp_conservation_score",
+      "id": "65_amniotes.gerp_conservation_score",
       "species": "meleagris_gallopavo",
       "assembly": "UMD2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/95_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.meleagris_gallopavo.UMD2.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "mus_musculus",
       "assembly": "GRCm38",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm38.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.mus_musculus.GRCm38.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "nomascus_leucogenys",
       "assembly": "Nleu_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.nomascus_leucogenys.Nleu_3.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "ovis_aries",
       "assembly": "Oar_v3.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries.Oar_v3.1.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "ovis_aries_rambouillet",
       "assembly": "Oar_rambouillet_v1.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries_rambouillet.Oar_rambouillet_v1.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.ovis_aries_rambouillet.Oar_rambouillet_v1.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "pan_troglodytes",
       "assembly": "Pan_tro_3.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pan_troglodytes.Pan_tro_3.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "pongo_abelii",
       "assembly": "PPYG2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.pongo_abelii.PPYG2.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "rattus_norvegicus",
       "assembly": "Rnor_6.0",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.rattus_norvegicus.Rnor_6.0.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "111_mammals.gerp_conservation_score",
+      "id": "90_mammals.gerp_conservation_score",
       "species": "sus_scrofa",
       "assembly": "Sscrofa11.1",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/111_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/90_mammals.gerp_conservation_score/gerp_conservation_scores.sus_scrofa.Sscrofa11.1.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "95_amniotes.gerp_conservation_score",
+      "id": "65_amniotes.gerp_conservation_score",
       "species": "taeniopygia_guttata",
       "assembly": "bTaeGut1_v1.p",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/95_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_amniotes.gerp_conservation_score/gerp_conservation_scores.taeniopygia_guttata.bTaeGut1_v1.p.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "86_fish.gerp_conservation_score",
+      "id": "65_fish.gerp_conservation_score",
       "species": "tetraodon_nigroviridis",
       "assembly": "TETRAODON8",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/86_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.tetraodon_nigroviridis.TETRAODON8.bw",
       "annotation_type": "gerp"
     },
     {
-      "id": "86_fish.gerp_conservation_score",
+      "id": "65_fish.gerp_conservation_score",
       "species": "salmo_salar",
       "assembly": "ICSASG_v2",
       "type": "remote",
-      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/86_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
+      "filename_template" : "ftp://ftp.ensembl.org/pub/release-102/compara/conservation_scores/65_fish.gerp_conservation_score/gerp_conservation_scores.salmo_salar.ICSASG_v2.bw",
       "annotation_type": "gerp"
     },
     {


### PR DESCRIPTION
Updated based on compara data:
mysql-ens-compara-prod-1 ensembl_compara_master --table -e 'SELECT name, first_release, last_release FROM method_link_species_set WHERE method_link_id = 501 AND first_release IS NOT NULL AND first_release <= 103 AND (last_release IS NULL OR last_release >= 103)'
+-------------------------------------------------+---------------+--------------+
| name                                            | first_release | last_release |
+-------------------------------------------------+---------------+--------------+
| 16 pig breeds GERP Conservation Scores          |           103 |         NULL |
| 90 eutherian mammals GERP Conservation Scores   |           103 |         NULL |
| 27 sauropsids GERP Conservation Scores          |           103 |         NULL |
| 65 fish GERP Conservation Scores                |           103 |         NULL |
| 65 amniota vertebrates GERP Conservation Scores |           103 |         NULL |
+-------------------------------------------------+---------------+———————+
Comment from compara regarding the drop in species count:  Starting from e103 the Compara database will only have data for ~200 species, not the full ~300 set any more. Cuts were made across all clades except the mouse strains and pig breeds analyses
