### PR TITLE
Citations import - format authors

### DIFF
--- a/scripts/import/import_EPMC.pl
+++ b/scripts/import/import_EPMC.pl
@@ -362,8 +362,8 @@ sub format_authors{
 
   if(defined $authors_final){
     my @author_list = split /, /, $authors_final;
-    if(scalar @author_list > 6) {
-      $new_authors = join(', ', @author_list[0..5]) . ', et al';
+    if(scalar @author_list > 4) {
+      $new_authors = join(', ', @author_list[0..3]) . ', et al';
     }
   }
 

--- a/scripts/import/import_EPMC.pl
+++ b/scripts/import/import_EPMC.pl
@@ -354,7 +354,7 @@ sub get_publication_info_from_epmc{
 }
 
 # Format authors list
-# only store the first 6 authors
+# only store the first 4 authors
 sub format_authors{
   my $authors_final = shift;
 

--- a/scripts/import/import_EPMC.pl
+++ b/scripts/import/import_EPMC.pl
@@ -347,27 +347,27 @@ sub get_publication_info_from_epmc{
     }
 
     ### format authors list
-    my $new_authors = format_authors($ref->{resultList}->{result}->{authorString});
-    $ref->{resultList}->{result}->{authorString} = $new_authors unless !$new_authors;
+    my $trimmed_author_list = trim_author_list($ref->{resultList}->{result}->{authorString});
+    $ref->{resultList}->{result}->{authorString} = $trimmed_author_list if $trimmed_author_list;
 
     return $ref;
 }
 
 # Format authors list
 # only store the first 4 authors
-sub format_authors{
+sub trim_author_list{
   my $authors_final = shift;
 
-  my $new_authors;
+  my $trimmed_authors;
 
   if(defined $authors_final){
     my @author_list = split /, /, $authors_final;
     if(scalar @author_list > 4) {
-      $new_authors = join(', ', @author_list[0..3]) . ', et al';
+      $trimmed_authors = join(', ', @author_list[0..3]) . ', et al';
     }
   }
 
-  return $new_authors;
+  return $trimmed_authors;
 }
 
 sub get_epmc_data{
@@ -533,8 +533,8 @@ sub check_dbSNP{
         }
 
         # format authors list
-        my $new_authors = format_authors($ref->{resultList}->{result}->{authorString});
-        $ref->{resultList}->{result}->{authorString} = $new_authors unless !$new_authors;
+        my $trimmed_author_list = trim_author_list($ref->{resultList}->{result}->{authorString});
+        $ref->{resultList}->{result}->{authorString} = $trimmed_author_list if $trimmed_author_list;
 
         $pub_upd_sth->execute( $ref->{resultList}->{result}->{title},
                                $ref->{resultList}->{result}->{pmcid},
@@ -1007,8 +1007,8 @@ sub parse_UCSC_file{
         next if $section =~/refs|ack/; ## not in this publication
 
         # format authors list
-        my $new_authors = format_authors($authors);
-        $authors = $new_authors unless !$new_authors;
+        my $trimmed_author_list = trim_author_list($authors);
+        $authors = $trimmed_author_list if $trimmed_author_list;
 
         $pmid = "" if $pmid eq "0";  ## nulls are set to 0 in UCSC database
 

--- a/scripts/import/import_EPMC.pl
+++ b/scripts/import/import_EPMC.pl
@@ -346,7 +346,28 @@ sub get_publication_info_from_epmc{
          return undef;
     }
 
+    ### format authors list
+    my $new_authors = format_authors($ref->{resultList}->{result}->{authorString});
+    $ref->{resultList}->{result}->{authorString} = $new_authors unless !$new_authors;
+
     return $ref;
+}
+
+# Format authors list
+# only store the first 6 authors
+sub format_authors{
+  my $authors_final = shift;
+
+  my $new_authors;
+
+  if(defined $authors_final){
+    my @author_list = split /, /, $authors_final;
+    if(scalar @author_list > 6) {
+      $new_authors = join(', ', @author_list[0..5]) . ', et al';
+    }
+  }
+
+  return $new_authors;
 }
 
 sub get_epmc_data{
@@ -510,6 +531,10 @@ sub check_dbSNP{
             $ref->{resultList}->{result}->{title} !~/$species_string/i){
             print $error_log "WARN dbSNP data:\t$l->[1]\t($ref->{resultList}->{result}->{title}) - species not mentioned\n"
         }
+
+        # format authors list
+        my $new_authors = format_authors($ref->{resultList}->{result}->{authorString});
+        $ref->{resultList}->{result}->{authorString} = $new_authors unless !$new_authors;
 
         $pub_upd_sth->execute( $ref->{resultList}->{result}->{title},
                                $ref->{resultList}->{result}->{pmcid},
@@ -980,6 +1005,10 @@ sub parse_UCSC_file{
         #my ($rs, $pmid, $section, $doi, $title, $authors, $year ) = split/\s+\|\s+|\t/;
         my ($rs, $pmid, $section, $doi, $title, $authors, $year, $extId ) = split/\t/;
         next if $section =~/refs|ack/; ## not in this publication
+
+        # format authors list
+        my $new_authors = format_authors($authors);
+        $authors = $new_authors unless !$new_authors;
 
         $pmid = "" if $pmid eq "0";  ## nulls are set to 0 in UCSC database
 


### PR DESCRIPTION
Format authors to store the first 4 authors. If longer than 4, include 'et al'. 
ENSVAR-4182