### PR TITLE
RunSift->run() checks also for blastdb* files

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunSift.pm
@@ -51,7 +51,7 @@ sub run {
   my $ncbi_dir        = $self->required_param('ncbi_dir');
   my $blastdb         = $self->required_param('blastdb');
 
-  if (! -e $blastdb) {
+  if (! -e $blastdb && !glob("$blastdb*")) {
     die("Blastdb ($blastdb) does not exist");
   }
 


### PR DESCRIPTION
Method run in class Bio::EnsEMBL::Variation::Pipeline::ProteinFunction::RunSift checks that $blastdb file actually exists before running. However, sometimes that file is compressed as BLASTP actually does not use it. A work around is to check that $blastdb* files exists on the same location, which would include both the original FASTA file and the files resulting from running makeblastdb.

This code has been tested while running the SIFT pipeline for maize for release 104 with help from @at7 , using 
/nfs/production/panda/ensemblgenomes/data/blastdb/uniref90.fasta

