### PR TITLE
Adds SpliceRegion Consequences to main VEP

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
@@ -149,11 +149,14 @@ sub _intron_effects {
           $intron_effects->{intronic} = 1;
         }
         
-        if (overlap($r_start, $r_end, $intron_end-16, $intron_end-2)) {
+        my ($start, $end) = ($r_start, $r_end);
+        ($start, $end) = ($end, $start) if $start > $end;
+
+        if (overlap($start, $end, $intron_end-16, $intron_end-2)) {
           $intron_effects->{polypyrimidine_splice_site} = 1;
         }
         
-        if (overlap($r_start, $r_end, $intron_start+2, $intron_start+16)) {
+        if (overlap($start, $end, $intron_start+2, $intron_start+16)) {
           $intron_effects->{polypyrimidine_splice_site_reverse} = 1;
         }
       }

--- a/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
@@ -170,6 +170,31 @@ sub _intron_effects {
           $intron_effects->{end_splice_site} = 1;
         }
         
+        if (overlap($r_start, $r_end, $intron_start+4, $intron_start+4)) {
+          $intron_effects->{fifth_base_splice_site} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_start+2, $intron_start+5)) {
+          $intron_effects->{donor_region_splice_site} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_end-16, $intron_end-2)) {
+          $intron_effects->{polypyrimidine_splice_site} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_end-4, $intron_end-4)) {
+          $intron_effects->{fifth_base_splice_site_reverse} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_end-5, $intron_end-2)) {
+          $intron_effects->{donor_region_splice_site_reverse} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_start+2, $intron_start+16)) {
+          $intron_effects->{polypyrimidine_splice_site_reverse} = 1;
+        }
+        
+        
         # the definition of splice_region (SO:0001630) is "within 1-3 bases 
         # of the exon or 3-8 bases of the intron", the intron start is the 
         # first base of the intron so we only need to add or subtract 7 from 

--- a/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseTranscriptVariationAllele.pm
@@ -145,8 +145,16 @@ sub _intron_effects {
         ($insertion && ($r_start == $intron_start+2 || $r_end == $intron_end-2))
        || overlap($r_start_unshifted, $r_end_unshifted, $intron_start+2, $intron_end-2) || 
       ($insertion && ($r_start_unshifted == $intron_start+2 || $r_end_unshifted == $intron_end-2))
-    ) {
+      ) {
           $intron_effects->{intronic} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_end-16, $intron_end-2)) {
+          $intron_effects->{polypyrimidine_splice_site} = 1;
+        }
+        
+        if (overlap($r_start, $r_end, $intron_start+2, $intron_start+16)) {
+          $intron_effects->{polypyrimidine_splice_site_reverse} = 1;
         }
       }
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
@@ -475,7 +475,7 @@ our @OVERLAP_CONSEQUENCES = (
         label => 'splice polypyrimidine tract variant',
         impact => 'LOW',
         include => {
-            intron_boundary => 1
+            intron => 1
         },
     },
     {

--- a/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
@@ -428,6 +428,57 @@ our @OVERLAP_CONSEQUENCES = (
         },
     },
     {
+        SO_accession => 'SO:0001787',
+        SO_term => 'splice_donor_5th_base_variant',
+        display_term => 'SPLICE_SITE',
+        feature_SO_term => 'primary_transcript',
+        feature_class => 'Bio::EnsEMBL::Transcript',
+        variant_feature_class => 'Bio::EnsEMBL::Variation::VariationFeature',
+        rank => '4',
+        tier => '3',
+        predicate => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_donor_5th_base_variant',
+        description => 'A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript',
+        label => 'splice donor 5th base variant',
+        impact => 'LOW',
+        include => {
+            intron_boundary => 1
+        },
+    },
+    {
+        SO_accession => 'SO:0002170',
+        SO_term => 'splice_donor_region_variant',
+        display_term => 'SPLICE_SITE',
+        feature_SO_term => 'primary_transcript',
+        feature_class => 'Bio::EnsEMBL::Transcript',
+        variant_feature_class => 'Bio::EnsEMBL::Variation::VariationFeature',
+        rank => '14',
+        tier => '3',
+        predicate => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_donor_region_variant',
+        description => 'A sequence variant that falls in the region between the 3rd and 6th base after splice junction (5\' end of intron).',
+        label => 'splice donor region variant',
+        impact => 'LOW',
+        include => {
+            intron_boundary => 1
+        },
+    },
+    {
+        SO_accession => 'SO:0002169',
+        SO_term => 'splice_polypyrimidine_tract_variant',
+        display_term => 'SPLICE_SITE',
+        feature_SO_term => 'primary_transcript',
+        feature_class => 'Bio::EnsEMBL::Transcript',
+        variant_feature_class => 'Bio::EnsEMBL::Variation::VariationFeature',
+        rank => '13',
+        tier => '3',
+        predicate => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_polypyrimidine_tract_variant',
+        description => 'A sequence variant that falls in the polypyrimidine tract at 3\' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)',
+        label => 'splice polypyrimidine tract variant',
+        impact => 'LOW',
+        include => {
+            intron_boundary => 1
+        },
+    },
+    {
         SO_accession => 'SO:0001627',
         SO_term => 'intron_variant',
         display_term => 'INTRONIC',

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -95,6 +95,9 @@ use constant SO_TERM_DOWNSTREAM_GENE_VARIANT => 'downstream_gene_variant';
 use constant SO_TERM_SPLICE_DONOR_VARIANT => 'splice_donor_variant';
 use constant SO_TERM_SPLICE_ACCEPTOR_VARIANT => 'splice_acceptor_variant';
 use constant SO_TERM_SPLICE_REGION_VARIANT => 'splice_region_variant';
+use constant SO_TERM_SPLICE_DONOR_5TH_BASE_VARIANT => 'splice_donor_5th_base_variant';
+use constant SO_TERM_SPLICE_DONOR_REGION_VARIANT => 'splice_donor_region_variant';
+use constant SO_TERM_SPLICE_POLYPYRIMIDINE_TRACT_VARIANT => 'splice_polypyrimidine_tract_variant';
 use constant SO_TERM_INTRON_VARIANT => 'intron_variant';
 use constant SO_TERM_5_PRIME_UTR_VARIANT => '5_prime_UTR_variant';
 use constant SO_TERM_3_PRIME_UTR_VARIANT => '3_prime_UTR_variant';
@@ -493,6 +496,60 @@ our %OVERLAP_CONSEQUENCES = (
                },
   'label' => 'splice region variant',
   'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_region',
+  'rank' => '13',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
+}
+),
+'splice_donor_5th_base_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
+  'SO_accession' => 'SO:0001787',
+  'SO_term' => 'splice_donor_5th_base_variant',
+  'description' => 'A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript',
+  'display_term' => 'SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
+  'include' => {
+                 'intron_boundary' => 1
+               },
+  'label' => 'splice donor 5th base variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_donor_5th_base_variant',
+  'rank' => '4',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
+}
+),
+'splice_donor_region_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
+  'SO_accession' => 'SO:0002170',
+  'SO_term' => 'splice_donor_region_variant',
+  'description' => 'A sequence variant that falls in the region between the 3rd and 6th base after splice junction (5\' end of intron).',
+  'display_term' => 'SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
+  'include' => {
+                 'intron_boundary' => 1
+               },
+  'label' => 'splice donor region variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_donor_region_variant',
+  'rank' => '14',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
+}
+),
+'splice_polypyrimidine_tract_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
+  'SO_accession' => 'SO:0001630',
+  'SO_term' => 'splice_polypyrimidine_tract_variant',
+  'description' => 'A sequence variant that falls in the polypyrimidine tract at 3\' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)',
+  'display_term' => 'SPLICE_SITE',
+  'feature_SO_term' => 'primary_transcript',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'LOW',
+  'include' => {
+                 'intron_boundary' => 1
+               },
+  'label' => 'splice polypyrimidine tract variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_polypyrimidine_tract_variant',
   'rank' => '13',
   'tier' => '3',
   'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -538,7 +538,7 @@ our %OVERLAP_CONSEQUENCES = (
 }
 ),
 'splice_polypyrimidine_tract_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
-  'SO_accession' => 'SO:0001630',
+  'SO_accession' => 'SO:0002169',
   'SO_term' => 'splice_polypyrimidine_tract_variant',
   'description' => 'A sequence variant that falls in the polypyrimidine tract at 3\' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)',
   'display_term' => 'SPLICE_SITE',

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -546,13 +546,13 @@ our %OVERLAP_CONSEQUENCES = (
   'feature_class' => 'Bio::EnsEMBL::Transcript',
   'impact' => 'LOW',
   'include' => {
-                 'intron_boundary' => 1
+                 'intron' => 1
                },
   'label' => 'splice polypyrimidine tract variant',
   'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_polypyrimidine_tract_variant',
   'rank' => '13',
   'tier' => '3',
-  'variant_feature_class' => 'Bio::EnsEMBL::Variation::VariationFeature'
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }
 ),
 'intron_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -505,6 +505,34 @@ sub essential_splice_site {
     return ( acceptor_splice_site(@_) or donor_splice_site(@_) );
 }
 
+sub splice_donor_5th_base_variant {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    $bvfo ||= $bvfoa->base_variation_feature_overlap;
+    $feat ||= $bvfo->feature;
+    my $ie = $bvfoa->_intron_effects($feat, $bvfo, $bvf);
+
+    return $feat->strand == 1 ? $ie->{fifth_base_splice_site} : $ie->{fifth_base_splice_site_reverse};
+}
+
+sub splice_donor_region_variant {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    $bvfo ||= $bvfoa->base_variation_feature_overlap;
+    $feat ||= $bvfo->feature;
+    my $ie = $bvfoa->_intron_effects($feat, $bvfo, $bvf);
+    
+    return 0 if splice_donor_5th_base_variant(@_);
+    return $feat->strand == 1 ? $ie->{donor_region_splice_site} : $ie->{donor_region_splice_site_reverse};
+}
+
+sub splice_polypyrimidine_tract_variant  {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    $bvfo ||= $bvfoa->base_variation_feature_overlap;
+    $feat ||= $bvfo->feature;
+    my $ie = $bvfoa->_intron_effects($feat, $bvfo, $bvf);
+
+    return $feat->strand == 1 ? $ie->{polypyrimidine_splice_site} : $ie->{polypyrimidine_splice_site_reverse};
+}
+
 sub splice_region {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvfo ||= $bvfoa->base_variation_feature_overlap;
@@ -512,7 +540,9 @@ sub splice_region {
     return 0 if donor_splice_site(@_);
     return 0 if acceptor_splice_site(@_);
     return 0 if essential_splice_site(@_);
-
+    return 0 if splice_donor_region_variant(@_);
+    return 0 if splice_donor_5th_base_variant(@_);
+    
     return $bvfoa->_intron_effects($feat, $bvfo, $bvf)->{splice_region};
 }
 

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -463,7 +463,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'A',
         start   => $intron_start+2,
         end     => $intron_start+1,
-        effects => [qw(splice_region_variant splice_polypyrimidine_tract_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant)],
     }, {
         comment => 'insertion between bases 7 & 8 is still splice_region',
         alleles => 'A',
@@ -1029,7 +1029,7 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         alleles => 'A',
         start   => $intron_start + 2,
         end     => $intron_start + 1,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant splice_polypyrimidine_tract_variant intron_variant)],
     }, {
         comment => 'insertion between last bases 7 & 8 is still splice_region',
         alleles => 'A',

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -437,7 +437,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
     }, {
         start   => $intron_start+2,
         end     => $intron_start+2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_donor_region_variant intron_variant)],
     }, {
         start   => $intron_start+7,
         end     => $intron_start+7,
@@ -483,11 +483,11 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
     }, {
         start   => $intron_end - 7,
         end     => $intron_end - 7,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_end - 2,
         end     => $intron_end - 2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_end - 1,
         end     => $intron_end - 1,
@@ -531,19 +531,19 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'A',
         start   => $intron_end-6,
         end     => $intron_end-7,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
-        comment => 'insertion between last bases 8 & 9 is just an intron_variant',
+        comment => 'insertion between last bases 8 & 9 is just an intron_variant and splice_polypyrimidine_tract_variant',
         alleles => 'A',
         start   => $intron_end-7,
         end     => $intron_end-8,
-        effects => [qw(intron_variant)],
+        effects => [qw(intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         comment => 'whole exon deletion',
         alleles => '-',
         start   => $exon_start-10,
         end     => $exon_end+10,
-        effects => [qw(intron_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
+        effects => [qw(intron_variant splice_donor_5th_base_variant splice_polypyrimidine_tract_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
     }, {
         comment => 'long sequence var where middle is identical but overlaps splice site',
         alleles => 'ATGTACTGCCTATGTGTGCTGTGAGTATGATACGGTGGACT',
@@ -751,12 +751,12 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_start-3,
         end     => $intron_start+2,
-        effects => [qw( splice_donor_variant coding_sequence_variant intron_variant)],
+        effects => [qw( splice_donor_variant splice_donor_region_variant coding_sequence_variant intron_variant)],
     }, {
         alleles => '-',
         start   => $intron_end-2,
         end     => $intron_end+3,
-        effects => [qw( splice_acceptor_variant coding_sequence_variant  intron_variant)],
+        effects => [qw( splice_acceptor_variant coding_sequence_variant splice_polypyrimidine_tract_variant intron_variant)],
     }, {
         comment => 'deletion overlapping UTR and start site, start lost 1',
         alleles => '-',
@@ -941,7 +941,7 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
     }, {
         start   => $intron_end - 2,
         end     => $intron_end - 2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_donor_region_variant intron_variant)],
     }, {
         start   => $intron_end - 7,
         end     => $intron_end - 7,
@@ -987,11 +987,11 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
     }, {
         start   => $intron_start + 7,
         end     => $intron_start + 7,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_start + 2,
         end     => $intron_start + 2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_start + 1,
         end     => $intron_start + 1,
@@ -1035,13 +1035,13 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         alleles => 'A',
         start   => $intron_start + 7,
         end     => $intron_start + 6,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant intron_variant splice_polypyrimidine_tract_variant)],
     }, {
-        comment => 'insertion between last bases 8 & 9 is just an intron_variant',
+        comment => 'insertion between last bases 8 & 9 is an intron_variant and splice_polypyrimidine_tract_variant',
         alleles => 'A',
         start   => $intron_start + 8,
         end     => $intron_start + 7,
-        effects => [qw(intron_variant)],
+        effects => [qw(intron_variant splice_polypyrimidine_tract_variant)],
     }, 
 
     # check the CDS 
@@ -1237,12 +1237,12 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_end - 2,
         end     => $intron_end + 3,
-        effects => [qw(splice_donor_variant coding_sequence_variant intron_variant)],
+        effects => [qw(splice_donor_variant splice_donor_region_variant coding_sequence_variant intron_variant)],
     }, {
         alleles => '-',
         start   => $intron_start - 3,
         end     => $intron_start + 2,
-        effects => [qw( splice_acceptor_variant coding_sequence_variant intron_variant)],
+        effects => [qw( splice_acceptor_variant splice_polypyrimidine_tract_variant coding_sequence_variant intron_variant)],
     }, {
         alleles => '-',
         start   => $cds_end - 2,
@@ -1287,11 +1287,11 @@ $transcript_tests->{$t3->stable_id}->{tests} = [
     }, {
         start   => $intron_start+2,
         end     => $intron_start+2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_donor_region_variant intron_variant)],
     }, {
         start   => $intron_end - 2,
         end     => $intron_end - 2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant splice_polypyrimidine_tract_variant intron_variant)],
     }, {
         start   => $intron_end - 1,
         end     => $intron_end - 1,

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -479,7 +479,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
     }, {
         start   => $intron_end - 8,
         end     => $intron_end - 8,
-        effects => [qw(intron_variant)],
+        effects => [qw(intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_end - 7,
         end     => $intron_end - 7,
@@ -983,7 +983,7 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
     }, {
         start   => $intron_start + 8,
         end     => $intron_start + 8,
-        effects => [qw(intron_variant)],
+        effects => [qw(intron_variant splice_polypyrimidine_tract_variant)],
     }, {
         start   => $intron_start + 7,
         end     => $intron_start + 7,

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -463,7 +463,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'A',
         start   => $intron_start+2,
         end     => $intron_start+1,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant splice_polypyrimidine_tract_variant intron_variant)],
     }, {
         comment => 'insertion between bases 7 & 8 is still splice_region',
         alleles => 'A',
@@ -525,7 +525,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'T',
         start   => $intron_end-1,
         end     => $intron_end-2,
-        effects => [qw(splice_region_variant intron_variant)],
+        effects => [qw(splice_region_variant splice_polypyrimidine_tract_variant intron_variant)],
     }, {
         comment => 'insertion between last bases 7 & 8 is still splice_region',
         alleles => 'A',


### PR DESCRIPTION
Adds the new consequences:
- splice_donor_5th_base_variant (SO:0001787) 
- splice_donor_region_variant (SO:0002170) 
- splice_polypyrimidine_tract_variant (SO:0002169 )
into the main VEP code. Currently, they can be added through the SpliceRegion plugin.

