### PR TITLE
added extra_mem resource class to Remapping_conf.pm

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
@@ -127,7 +127,8 @@ sub resource_classes {
     return {
         %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
             'default_mem' => { 'LSF' => '-R"select[mem>2500] rusage[mem=2500]" -M2500'}, 
-            'high_mem'    => { 'LSF' => '-R"select[mem>5500] rusage[mem=5500]" -M5500'}, 
+            'high_mem'    => { 'LSF' => '-R"select[mem>5500] rusage[mem=5500]" -M5500'},
+            'extra_mem'   => { 'LSF' => '-R"select[mem>12500] rusage[mem=12500]" -M12500'},			
     };
 }
 


### PR DESCRIPTION
HI @at7 , while remapping the previous variation to the new contiguous barley (_Hordeum vulgare_) assembly all run_mapping jobs ran out of memory. Selecting the extra_mem resource class solve the problem.