### PR TITLE
Update phenotype hive import - e104

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
@@ -141,9 +141,9 @@ sub get_pubmed_prefix {
 sub core_db_adaptor {
   my $self = shift;
 
-  $self->{core_dba} = $self->get_species_adaptor("core") if !defined $self->{core_dba};
+  # no caching on purpose
+  return $self->get_species_adaptor("core");
 
-  return $self->{core_dba};
 }
 
 =head2 variation_db_adaptor
@@ -157,7 +157,7 @@ sub core_db_adaptor {
 
 sub variation_db_adaptor {
   my $self = shift;
-  
+
   # no caching on purpose
   return $self->get_species_adaptor("variation");
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
@@ -141,7 +141,9 @@ sub get_pubmed_prefix {
 sub core_db_adaptor {
   my $self = shift;
 
-  # no caching on purpose
+  # no caching on purpose see eHive docs, worker will only compile the Runable once;
+  # Runnable object itself  $self->{}), global objects (e.g. StatementHandles)
+  # and singletons (including the Registry) persist across eHive worker jobs
   return $self->get_species_adaptor("core");
 
 }
@@ -158,7 +160,7 @@ sub core_db_adaptor {
 sub variation_db_adaptor {
   my $self = shift;
 
-  # no caching on purpose
+  # no caching on purpose same as core_db_adaptor
   return $self->get_species_adaptor("variation");
 
 }
@@ -176,7 +178,8 @@ sub variation_db_adaptor {
 sub ontology_db_adaptor {
   my ($self, $db_adaptor) = @_;
 
-  $self->{ontology_dba} =  $self->get_adaptor('multi', 'ontology') if !defined $self->{ontology_dba};
+  # no caching on purpose same as core_db_adaptor
+  $self->{ontology_dba} =  $self->get_adaptor('multi', 'ontology');
 
   return $self->{ontology_dba};
 }
@@ -364,7 +367,8 @@ sub default_phenotype_class {
 
   if (defined $pheno_class ){
     $self->{default_phenotype_class} = $pheno_class ;
-  } elsif (! defined $self->{default_phenotype_class}){
+  } else {
+    # no caching on purpose same as core_db_adaptor
     # phenotype class is similar to variation class as it contains an attrib_id of specific attrib_type
     $self->{default_phenotype_class} = $self->_get_attrib_ids("phenotype_type", "trait");
   }
@@ -419,7 +423,7 @@ sub update_meta_coord {
 sub get_seq_region_ids {
   my $self = shift;
 
-  return $self->{seq_region_ids} if (defined $self->{seq_region_ids});
+  # no caching on purpose same as core_db_adaptor
 
   my $sth = $self->variation_db_adaptor->dbc->prepare(qq{
     SELECT seq_region_id, name
@@ -1645,7 +1649,7 @@ sub get_new_results {
 sub get_old_results {
   my  $self = shift;
 
-  return $self->{previous_result} if defined $self->{previous_result};
+  # no caching on purpose same as core_db_adaptor
 
   my $int_dba ;
   eval{ $int_dba = $self->get_adaptor('multi', 'intvar');};

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/BasePhenotypeAnnotation.pm
@@ -157,10 +157,10 @@ sub core_db_adaptor {
 
 sub variation_db_adaptor {
   my $self = shift;
+  
+  # no caching on purpose
+  return $self->get_species_adaptor("variation");
 
-  $self->{variation_dba} =  $self->get_species_adaptor("variation") if !defined $self->{variation_dba};
-
-  return $self->{variation_dba};
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
@@ -385,7 +385,7 @@ sub check_source {
 
     my @check_names= grep {/$source->{source_name}/ } keys $previous_counts->{phenotype_feature_count_details};
     if (scalar(@check_names) != 1) {
-      $text_out.= "WARNING:".scalar(@check_names). " check results found for '".$source->{source_name}."', where 1 expected (0 is expected for EGA): ".@check_names." \n";
+      $text_out .= "WARNING:".scalar(@check_names) . " check results found for '" . $source->{source_name} . "', where 1 expected (0 is expected for EGA): " . @check_names . " \n";
       $self->print_logFH($text_out);
       return;
     }
@@ -393,9 +393,9 @@ sub check_source {
     my $check_name =$check_names[0];
     if (defined $previous_counts->{phenotype_feature_count_details}{$check_name} &&
         $previous_counts->{phenotype_feature_count_details}{$check_name}  > $new_counts->{phenotype_feature_count_details}{$check_name}){
-      $text_out.= "WARNING: ".$new_counts->{phenotype_feature_count_details}{$check_name}." $check_name entries";
-      $text_out.= " (previously ".$previous_counts->{phenotype_feature_count_details}{$check_name}.")" ;
-      $text_out.= "\n";
+      $text_out .= "WARNING: " . $new_counts->{phenotype_feature_count_details}{$check_name} . " $check_name entries";
+      $text_out .= " (previously " . $previous_counts->{phenotype_feature_count_details}{$check_name} . ")" ;
+      $text_out .= "\n";
       #for grch37 do not fail the job as prev counts are retrieved by species and not by assembly and grch38 are always reported
       $count_ok = 0 unless $assembly eq 'GRCh37';
     }
@@ -406,9 +406,9 @@ sub check_source {
 
       if (defined $previous_counts->{$check_name} &&
           $previous_counts->{$check_name}  > $new_counts->{$check_name}){
-        $text_out.= "WARNING: ".$new_counts->{"$table\_count"}." $table entries";
-        $text_out.= " (previously ".$previous_counts->{"$table\_count"}.")" if defined  $previous_counts->{"$table\_count"} ;
-        $text_out.= "\n";
+        $text_out .= "WARNING: " . $new_counts->{"$table\_count"} . " $table entries";
+        $text_out .= " (previously " . $previous_counts->{"$table\_count"} . ")" if defined  $previous_counts->{"$table\_count"} ;
+        $text_out .= "\n";
         #for grch37 do not fail the job as prev counts are retrieved by species and not by assembly and grch38 are always reported
         $count_ok = 0 unless $assembly eq 'GRCh37';
       }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
@@ -370,6 +370,7 @@ sub check_source {
   my $self = shift;
 
   my $source = $self->param('source');
+  my $assembly = $self->get_assembly;
 
   ## retrieve old results from production db for comparison if available
   my $previous_counts = $self->get_old_results();
@@ -395,7 +396,8 @@ sub check_source {
       $text_out.= "WARNING: ".$new_counts->{phenotype_feature_count_details}{$check_name}." $check_name entries";
       $text_out.= " (previously ".$previous_counts->{phenotype_feature_count_details}{$check_name}.")" ;
       $text_out.= "\n";
-      $count_ok = 0;
+      #for grch37 do not fail the job as prev counts are retrieved by species and not by assembly and grch38 are always reported
+      $count_ok = 0 unless $assembly eq 'GRCh37';
     }
   } else {
     my @tables = ('phenotype', 'phenotype_feature', 'phenotype_feature_attrib', 'phenotype_ontology_accession');
@@ -407,7 +409,8 @@ sub check_source {
         $text_out.= "WARNING: ".$new_counts->{"$table\_count"}." $table entries";
         $text_out.= " (previously ".$previous_counts->{"$table\_count"}.")" if defined  $previous_counts->{"$table\_count"} ;
         $text_out.= "\n";
-        $count_ok = 0;
+        #for grch37 do not fail the job as prev counts are retrieved by species and not by assembly and grch38 are always reported
+        $count_ok = 0 unless $assembly eq 'GRCh37';
       }
     }
   }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/CheckPhenotypeAnnotation.pm
@@ -383,8 +383,11 @@ sub check_source {
   if (defined $source && defined $previous_counts->{phenotype_feature_count_details} ){
 
     my @check_names= grep {/$source->{source_name}/ } keys $previous_counts->{phenotype_feature_count_details};
-    $text_out.= "WARNING:".scalar(@check_names). " check results found, where 1 expected:".@check_names." \n" if (scalar(@check_names) != 1);
-    next if (scalar(@check_names) != 1);
+    if (scalar(@check_names) != 1) {
+      $text_out.= "WARNING:".scalar(@check_names). " check results found for '".$source->{source_name}."', where 1 expected (0 is expected for EGA): ".@check_names." \n";
+      $self->print_logFH($text_out);
+      return;
+    }
 
     my $check_name =$check_names[0];
     if (defined $previous_counts->{phenotype_feature_count_details}{$check_name} &&

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/FinishPhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/FinishPhenotypeAnnotation.pm
@@ -144,6 +144,10 @@ sub update_internal_db{
     return;
   }
 
+  my $meta_dba = $self->get_species_adaptor('core')->get_MetaContainerAdaptor;
+  my @mapping_info = @{ $meta_dba->list_value_by_key('assembly.default') };
+  my $genome_assembly = $mapping_info[0];
+
   my $var_dba = $self->get_species_adaptor('variation');
   my $ensdb_name = $var_dba->dbc->dbname;
 
@@ -164,6 +168,7 @@ sub update_internal_db{
       version     => $ens_version,
       status_desc => 'Created'
     });
+    $ensdb->genome_reference($genome_assembly) if defined $genome_assembly;
     $ensvardb_dba->store( $ensdb );
   }
   $ensvardb_dba->update_status( $ensdb, 'phenotype_annotation_run' );

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/FinishPhenotypeAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/FinishPhenotypeAnnotation.pm
@@ -144,12 +144,9 @@ sub update_internal_db{
     return;
   }
 
-  my $meta_dba = $self->get_species_adaptor('core')->get_MetaContainerAdaptor;
-  my @mapping_info = @{ $meta_dba->list_value_by_key('assembly.default') };
-  my $genome_assembly = $mapping_info[0];
-
   my $var_dba = $self->get_species_adaptor('variation');
   my $ensdb_name = $var_dba->dbc->dbname;
+  my $genome_assembly = $self->get_assembly;
 
   my $ensvardb_dba  =  $int_dba->get_EnsVardbAdaptor();
   my $result_dba    =  $int_dba->get_ResultAdaptor();

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportAnimalQTL.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportAnimalQTL.pm
@@ -236,8 +236,7 @@ sub write_output {
     close($pipelogFH);
   }
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportCGC.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportCGC.pm
@@ -135,6 +135,9 @@ sub run {
 
   my $file_cgc = $self->required_param('cgc_file');
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   #get source id
   my $source_id = $self->get_or_add_source(\%source_info);
   $self->print_logFH("$source_info{source_name_short} source_id is $source_id\n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportCGC.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportCGC.pm
@@ -162,8 +162,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
@@ -98,6 +98,9 @@ sub run {
 
   my $file_ddg2p = $self->required_param('ddg2p_file');
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name});
+
   #get source id
   my $source_id = $self->get_or_add_source(\%source_info);
   $self->print_logFH("$source_info{source_name} source_id is $source_id\n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
@@ -99,7 +99,7 @@ sub run {
   my $file_ddg2p = $self->required_param('ddg2p_file');
 
   # dump and clean pre-existing phenotype features
-  $self->dump_phenotypes($source_info{source_name});
+  $self->dump_phenotypes($source_info{source_name}, 1);
 
   #get source id
   my $source_id = $self->get_or_add_source(\%source_info);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportDDG2P.pm
@@ -125,8 +125,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportEGA.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportEGA.pm
@@ -150,8 +150,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
@@ -150,8 +150,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
@@ -127,6 +127,9 @@ sub run {
 
   my $gwas_file = $self->required_param('gwas_file');
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   # get phenotype data
   my $results = $self->parse_input_file($gwas_file);
   $self->print_pipelogFH("Got ".(scalar @{$results->{'phenotypes'}})." phenotypes \n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportGWAS.pm
@@ -209,6 +209,9 @@ sub parse_input_file {
       my $ratio_info     = $content{'95% CI (TEXT)'};
       my @accessions     = split/\,/, $content{'MAPPED_TRAIT_URI'};
 
+      print $errFH1 "WARNING: 'DISEASE/TRAIT' entry is empty for '$rs_id'\n" if ($phenotype eq '');
+      next if ($phenotype eq '');
+
       my $risk_frequency = '';
       if ($rs_risk_allele =~ /^\s*$rs_id-+\s*(\w+)\s*$/i) {
         $rs_risk_allele = $1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
@@ -81,6 +81,7 @@ sub fetch_input {
     if ($run_type ne GWAS && $run_type ne EGA && $run_type ne HUMAN_VAR){
       # species parameter needs to be set for the core db, variation db adaptor fetch
       $self->param('species', 'homo_sapiens');
+      $DB::single=1;
       update_seq_region_ids($self->core_db_adaptor, $self->variation_db_adaptor);
     }
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
@@ -102,8 +102,7 @@ sub write_output {
 
     $self->print_pipelogFH("Passing on check jobs (". scalar @{$self->param('output_ids')} .") for check_phenotypes \n") if $self->param('debug_mode');
 
-    #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-    $self->dataflow_output_id($self->param('output_ids'), 1);
+    $self->dataflow_output_id($self->param('output_ids'), 8);
   }
   close($self->pipelogFH) if defined $self->pipelogFH;
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportHuman.pm
@@ -81,7 +81,6 @@ sub fetch_input {
     if ($run_type ne GWAS && $run_type ne EGA && $run_type ne HUMAN_VAR){
       # species parameter needs to be set for the core db, variation db adaptor fetch
       $self->param('species', 'homo_sapiens');
-      $DB::single=1;
       update_seq_region_ids($self->core_db_adaptor, $self->variation_db_adaptor);
     }
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportIMPC.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportIMPC.pm
@@ -138,8 +138,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMGI.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMGI.pm
@@ -130,8 +130,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMIMmorbid.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMIMmorbid.pm
@@ -114,6 +114,9 @@ sub run {
 
   my $file_mim = $self->required_param('mim_file');
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   #get source id
   my $source_id = $self->get_or_add_source(\%source_info);
   $self->print_pipelogFH("$source_info{source_name} source_id is $source_id\n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMIMmorbid.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMIMmorbid.pm
@@ -141,8 +141,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMouse.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportMouse.pm
@@ -108,8 +108,7 @@ sub write_output {
 
     $self->print_logFH("Passing on check jobs (". scalar @{$self->param('output_ids')} .") for check_phenotypes \n") if $self->param('debug_mode');
 
-    #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-    $self->dataflow_output_id($self->param('output_ids'), 1);
+    $self->dataflow_output_id($self->param('output_ids'), 4);
   }
   close($self->logFH) if defined $self->logFH;
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOMIA.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOMIA.pm
@@ -189,8 +189,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH;
   close($self->pipelogFH) if defined $self->pipelogFH;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOMIA.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOMIA.pm
@@ -131,7 +131,11 @@ sub fetch_input {
   my $file_omia = 'omia_gene_table.txt';
 
   my $workdir = $pipeline_dir."/".$source_info{source_name_short}."/".$species;
-  make_path($workdir) or die "Failed to create $workdir $!\n";
+  unless (-d $workdir) {
+    my $err;
+    make_path($workdir, {error => \$err});
+    die "make_path failed: ".Dumper($err) if $err && @$err;
+  }
   $self->workdir($workdir);
 
   open(my $logFH, ">", $workdir."/".'log_import_out_'.$source_info{source_name_short}.'_'.$species) || die ("Could not open file for writing: $!\n");

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOrphanet.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOrphanet.pm
@@ -120,8 +120,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH;
   close($self->pipelogFH) if defined $self->pipelogFH;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOrphanet.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportOrphanet.pm
@@ -94,6 +94,9 @@ sub run {
 
   my $file_orphanet = $self->required_param('orphanet_file');
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   # get phenotype data + save it (all in one method)
   my ($results,$source_date) = $self->parse_input_file($file_orphanet);
   $self->print_logFH("Got ".(scalar @{$results->{'phenotypes'}})." phenotypes \n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportRGD.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportRGD.pm
@@ -163,8 +163,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportRGD.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportRGD.pm
@@ -124,6 +124,9 @@ sub run {
   #Process QTLs file
   my $rgd_file = $self->required_param('qtl_file');   #GO through files and parse them in the correct format
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   # get seq_region_ids
   my $seq_region_ids = $self->get_seq_region_ids();
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportZFIN.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportZFIN.pm
@@ -99,6 +99,9 @@ sub run {
   #Process QTLs file
   my $input_file = $self->required_param('zfin_file');   #Go through files and parse them in the correct format
 
+  # dump and clean pre-existing phenotype features
+  $self->dump_phenotypes($source_info{source_name}, 1);
+
   # get phenotype data
   my $results = $self->parse_input_file($input_file);
   $self->print_logFH("Got ".(scalar @{$results->{'phenotypes'}})." phenotypes \n") if ($self->debug);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportZFIN.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportZFIN.pm
@@ -122,8 +122,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/OntologyMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/OntologyMapping.pm
@@ -111,8 +111,7 @@ sub write_output {
   close($self->errFH) if defined $self->errFH ;
   close($self->pipelogFH) if defined $self->pipelogFH ;
 
-  #WARNING: this will overwrite the autoflow, see eHive 2.5 manual
-  $self->dataflow_output_id($self->param('output_ids'), 1);
+  $self->dataflow_output_id($self->param('output_ids'), 2);
 
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
@@ -173,7 +173,7 @@ sub pipeline_analyses {
                 @common_params,
                 run_type => $self->o('run_type'),
             },
-            -input_ids  => [],
+            -input_ids  => [], #default
             -rc_name    => 'default',
             -max_retry_count => 0,
             -flow_into  => {
@@ -193,7 +193,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -212,11 +212,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_gwas']
+                2 => [ 'check_gwas']
             },
         },
 
@@ -225,7 +225,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -240,11 +240,11 @@ sub pipeline_analyses {
                 ega_database_conf => $self->o('ega_database_conf'),
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_ega']
+                2 => [ 'check_ega']
             },
         },
 
@@ -253,7 +253,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -267,11 +267,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_orphanet']
+                2 => [ 'check_orphanet']
             },
         },
 
@@ -280,7 +280,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -294,11 +294,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_mimmorbid']
+                2 => [ 'check_mimmorbid']
             },
         },
 
@@ -307,7 +307,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -321,11 +321,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_ddg2p']
+                2 => [ 'check_ddg2p']
             },
         },
 
@@ -334,7 +334,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -348,11 +348,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_cancerGC']
+                2 => [ 'check_cancerGC']
             },
         },
 
@@ -361,7 +361,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -max_retry_count => 0,
@@ -374,13 +374,13 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
                 '2->A' => [ 'import_impc'],
                 '3->A' => [ 'import_mgi'],
-                'A->1' => [ 'check_phenotypes'],
+                'A->4' => [ 'check_phenotypes'],
             },
         },
 
@@ -389,11 +389,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => { 'check_impc' => INPUT_PLUS() },
+                2 => { 'check_impc' => INPUT_PLUS() },
             },
         },
 
@@ -402,7 +402,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -416,11 +416,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_mgi'],
+                2 => [ 'check_mgi'],
             },
         },
 
@@ -429,7 +429,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -max_retry_count => 0,
@@ -442,7 +442,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -456,12 +456,12 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_omia']
+                2 => [ 'check_omia']
             },
         },
 
@@ -470,7 +470,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
@@ -487,12 +487,12 @@ sub pipeline_analyses {
                 threshold_qtl       => $self->o('threshold_qtl'),
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_animalqtl']
+                2 => [ 'check_animalqtl']
             },
         },
 
@@ -501,12 +501,12 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
             -flow_into => {
-                1 => [ 'check_phenotypes']
+                2 => [ 'check_phenotypes']
             },
             -max_retry_count => 0,
         },
@@ -519,11 +519,11 @@ sub pipeline_analyses {
                 threshold_qtl   => $self->o('threshold_qtl'),
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_phenotypes']
+                2 => [ 'check_phenotypes']
             },
         },
 
@@ -532,11 +532,11 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'check_phenotypes']
+                2 => [ 'check_phenotypes']
             },
         },
 
@@ -545,7 +545,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
             -flow_into  => {
@@ -559,12 +559,12 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
             -flow_into  => {
-                1 => [ 'finish_phenotype_annotation']
+                2 => [ 'finish_phenotype_annotation']
             },
         },
 
@@ -573,7 +573,7 @@ sub pipeline_analyses {
             -parameters => {
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -analysis_capacity => 1,
             -rc_name    => 'default',
@@ -588,10 +588,10 @@ sub pipeline_analyses {
                 pipeline_name => $self->o('pipeline_name'),
                 @common_params,
             },
-            -input_ids      => [],
+            -input_ids      => [], #default
             -hive_capacity  => 1,
             -rc_name    => 'default',
-            -flow_into      => {},
+            -flow_into      => {}, #default
             -failed_job_tolerance => 0,
             -max_retry_count => 0,
         },

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
@@ -203,7 +203,7 @@ sub pipeline_analyses {
                 '5->A' => [ 'import_mimmorbid' ],
                 '6->A' => [ 'import_ddg2p' ],
                 '7->A' => [ 'import_cancerGC' ],
-                'A->1' => [ 'check_phenotypes'],
+                'A->8' => [ 'check_phenotypes'],
             },
         },
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
@@ -173,7 +173,7 @@ sub pipeline_analyses {
                 @common_params,
                 run_type => $self->o('run_type'),
             },
-            -input_ids  => [{}],
+            -input_ids  => [],
             -rc_name    => 'default',
             -max_retry_count => 0,
             -flow_into  => {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/PhenotypeAnnotation_conf.pm
@@ -83,7 +83,7 @@ sub default_options {
         # a directory to keep hive output files and your registry file, you should
         # create this if it doesn't exist
 
-        pipeline_dir            => '/hps/nobackup/production/ensembl/' . $login . '/' . $self->o('pipeline_name')."_".$self->o('ensembl_release') ,
+        pipeline_dir            => '/hps/nobackup2/production/ensembl/' . $login . '/' . $self->o('pipeline_name')."_".$self->o('ensembl_release') ,
 
         # a directory where hive workers will dump STDOUT and STDERR for their jobs
         # if you use lots of workers this directory can get quite big, so it's


### PR DESCRIPTION
- fix required for GWAS e104 37 import: commit 'skip empty phenotype gwas'
- remove caching  of db adaptor
- update default dir: ENSVAR-3745
- review input ids, don't use overflow: ENSVAR-3666
- add source specific check: ENSVAR-3752
- remove old import before fresh import: ENSVAR-3746
- save genome assembly in internal production db: ENSVAR-3917