### PR TITLE
Task105/remapping pipeline updates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -63,8 +63,8 @@ sub default_options {
         hive_no_init => 0,
 
         # the location of your checkout of the ensembl API (the hive looks for SQL files here)
-        hive_root_dir           => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'} . '/ensembl-hive',
-        ensembl_cvs_root_dir    => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
+        ensembl_cvs_root_dir    => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
+        hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive',
 
         # a name for your pipeline (will also be used in the name of the hive database)
         pipeline_name           => 'ancestral_alleles',

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -61,17 +61,16 @@ sub default_options {
         hive_use_triggers => 0,
         hive_auto_rebalance_semaphores => 0, 
         hive_no_init => 0,
+
         # the location of your checkout of the ensembl API (the hive looks for SQL files here)
-        
-        ensembl_cvs_root_dir    => $ENV{'HOME'} . '/bin',
-        hive_root_dir           => $ENV{'HOME'} . '/bin/ensembl-hive', 
+        hive_root_dir           => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'} . '/ensembl-hive',
+        ensembl_cvs_root_dir    => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
+
         # a name for your pipeline (will also be used in the name of the hive database)
-        
         pipeline_name           => 'ancestral_alleles',
 
         # a directory to keep hive output files and your registry file, you should
         # create this if it doesn't exist
-
         pipeline_dir            => $self->o('pipeline_dir'),
         compara_dir             => $self->o('compara_dir'),
 
@@ -81,8 +80,8 @@ sub default_options {
         non_dbSNP_only => 0,
         
         
-        default_lsf_options => '-qproduction-rh74 -R"select[mem>2000] rusage[mem=2000]" -M2000',
-        medmem_lsf_options  => '-qproduction-rh74 -R"select[mem>5000] rusage[mem=5000]" -M5000',
+        default_lsf_options => '-q production -R"select[mem>2000] rusage[mem=2000]" -M2000',
+        medmem_lsf_options  => '-q production -R"select[mem>5000] rusage[mem=5000]" -M5000',
 
         hive_db_host    => 'mysql-ens-var-prod-1',
         hive_db_port    => 4449,

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/AncestralAlleles/AncestralAlleles_conf.pm
@@ -63,7 +63,6 @@ sub default_options {
         hive_no_init => 0,
 
         # the location of your checkout of the ensembl API (the hive looks for SQL files here)
-        ensembl_cvs_root_dir    => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
         hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive',
 
         # a name for your pipeline (will also be used in the name of the hive database)

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/PreRunChecks.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/PreRunChecks.pm
@@ -60,8 +60,8 @@ sub run {
 
   my $core_dbname = $cdba->dbc->dbname;
   $vdba->dbc()->sql_helper()->execute_update(-SQL => "DELETE FROM seq_region;", -PARAMS => [] );
-  my $sql = "INSERT INTO seq_region(seq_region_id, name)"
-    . "SELECT sr.seq_region_id, sr.name "
+  my $sql = "INSERT INTO seq_region(seq_region_id, name, coord_system_id) "
+    . "SELECT sr.seq_region_id, sr.name, sr.coord_system_id "
     . "FROM $core_dbname.seq_region_attrib sra, $core_dbname.attrib_type at, $core_dbname.seq_region sr "
     . "WHERE sra.attrib_type_id=at.attrib_type_id "
     . "AND at.code='toplevel' " 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingVariationFeature_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingVariationFeature_conf.pm
@@ -83,15 +83,6 @@ sub pipeline_wide_parameters {
     };
 }
 
-sub resource_classes {
-    my ($self) = @_;
-    return {
-        %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
-            'default_mem' => { 'LSF' => '-R"select[mem>2500] rusage[mem=2500]" -M2500'}, 
-            'high_mem'    => { 'LSF' => '-R"select[mem>5500] rusage[mem=5500]" -M5500'}, 
-    };
-}
-
 sub pipeline_analyses {
   my ($self) = @_;
   my @analyses;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
@@ -46,7 +46,6 @@ sub default_options {
         hive_use_triggers       => 0,
         hive_auto_rebalance_semaphores => 0,  # do not attempt to rebalance semaphores periodically by default
         hive_no_init            => 0, # setting it to 1 will skip pipeline_create_commands (useful for topping up)
-        ensembl_cvs_root_dir    => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
         hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive',
         debug                   => 0,
         run_variant_qc          => 1,

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
@@ -46,8 +46,8 @@ sub default_options {
         hive_use_triggers       => 0,
         hive_auto_rebalance_semaphores => 0,  # do not attempt to rebalance semaphores periodically by default
         hive_no_init            => 0, # setting it to 1 will skip pipeline_create_commands (useful for topping up)
-        hive_root_dir           => $ENV{'HOME'} . '/bin/ensembl-hive',
-        ensembl_cvs_root_dir    => $ENV{'HOME'} . '/bin',
+        hive_root_dir           => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'} . '/ensembl-hive',
+        ensembl_cvs_root_dir    => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
         debug                   => 0,
         run_variant_qc          => 1,
         use_fasta_files         => 0,
@@ -126,9 +126,9 @@ sub resource_classes {
     my ($self) = @_;
     return {
         %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
-            'default_mem' => { 'LSF' => '-R"select[mem>2500] rusage[mem=2500]" -M2500'}, 
-            'high_mem'    => { 'LSF' => '-R"select[mem>5500] rusage[mem=5500]" -M5500'},
-            'extra_mem'   => { 'LSF' => '-R"select[mem>12500] rusage[mem=12500]" -M12500'},			
+            'default_mem' => { 'LSF' => '-q production -R"select[mem>2500] rusage[mem=2500]" -M2500'},
+            'high_mem'    => { 'LSF' => '-q production -R"select[mem>5500] rusage[mem=5500]" -M5500'},
+            'extra_mem'   => { 'LSF' => '-q production -R"select[mem>12500] rusage[mem=12500]" -M12500'},
     };
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/Remapping_conf.pm
@@ -46,8 +46,8 @@ sub default_options {
         hive_use_triggers       => 0,
         hive_auto_rebalance_semaphores => 0,  # do not attempt to rebalance semaphores periodically by default
         hive_no_init            => 0, # setting it to 1 will skip pipeline_create_commands (useful for topping up)
-        hive_root_dir           => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'} . '/ensembl-hive',
-        ensembl_cvs_root_dir    => '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
+        ensembl_cvs_root_dir    => $ENV{'ENSEMBL_CVS_ROOT_DIR'} || '/hps/software/users/ensembl/repositories/' . $ENV{'USER'},
+        hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive',
         debug                   => 0,
         run_variant_qc          => 1,
         use_fasta_files         => 0,


### PR DESCRIPTION
-- path and queue updates for new codon cluster
-- for remapping pipeline:
   -- remove resource_classes from RemappingVariationFeature_conf.pm, as it is inherited from Remapping_conf.pm
   -- when copying over seq region data from the core to variation database also include coord_system_id