### PR TITLE
Prf104/ancestral allele pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -78,7 +78,7 @@ sub default_options {
         reg_file                => $self->o('pipeline_dir') . '/ensembl.registry',
         batch_size => 1_000_000,
         create_stats => 0,
-        none_dbSNP_only => 0,
+        non_dbSNP_only => 0,
         
         
         default_lsf_options => '-qproduction-rh74 -R"select[mem>2000] rusage[mem=2000]" -M2000',
@@ -117,7 +117,7 @@ sub pipeline_analyses {
         compara_dir      => $self->o('compara_dir'),
         batch_size       => $self->o('batch_size'),
         create_stats     => $self->o('create_stats'),
-        none_dbSNP_only  => $self->o('none_dbSNP_only'),
+        non_dbSNP_only   => $self->o('non_dbSNP_only'),
 
     );
    

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/Init.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/Init.pm
@@ -110,7 +110,8 @@ sub store_previous_release_stats {
   my $non_dbSNP_only = shift;
   my $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature GROUP BY ancestral_allele;/;
   if ($non_dbSNP_only) {
-    $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature WHERE source_id != 1 GROUP BY ancestral_allele;/;
+    my $dbSNP_source_id = $self->get_source_id('dbSNP');
+    $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature WHERE source_id != $dbSNP_source_id GROUP BY ancestral_allele;/;
   }
 
   if (! -e "$species_dir/previous_release_stats") {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
@@ -37,7 +37,6 @@ sub run {
     $self->param('species', $species_name);
     my $vdba = $self->get_species_adaptor('variation');
     my $dbc = $vdba->dbc;
-die;
     $self->update_ancestral_alleles($species_dir, $dbc);
     if ($self->param('create_stats')) {
       $self->compare_previous_release_stats($species_dir, $dbc);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/PostProcessing.pm
@@ -71,7 +71,8 @@ sub compare_previous_release_stats {
   my $non_dbSNP_only = $self->param('non_dbSNP_only');
   my $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature GROUP BY ancestral_allele;/;
   if ($non_dbSNP_only) {
-    $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature WHERE source_id != 1 GROUP BY ancestral_allele;/;
+    my $dbSNP_source_id = $self->get_source_id('dbSNP');
+    $sql = qq/SELECT ancestral_allele, COUNT(*) FROM variation_feature WHERE source_id != $dbSNP_source_id GROUP BY ancestral_allele;/;
   }
   my $previous_release_stats = {};
   my $fh = FileHandle->new("$species_dir/previous_release_stats", 'r');

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/BaseVariationProcess.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/BaseVariationProcess.pm
@@ -170,4 +170,16 @@ sub get_species_id {
   return $meta_container_adaptor->species_id();
 }
 
+sub get_source_id {
+  my $self = shift;
+  my $source_name = shift;
+  my $variation_dba = $self->get_species_adaptor('variation');
+  my $source_adaptor = $variation_dba->get_SourceAdaptor; 
+  my $source = $source_adaptor->fetch_by_name($source_name);
+  if (!defined $source) {
+    die "Could not fetch source for name: $source_name" 
+  }
+  return $source->dbID();
+} 
+
 1;


### PR DESCRIPTION
-- rename option
-- If the pipeline only updates non-dbSNP variants we only need to compare ancestral allele assignments, before and after the pipeline was run, for non-dbSNP variants