### PR TITLE
Task105/update remap read coverage

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/BaseRemapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/BaseRemapping.pm
@@ -105,32 +105,6 @@ sub run_cmd {
   }
 }
 
-sub get_individual_name {
-  my $self = shift;
-  my $individual_id = shift;
-  my $vdba = $self->param('vdba_oldasm');
-  my $dbname = $vdba->dbc->dbname();
-  my $dbh = $vdba->dbc->db_handle();
-
-  my $column = 'sample_id';
-  my $table = 'sample';
-  my $column_names = $self->get_column_names($dbh, $dbname, 'individual');
-  if (grep /individual_id/, @$column_names) {
-    $column = 'individual_id';
-    $table = 'individual';
-  }
-
-  my $sth = $dbh->prepare(qq{SELECT name FROM $table where $column=$individual_id;});
-  my @names = ();
-  $sth->execute();
-  while (my $row = $sth->fetchrow_arrayref) {
-    push @names, $row->[0];
-  }
-  $sth->finish();
-  die ("Wrong number of names for individiual_id: $individual_id in DB: $dbname: " . scalar @names) if ((scalar @names) != 1);
-  return $names[0];
-}
-
 sub get_column_names {
   my ($self, $dbh, $dbname, $table_name) = @_;
   my $query = qq{SHOW columns FROM $dbname.$table_name};

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/FilterMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/FilterMapping.pm
@@ -43,13 +43,13 @@ sub fetch_input {
     fasta_files_dir       => 'fasta_file',
   };
   my $file_number = $self->param('file_number');
-  my $individual_dir = '';
+  my $sample_dir = '';
   if ($self->param('mode') eq 'remap_read_coverage') {
-    my $individual_id = $self->param('individual_id');
-    $individual_dir = "/$individual_id/";
+    my $sample_id = $self->param('sample_id');
+    $sample_dir = "/$sample_id/";
   }
   foreach my $param (keys %$params) {
-    my $dir = $self->param($param) . $individual_dir;
+    my $dir = $self->param($param) . $sample_dir;
     if ($param =~ /mapping_results_dir/) {
       my $file_mappings = "$dir/mappings_$file_number.txt";
       my $file_failed_mappings = "$dir/failed_mapping_$file_number.txt";
@@ -140,7 +140,6 @@ sub print_complete_feature_line {
   my $variation_feature_id = $data->{variation_feature_id};
   $data->{variation_feature_id_old} = $variation_feature_id;
   my @output = ();
-#  $self->warning(join(', ', keys %$data));
   foreach my $column_name (sort keys %$data) {
     unless ($column_name =~ /^variation_feature_id$/ || $column_name =~ /^seq_region_name$/) {
       if ($self->param('mode') eq 'remap_QTL') {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/InitFilterMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/InitFilterMapping.pm
@@ -42,29 +42,26 @@ sub write_output {
   my $statistics_dir = $self->param('statistics_dir');
   if ($self->param('mode') eq 'remap_read_coverage') {
     my @input = ();
-    opendir (IND_DIR, $mapping_results_dir) or die $!;
-    while (my $individual_dir = readdir(IND_DIR)) {
-      next if ($individual_dir =~ /^\./);
-      my $individual_name = $self->get_individual_name($individual_dir);
-      die "Couldn't fetch individual with ID: $individual_dir" unless($individual_dir);
-      make_path("$filtered_mappings_dir/$individual_dir") or die "Failed to create $filtered_mappings_dir/$individual_dir $!";
-      make_path("$load_features_dir/$individual_dir") or die "Failed to create $load_features_dir/$individual_dir $!";
-      make_path("$statistics_dir/$individual_dir") or die "Failed to create $statistics_dir/$individual_dir $!";
+    opendir (SAMPLE_DIR, $mapping_results_dir) or die $!;
+    while (my $sample_dir = readdir(SAMPLE_DIR)) {
+      next if ($sample_dir =~ /^\./);
+      make_path("$filtered_mappings_dir/$sample_dir") or die "Failed to create $filtered_mappings_dir/$sample_dir $!";
+      make_path("$load_features_dir/$sample_dir") or die "Failed to create $load_features_dir/$sample_dir $!";
+      make_path("$statistics_dir/$sample_dir") or die "Failed to create $statistics_dir/$sample_dir $!";
 
-      my $count_mappings_files =  $self->compare_file_counts("$mapping_results_dir/$individual_dir");
+      my $count_mappings_files =  $self->compare_file_counts("$mapping_results_dir/$sample_dir");
       my $file_number = 1;
       while ($file_number <= $count_mappings_files) {
-        die "No such file $mapping_results_dir/$individual_dir/mappings_$file_number.txt" unless (-e "$mapping_results_dir/$individual_dir/mappings_$file_number.txt");
-        die "No such file $mapping_results_dir/$individual_dir/failed_mapping_$file_number.txt" unless (-e "$mapping_results_dir/$individual_dir/failed_mapping_$file_number.txt");
+        die "No such file $mapping_results_dir/$sample_dir/mappings_$file_number.txt" unless (-e "$mapping_results_dir/$sample_dir/mappings_$file_number.txt");
+        die "No such file $mapping_results_dir/$sample_dir/failed_mapping_$file_number.txt" unless (-e "$mapping_results_dir/$sample_dir/failed_mapping_$file_number.txt");
         push @input, {
           'file_number' => $file_number,
-          'individual_id' => $individual_dir,
-          'individual_name' => $individual_name,
+          'sample_id' => $sample_dir,
         };
         $file_number++;
       }
     }
-    closedir(IND_DIR);
+    closedir(SAMPLE_DIR);
     $self->dataflow_output_id(\@input, 2);
   } else {
     my $count_mappings_files = $self->compare_file_counts($mapping_results_dir);

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/InitReadCoverageMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/InitReadCoverageMapping.pm
@@ -50,19 +50,19 @@ sub write_output {
   my $bam_files_dir   = $self->param('bam_files_dir');
   my @jobs = ();
 
-  opendir (IND_DIR, $fasta_files_dir) or die $!;
-  while (my $individual_dir = readdir(IND_DIR)) {
-    next if ($individual_dir =~ /^\./);
-    make_path("$bam_files_dir/$individual_dir") or die "Failed to create dir $bam_files_dir/$individual_dir $!";;
-    opendir(DIR, "$fasta_files_dir/$individual_dir") or die $!;
+  opendir (SAMPLE_DIR, $fasta_files_dir) or die $!;
+  while (my $sample_dir = readdir(SAMPLE_DIR)) {
+    next if ($sample_dir =~ /^\./);
+    make_path("$bam_files_dir/$sample_dir") or die "Failed to create dir $bam_files_dir/$sample_dir $!";;
+    opendir(DIR, "$fasta_files_dir/$sample_dir") or die $!;
     while (my $file = readdir(DIR)) {
       if ($file =~ /^(.+)\.fa$/) {
         my $file_number = $1;
-        my $bam_files_dir = "$bam_files_dir/$individual_dir/";
+        my $bam_files_dir = "$bam_files_dir/$sample_dir/";
         push @jobs, {
           'file_number'   => $file_number,
           'bam_files_dir' => $bam_files_dir,
-          'fasta_file'    => "$fasta_files_dir/$individual_dir/$file_number.fa",
+          'fasta_file'    => "$fasta_files_dir/$sample_dir/$file_number.fa",
           'sam_file'      => "$bam_files_dir/$file_number.sam",
           'bam_file'      => "$bam_files_dir/$file_number.bam",
           'err_file'      => "$bam_files_dir/$file_number.err",
@@ -80,7 +80,7 @@ sub write_output {
 sub generate_remap_read_coverage_input {
   my $self = shift;
 
-  my $old_assembly_fasta_file_dir = $self->param('old_assembly_fasta_file_dir');
+  my $old_assembly_fasta_file_dir = $self->param('old_assembly_dir');
   my $fasta_db = Bio::DB::Fasta->new($old_assembly_fasta_file_dir, -reindex => 1);
   $self->param('fasta_db', $fasta_db);
 
@@ -91,16 +91,16 @@ sub generate_remap_read_coverage_input {
   my $fh_report_non_ref_entries = FileHandle->new("$pipeline_dir/report_non_ref_entries.txt", 'w'); 
 
   my $strand = 1;
-  opendir (IND_DIR, $dump_features_dir) or die $!;
-  while (my $individual_dir = readdir(IND_DIR)) {
-    next if ($individual_dir =~ /^\./);
-    make_path("$fasta_files_dir/$individual_dir") or die "Failed to create dir $fasta_files_dir/$individual_dir $!";;
-    opendir(DIR, "$dump_features_dir/$individual_dir") or die $!;
+  opendir (SAMPLE_DIR, $dump_features_dir) or die $!;
+  while (my $sample_dir = readdir(SAMPLE_DIR)) {
+    next if ($sample_dir =~ /^\./);
+    make_path("$fasta_files_dir/$sample_dir") or die "Failed to create dir $fasta_files_dir/$sample_dir $!";;
+    opendir(DIR, "$dump_features_dir/$sample_dir") or die $!;
     while (my $file = readdir(DIR)) {
       if ($file =~ /^(.+)\.txt$/) {
         my $file_number = $1;
-        my $fh = FileHandle->new("$dump_features_dir/$individual_dir/$file", 'r');
-        my $fh_fasta_file = FileHandle->new("$fasta_files_dir/$individual_dir/$file_number.fa", 'w');
+        my $fh = FileHandle->new("$dump_features_dir/$sample_dir/$file", 'r');
+        my $fh_fasta_file = FileHandle->new("$fasta_files_dir/$sample_dir/$file_number.fa", 'w');
         while (<$fh>) {
           chomp;
           my $data = $self->read_line($_);
@@ -148,94 +148,40 @@ sub generate_remap_read_coverage_input {
 sub dump_read_coverage {
   my $self = shift;
 
-  my $vdba = $self->param('vdba');
+  my $vdba = $self->param('vdba_oldasm');
   my $dbname = $vdba->dbc->dbname();
   my $dbh = $vdba->dbc->db_handle;
 
-  # get individiual_ids in old read coverage table
-  my $individual_id = 'sample_id';
-  my $individual_table = 'sample';
-  my $table_names = get_table_names($dbh, $dbname);
-  my $rc_individual_ids;
-  if (grep /read_coverage/, @$table_names) {
-    my $column_names = get_column_names($dbh, $dbname, 'read_coverage');
-    if (grep /individual_id/, @$column_names) {
-      $individual_id = 'individual_id';
-      $individual_table = 'individual';
-    }
-  # get strain names and number of reads
-    my $query = qq{
-      SELECT distinct $individual_id FROM read_coverage
-    };
-    $rc_individual_ids = run_query($dbh, $query);
-  }
-  my $rc_individual_ids_hash = {};
-  foreach my $id (@$rc_individual_ids) {
-    $rc_individual_ids_hash->{$id} = 1;
-  }
-
-  my $name_to_id = {};
-
-  my @individual_names = split(',', $self->param('individuals'));
-  if (scalar @individual_names > 0) {
-    foreach my $name (@individual_names) {
-      my $ids = $self->get_individual_ids($name);
-      my $count = 0;
-      foreach my $id (@$ids) {
-        if ($rc_individual_ids_hash->{$id}) {
-          $name_to_id->{$name} = $id;
-          $count++;
-        } 
-      }
-      die "Too many individual ids in table for $name" unless ($count == 1);
-    } 
-  } else {
-    foreach my $id (keys %$rc_individual_ids_hash) {
-      my $name = $self->get_individual_name($id);
-      $name_to_id->{$name} = $id;
-      push @individual_names, $name;
-    }
-  }
-
-  $individual_id = 'sample_id';
-  $individual_table = 'sample';
-  $table_names = get_table_names($dbh, $dbname);
-  if (grep /read_coverage/, @$table_names) {
-    my $column_names = get_column_names($dbh, $dbname, 'read_coverage');
-    if (grep /individual_id/, @$column_names) {
-      $individual_id = 'individual_id';
-      $individual_table = 'individual';
-    }
-  } else {
-    die "No read_coverage table in $dbname";
-  }
+  my $query = qq{
+    SELECT distinct sample_id FROM read_coverage
+  };
+  my $sample_ids = $self->run_query($dbh, $query);
 
   my $sth = $dbh->prepare(qq{
-      SELECT rc.seq_region_id, rc.seq_region_start, rc.seq_region_end, rc.level, rc.$individual_id, i.name, sr.name
-      FROM read_coverage rc, seq_region sr, $individual_table i
+      SELECT rc.seq_region_id, rc.seq_region_start, rc.seq_region_end, rc.level, rc.sample_id, s.name, sr.name
+      FROM read_coverage rc, seq_region sr, sample s
       WHERE rc.seq_region_id = sr.seq_region_id
-      AND rc.$individual_id = i.$individual_id
-      AND i.name = ?; 
+      AND rc.sample_id = s.sample_id
+      AND s.sample_id = ?;
       }, {mysql_use_result => 1});
   $sth->execute();
 
-  my @keys = ('seq_region_id', 'seq_region_start', 'seq_region_end', 'level', 'individual_id', 'individual_name', 'seq_region_name');
+  my @keys = ('seq_region_id', 'seq_region_start', 'seq_region_end', 'level', 'sample_id', 'sample_name', 'seq_region_name');
 
   my $dump_features_dir = $self->param('dump_features_dir');
   my $entry = 1;
-  foreach my $individual_name (@individual_names) {
+  foreach my $sample_id (@$sample_ids) {
     my $file_count = 1;
     my $entries_per_file = $self->param('entries_per_file');
     my $count_entries = 0;
-    my $individual_id = $name_to_id->{$individual_name};
 
-    unless (-d "$dump_features_dir/$individual_id") {
-      make_path("$dump_features_dir/$individual_id") or die "Failed to create dir $dump_features_dir/$individual_id $!";;
+    unless (-d "$dump_features_dir/$sample_id") {
+      make_path("$dump_features_dir/$sample_id") or die "Failed to create dir $dump_features_dir/$sample_id $!";;
     }
 
-    my $fh = FileHandle->new("$dump_features_dir/$individual_id/$file_count.txt", 'w');
+    my $fh = FileHandle->new("$dump_features_dir/$sample_id/$file_count.txt", 'w');
 
-    $sth->execute($individual_name);
+    $sth->execute($sample_id);
     while (my $row = $sth->fetchrow_arrayref) {
       my @values = map { defined $_ ? $_ : '\N' } @$row;
       my @pairs = ();
@@ -247,7 +193,7 @@ sub dump_read_coverage {
       if ($count_entries >= $entries_per_file) {
         $fh->close();
         $file_count++;
-        $fh = FileHandle->new("$dump_features_dir/$individual_id/$file_count.txt", 'w');
+        $fh = FileHandle->new("$dump_features_dir/$sample_id/$file_count.txt", 'w');
         $count_entries = 0;
       }
       $count_entries++;
@@ -256,62 +202,6 @@ sub dump_read_coverage {
     $fh->close();
     $sth->finish();
   }
-}
-
-sub get_individual_ids {
-  my $self = shift;
-  my $individual_name = shift;
-  $self->warning($individual_name);
-  my $vdba = $self->param('vdba');
-
-  my $dbname = $vdba->dbc->dbname();
-  my $dbh = $vdba->dbc->db_handle();
-
-  my $column = 'sample_id';
-  my $table = 'sample';
-
-  my $column_names = get_column_names($dbh, $dbname, 'individual');
-  if (grep /individual_id/, @$column_names) {
-    $column = 'individual_id';
-    $table = 'individual';
-  }
-  my $sth = $dbh->prepare(qq{SELECT $column FROM $table where name='$individual_name';});
-
-  my @ids = ();
-  $sth->execute();
-  while (my $row = $sth->fetchrow_arrayref) {
-    push @ids, $row->[0];
-  }
-  $sth->finish();
-  return \@ids;
-}
-
-sub get_individual_name {
-  my $self = shift;
-  my $individual_id = shift;
-  $self->warning($individual_id);
-  my $vdba = $self->param('vdba');
-
-  my $dbname = $vdba->dbc->dbname();
-  my $dbh = $vdba->dbc->db_handle();
-
-  my $column = 'sample_id';
-  my $table = 'sample';
-
-  my $column_names = get_column_names($dbh, $dbname, 'individual');
-  if (grep /individual_id/, @$column_names) {
-    $column = 'individual_id';
-    $table = 'individual';
-  }
-  my $sth = $dbh->prepare(qq{SELECT name FROM $table where $column=$individual_id;});
-
-  my @names = ();
-  $sth->execute();
-  while (my $row = $sth->fetchrow_arrayref) {
-    push @names, $row->[0];
-  }
-  $sth->finish();
-  return $names[0];
 }
 
 1;

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/LoadMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/LoadMapping.pm
@@ -88,6 +88,14 @@ sub load_read_coverage {
   $dbc->do(qq{ ALTER TABLE $result_table ENABLE KEYS});
 
   $self->rename_mapped_feature_table;
+
+  # We can end up with multiple mappings for the same read. In that
+  # case we only keep one copy and remove all duplicates.
+
+  $dbc->do(qq{ RENAME TABLE $feature_table TO $feature_table\_dup;});
+  $dbc->do(qq{ CREATE TABLE $feature_table LIKE $feature_table\_dup;});
+  $dbc->do(qq{ INSERT INTO $feature_table SELECT DISTINCT * FROM $feature_table\_dup;});
+  $dbc->do(qq{ DROP TABLE $feature_table\_dup;});
 }
 
 sub load_mapping_results {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/LoadMapping.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/LoadMapping.pm
@@ -65,10 +65,10 @@ sub load_read_coverage {
   my @column_names = @{$self->get_sorted_column_names($vdba, $result_table)};
   my $column_names_concat = join(',', @column_names);
 
-  opendir(IND_DIR, $load_features_dir) or die $!;
-  while (my $individual_dir = readdir(IND_DIR))  {
-    next if ($individual_dir =~ /^\./);
-    my $dir = "$load_features_dir/$individual_dir";
+  opendir(SAMPLE_DIR, $load_features_dir) or die $!;
+  while (my $sample_dir = readdir(SAMPLE_DIR))  {
+    next if ($sample_dir =~ /^\./);
+    my $dir = "$load_features_dir/$sample_dir";
     opendir(DIR, $dir) or die $!;
     while (my $file = readdir(DIR)) {
       if ($file =~ /^(.+)\.txt$/) {
@@ -86,6 +86,8 @@ sub load_read_coverage {
   closedir(IND_DIR);
 
   $dbc->do(qq{ ALTER TABLE $result_table ENABLE KEYS});
+
+  $self->rename_mapped_feature_table;
 }
 
 sub load_mapping_results {

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingReadCoverage_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingReadCoverage_conf.pm
@@ -20,12 +20,12 @@ limitations under the License.
  <http://www.ensembl.org/Help/Contact>.
 =cut
 
-package Bio::EnsEMBL::Variation::Pipeline::Remapping::RemappingVariationFeature_conf;
+package Bio::EnsEMBL::Variation::Pipeline::Remapping::RemappingReadCoverage_conf;
 
 use strict;
 use warnings;
 
-use base ('Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf');
+use base ('Bio::EnsEMBL::Variation::Pipeline::Remapping::Remapping_conf');
 
 sub default_options {
     my ($self) = @_;
@@ -38,57 +38,23 @@ sub default_options {
 # these values, if you find you do need to then we should probably
 # make it an option here, contact the variation team to discuss
 # this - patches are welcome!
+#
+
     return {
-        hive_force_init         => 1,
-        hive_use_param_stack    => 0,
-        hive_use_triggers       => 0,
-        hive_auto_rebalance_semaphores => 0,  # do not attempt to rebalance semaphores periodically by default
-        hive_no_init            => 0, # setting it to 1 will skip pipeline_create_commands (useful for topping up)
-        hive_root_dir           => $ENV{'HOME'} . '/bin/ensembl-hive',
-        ensembl_cvs_root_dir    => $ENV{'HOME'} . '/bin',
-        hive_db_port            => 4521,
-        hive_db_user            => 'ensadmin',
-        hive_db_host            => 'mysql-ens-var-prod-2.ebi.ac.uk',
-        debug                   => 0,
-        debug_sequence_name     => 3,
-        run_variant_qc          => 1,
-        use_fasta_files         => 0,
-        flank_seq_length        => 150,
-        algn_score_threshold    => 0.95,
-        max_map_weight          => 5,
-        use_prior_for_filtering => 1,
-        map_to_chrom_only       => 1,
-        entries_per_file        => 200000,
-        mode                    => 'remap_db_table', # options: remap_db_table (default), remap_multi_map, remap_alt_loci, remap_read_coverage, remap_post_projection, remap_svf_post_projection, remap_svf, remap_qtls
-        bwa_location            => 'bwa',
-        samtools_location       => 'samtools',
-        dump_multi_map          => 1,
-        feature_table           => 'variation_feature',
-        feature_table_failed_projection => 0, #'variation_feature_failed'
-        feature_table_projection => 0, #'variation_feature_projection',
-        individuals             => '',
-        pipeline_dir            => $self->o('pipeline_dir'),
-        bam_files               => $self->o('pipeline_dir') . '/bam_files',
-        dump_features           => $self->o('pipeline_dir') . '/dump_features',
-        fasta_files             => $self->o('pipeline_dir') . '/fasta_files',
-        filtered_mappings       => $self->o('pipeline_dir') . '/filtered_mappings',
-        load_features           => $self->o('pipeline_dir') . '/load_features',
-        mapping_results         => $self->o('pipeline_dir') . '/mapping_results', 
-        statistics              => $self->o('pipeline_dir') . '/statistics',   
-        dump_mapped_features    => $self->o('pipeline_dir') . '/dump_mapped_features',
-        qc_failure_reasons      => $self->o('pipeline_dir') . '/qc_failure_reasons',
-        qc_mapped_features      => $self->o('pipeline_dir') . '/qc_mapped_features',
-        qc_update_features      => $self->o('pipeline_dir') . '/qc_update_features',
-
-
-        pipeline_db => {
-            -host   => $self->o('hive_db_host'),
-            -port   => $self->o('hive_db_port'),
-            -user   => $self->o('hive_db_user'),
-            -pass   => $self->o('hive_db_password'),            
-            -dbname => $ENV{'USER'} . '_' . $self->o('pipeline_name'),
-            -driver => 'mysql',
-        },
+      %{ $self->SUPER::default_options() },
+      mode                    => 'remap_read_coverage',
+      debug                   => 0,
+      debug_sequence_name     => 3,
+      flank_seq_length        => 150,
+      algn_score_threshold    => 0.95,
+      max_map_weight          => 5,
+      use_prior_for_filtering => 1,
+      map_to_chrom_only       => 1,
+      entries_per_file        => 200000,
+      feature_table           => 'read_coverage',
+      feature_table_mapping_results => 'read_coverage_mapping_results',
+      qc_mapped_features      => $self->o('pipeline_dir') . '/qc_mapped_features',
+      hive_db_name            => $ENV{'USER'} . '_ehive_remapping_rc_' . $self->o('ensembl_release') . '_' . $self->o('assembly') . '_' . $self->o('species'),
     };
 }
 
@@ -97,40 +63,17 @@ sub pipeline_wide_parameters {
     return {
         %{$self->SUPER::pipeline_wide_parameters},          # here we inherit anything from the base class
         mode                         => $self->o('mode'),
-        registry_file_oldasm         => $self->o('registry_file_oldasm'),
-        registry_file_newasm         => $self->o('registry_file_newasm'),
-        dump_features_dir            => $self->o('dump_features'),
-        dump_mapped_features_dir     => $self->o('dump_mapped_features'),
-        filtered_mappings_dir        => $self->o('filtered_mappings'),
-        load_features_dir            => $self->o('load_features'),
-        statistics_dir               => $self->o('statistics'),
-        fasta_files_dir              => $self->o('fasta_files'),
-        bam_files_dir                => $self->o('bam_files'),
-        mapping_results_dir          => $self->o('mapping_results'),
-        old_assembly_fasta_file_dir  => $self->o('old_assembly'),
-        new_assembly_fasta_file_dir  => $self->o('new_assembly'),
-        new_assembly_fasta_file_name => $self->o('new_assembly_file_name'),
-        species                      => $self->o('species'),
-        bwa_dir                      => $self->o('bwa_location'),
-        samtools_dir                 => $self->o('samtools_location'),
-        pipeline_dir                 => $self->o('pipeline_dir'),
-        flank_seq_length             => $self->o('flank_seq_length'),	
-        use_fasta_files              => $self->o('use_fasta_files'),
-        feature_table                => $self->o('feature_table'),
-        feature_table_projection     => $self->o('feature_table_projection'),
-        feature_table_failed_projection => $self->o('feature_table_failed_projection'),
-        individuals                  => $self->o('individuals'),
-        algn_score_threshold         => $self->o('algn_score_threshold'),
-        max_map_weight               => $self->o('max_map_weight'),
-        use_prior_for_filtering      => $self->o('use_prior_for_filtering'),
-        map_to_chrom_only            => $self->o('map_to_chrom_only'),
-        entries_per_file             => $self->o('entries_per_file'),
-        debug                        => $self->o('debug'),
-        debug_sequence_name          => $self->o('debug_sequence_name'),
-        dump_multi_map               => $self->o('dump_multi_map'),
-        qc_failure_reasons           => $self->o('qc_failure_reasons'),
-        qc_mapped_features           => $self->o('qc_mapped_features'),
-        qc_update_features           => $self->o('qc_update_features'),
+        flank_seq_length              => $self->o('flank_seq_length'), 
+        feature_table                 => $self->o('feature_table'),
+        feature_table_mapping_results => $self->o('feature_table_mapping_results'),
+        algn_score_threshold          => $self->o('algn_score_threshold'),
+        max_map_weight                => $self->o('max_map_weight'),
+        use_prior_for_filtering       => $self->o('use_prior_for_filtering'),
+        map_to_chrom_only             => $self->o('map_to_chrom_only'),
+        entries_per_file              => $self->o('entries_per_file'),
+        debug                         => $self->o('debug'),
+        debug_sequence_name           => $self->o('debug_sequence_name'),
+        qc_mapped_features_dir        => $self->o('qc_mapped_features'),
     };
 }
 
@@ -147,9 +90,10 @@ sub pipeline_analyses {
     my ($self) = @_;
     my @analyses;
     push @analyses, (
-        {
+  {
             -logic_name => 'pre_run_checks',
             -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::PreRunChecks',
+            -max_retry_count  => 0,
             -input_ids  => [{},],
             -flow_into  => {
                 1 => ['init_mapping']
@@ -157,34 +101,28 @@ sub pipeline_analyses {
         },
         {   
             -logic_name        => 'init_mapping', 
-            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::InitVariationFeatureMapping',
+            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::InitReadCoverageMapping',
             -rc_name           => 'default_mem',
             -analysis_capacity => 5,
+            -max_retry_count  => 0,
             -flow_into => { 
                 '2->A' => ['run_mapping'],
-                'A->1' => ['finish_mapping']
-            },		
+                'A->1' => ['init_parse_mapping']
+            },    
         },
         {
             -logic_name => 'run_mapping',
             -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::RunMapping',
             -rc_name    => 'high_mem',
         },
-        {	
-            -logic_name => 'finish_mapping',
-            -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FinishMapping',
-            -flow_into  => {
-              1 => ['init_parse_mapping'],
-            },
-        },
-{
+        {
             -logic_name        => 'init_parse_mapping', 
             -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::InitParseMapping',
             -rc_name           => 'default_mem',
             -analysis_capacity => 5,
             -flow_into => { 
                 '2->A' => ['parse_mapping'],
-                'A->1' => ['finish_parse_mapping']
+                'A->1' => ['init_filter_mapping']
             },    
         },
         {
@@ -194,14 +132,8 @@ sub pipeline_analyses {
             -rc_name           => 'default_mem',
         },
         {
-            -logic_name => 'finish_parse_mapping',
-            -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FinishParseMapping',
-            -flow_into => {
-                1 => ['init_filter_mapping'],
-            },
-        },
-        {
             -logic_name        => 'init_filter_mapping',
+            -max_retry_count   => 0,
             -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::InitFilterMapping',
             -rc_name           => 'default_mem',
             -analysis_capacity => 5,
@@ -212,7 +144,8 @@ sub pipeline_analyses {
         },
         {
             -logic_name        => 'filter_mapping',
-            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FilterVariationFeatureMapping',
+            -max_retry_count   => 0,
+            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FilterReadCoverageMapping',
             -analysis_capacity => 5,
             -rc_name           => 'default_mem',
         },
@@ -226,31 +159,7 @@ sub pipeline_analyses {
         {
           -logic_name => 'load_mapping',
           -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::LoadMapping',
-          -flow_into => {
-                1 => ['init_variant_qc'],
-          },
-        },
-        {
-            -logic_name        => 'init_variant_qc',
-            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::InitVariationFeatureQC',
-            -rc_name           => 'default_mem',
-            -analysis_capacity => 5,
-            -flow_into => {
-                '2->A' => ['variant_qc'],
-                'A->1' => ['finish_variant_qc']
-            },
-        },
-        {
-            -logic_name        => 'variant_qc',
-            -module            => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::VariationFeatureQC',
-            -analysis_capacity => 5,
-            -rc_name           => 'default_mem',
-        },
-        {
-            -logic_name => 'finish_variant_qc',
-            -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FinishVariationFeatureQC',
-        },
-
+        }
     );
    return \@analyses;
 }


### PR DESCRIPTION
the read coverage remapping code was outdated. Updates include:
-- make RemappingReadCoverage_conf.pm  inherit from Remapping_conf.pm
-- the code was still supporting individual ids in the read coverage table. Replaced all occurrences of individual by sample
-- remap all samples in the read coverage table and don't try to map sample ids between old and new database. This task needs to be done separately if the sample ids have changed between old and new assembly
-- removed unused code