### PR TITLE
catch case where mf_start is negative

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/MotifFeatureVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/MotifFeatureVariationAllele.pm
@@ -105,6 +105,7 @@ sub motif_start {
         # check that we're in bounds
 
         return undef if $mf_start > $mf->length;
+        return undef if $mf_start < 1;
         $self->{motif_start} = $mf_start;
     }
     return $self->{motif_start};


### PR DESCRIPTION
Running the funcgen pipeline on codon was causing errors when mf_start was < 1. Returning undef for those cases fixed the error.