### PR TITLE
remove old version of gnomADe GRCh38

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -196,62 +196,6 @@
       }
     },
     {
-      "id": "gnomADe_GRCh38",
-      "description": "Genome Aggregation Database exomes r2.1",
-      "species": "homo_sapiens",
-      "assembly": "GRCh38",
-      "type": "remote",
-      "filename_template": "ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/gnomad.exomes.r2.1.sites.grch38.chr###CHR###_noVEP.vcf.gz",
-      "chromosomes": [
-        "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
-        "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"
-      ],
-      "population_prefix": "gnomADe:",
-      "population_display_group": {
-        "display_group_name": "gnomAD exomes",
-        "display_group_priority": 1.4
-      },
-      "populations": {
-        "9900010": {
-          "name": "gnomADe:ALL",
-          "_raw_name": "",
-          "description": "All gnomAD exomes individuals"
-        },
-        "9900011": {
-          "name": "afr",
-          "description": "African/African American"
-        },
-        "9900012": {
-          "name": "amr",
-          "description": "Latino"
-        },
-        "9900013": {
-          "name": "asj",
-          "description": "Ashkenazi Jewish"
-        },
-        "9900014": {
-          "name": "eas",
-          "description": "East Asian"
-        },
-        "9900015": {
-          "name": "fin",
-          "description": "Finnish"
-        },
-        "9900016": {
-          "name": "nfe",
-          "description": "Non-Finnish European"
-        },
-        "9900017": {
-          "name": "oth",
-          "description": "Other"
-        },
-        "9900018": {
-          "name": "sas",
-          "description": "South Asian"
-        }
-      }
-    },
-    {
       "id": "gnomADe_r2.1.1_GRCh38",
       "description": "Genome Aggregation Database exomes r2.1.1",
       "species": "homo_sapiens",


### PR DESCRIPTION
we need to remove the old version. The generate population table script reads studies from the vcf config and if we keep the old version of gnomAD it will also appear in the docs which we don't want.