### PR TITLE
[Deprecated] Change mart_variation_effect.pl to use DBConnection

### DIFF
--- a/scripts/misc/mart_variation_effect.pl
+++ b/scripts/misc/mart_variation_effect.pl
@@ -26,7 +26,7 @@ Questions may also be sent to the Ensembl help desk at
 
 =cut
 
-
+use Bio::EnsEMBL::DBSQL::DBConnection;
 use DBI;
 use Getopt::Long;
 use ImportUtils qw(load);
@@ -97,15 +97,15 @@ for my $source_table (split(/\s+/, $table_input)) {
 
   foreach my $db (@$filtered_db_list) {
     print "\nProcessing database $db\n";
-    my $dbc = DBI->connect(
-        sprintf(
-          "DBI:mysql(RaiseError=>1):host=%s;port=%s;db=%s",
-          $config->{host},
-          $config->{port},
-          $db,
-          ), $config->{user}, $config->{password}
-        );
-
+    my $dbc = Bio::EnsEMBL::DBSQL::DBConnection->new(
+      -user   => $config->{user},
+      -dbname => $db,
+      -host   => $config->{host},
+      -pass => $config->{password},
+      -driver => 'mysql',
+      -port => $config->{port},
+    );
+    
     print "Getting column definition\n";
 
     # get column definition from transcript_variation


### PR DESCRIPTION
Use `Bio::EnsEMBL::DBSQL::DBConnection` instead of `DBI` when loading from a file dump. Similar to #751