### PR TITLE
SPDI uses the sequence version number

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2491,8 +2491,9 @@ sub fetch_by_spdi_notation{
   elsif($count_separator < 3){ throw ("Could not parse the SPDI notation $spdi. Too few elements present"); } 
 
   my $raw_sequence_id = $sequence_id;
-  # strip version number from reference 
-  if($sequence_id =~ m/\./i){
+  # strip version number from reference (only LRG and NT)
+  # NC_ should have a version number, example for mouse: NC_000068.8:3115317:T:C
+  if($sequence_id =~ m/\./i && ($sequence_id =~ m/^LRG/i || $sequence_id =~ m/^NT/i)){
     $sequence_id =~ s/\.\d+//g;
   } 
 

--- a/modules/t/variationFeatureAdaptor.t
+++ b/modules/t/variationFeatureAdaptor.t
@@ -504,8 +504,8 @@ ok($vf->allele_string eq 'GCCCCCC/CT' , "Valid indel");
 my $spdi_lrg = 'LRG_293:69534:N:G';
 $vf = $vfa->fetch_by_spdi_notation($spdi_lrg);
 ok($vf->allele_string eq 'N/G', "LRG - Valid insertion 'LRG_293:69534:N:G'");
-$vf = $vfa->fetch_by_spdi_notation('NT_004487:127830:N:C');
-ok($vf->allele_string eq 'N/C', "NT - Valid substitution 'NT_004487:127830:N:C'");
+$vf = $vfa->fetch_by_spdi_notation('NT_004487.20:127830:N:C');
+ok($vf->allele_string eq 'N/C', "NT - Valid substitution 'NT_004487.20:127830:N:C'");
 
 ## check ref matching
 my $bad_hgvs = 'ENSP00000434898.1:p.Cys6Ser';


### PR DESCRIPTION
Mouse `NC_000068.8:3115317:T:C` fetches the sequence from GRCm38 instead of GRCm39 because fetch_by_spdi_notation doesn't use the sequence version. 

Ticket: ENSVAR-3947
