### PR TITLE
after removing empty populations remove check for parus major

### DIFF
--- a/scripts/misc/generate_population_table.pl
+++ b/scripts/misc/generate_population_table.pl
@@ -219,7 +219,6 @@ foreach my $species (sort { ($a !~ /Homo/ cmp $b !~ /Homo/) || $a cmp $b } keys(
       # Loop over the populations and add a row for each
       foreach my $pop (@pop_list) {
         next if ($pop_seen{$pop});
-        next if ($species eq 'Parus major' && $pop_data{$pop}{'size'} eq '-');
 
         # Avoid duplicated entries within the same project
         $pop_seen{$pop} = 1;


### PR DESCRIPTION
The bug fix can be reverted now that the empty populations have been remove from the parus major database.
https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4056