### PR TITLE
SQL Foreign keys - remove variation_citation attrib_id 

### DIFF
--- a/sql/foreign_keys.sql
+++ b/sql/foreign_keys.sql
@@ -141,7 +141,6 @@ ALTER TABLE phenotype_ontology_accession ADD FOREIGN KEY (phenotype_id) REFERENC
 
 ALTER TABLE variation_citation ADD FOREIGN KEY (variation_id) REFERENCES variation(variation_id);
 ALTER TABLE variation_citation ADD FOREIGN KEY (publication_id) REFERENCES publication(publication_id);
-ALTER TABLE variation_citation ADD FOREIGN KEY (data_source_attrib) REFERENCES attrib(attrib_id); 
 
 ALTER TABLE variation_feature ADD FOREIGN KEY (source_id) REFERENCES source(source_id);
 ALTER TABLE variation_feature ADD FOREIGN KEY (variation_id) REFERENCES variation(variation_id);


### PR DESCRIPTION
The FK datacheck picks up the relationship from sql/foreign_keys.sql. The DCs end up doing a JOIN between a value (attrib.attrib_id) and a set value (variation_citation.data_source_attrib) which is incorrect. 
Related tickets: ENSVAR-1996 and ENSVAR-3980