### PR TITLE
Bugfix104/fix docs population display 2

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -769,12 +769,12 @@
         "LG1", "LG2","LG3","LG4","LG5","LG6","LG7","LG8","LG9","LG10","LG11","LG12","LG13","LG14","LG15","LG16","LG17","LG18","LG19","LG20","LG21","LG22","LG23"
       ],
       "population_display_group": {
-        "display_group_name": "PRJEB38764",
+        "display_group_name": "PRJEB38548",
         "display_group_priority": "1"
       },
       "populations": {
         "1": {
-          "name": "PRJEB38764",
+          "name": "PRJEB38548",
           "_af": "AF"
         }
       }

--- a/scripts/misc/generate_population_table.pl
+++ b/scripts/misc/generate_population_table.pl
@@ -533,14 +533,18 @@ sub get_project_label {
   if ($project->{'population_display_group'} && $project->{'population_display_group'}{'display_group_name'}) {
     $label = $project->{'population_display_group'}{'display_group_name'};
   }
-  elsif ($label =~ /^1000/) {
+
+  if ($label =~ /^1000/) {
     $label = '1000 Genomes Project';
   }
   elsif ($label =~ /^nextgen/) {
     $label = 'NextGen Project';
   }
-  elsif ($label =~ /EVA_(.+)$/i) {
+  elsif ($label =~ /EVA_(.+)$/) {
     $label = "EVA study $1";
+  }
+  elsif ($label =~ /^PRJEB(.+)/) {
+    $label = "EVA study $label";
   }
   elsif ($label =~ /mouse_genome_project/) {
     $label = "Mouse Genomes Project (MGP)";


### PR DESCRIPTION
-- for two new EVA species the population_display_group is stored in the vcf config file and overwrites the label
-- also support case where label looks like PRJEB...
-- we used the wrong display group id for nile tilapia, after fix still all works on my [sandbox](http://ves-hx2-76.ebi.ac.uk:5040/Oreochromis_niloticus/Variation/Population?db=core;r=LG19:18792028-18872052;v=LG19:18819865:A_G:PRJEB38548;vdb=variation;vf=LG19:18819865:A_G:PRJEB38548); I create a PR for public-plugins too