### PR TITLE
refactor: Add filename to parse_data input

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/BaseVepTabixPlugin.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/BaseVepTabixPlugin.pm
@@ -381,7 +381,7 @@ sub _get_data_hts {
     next unless $iter;
 
     while(my $line = $iter->next) {
-      my $parsed = $self->parse_data($line);
+      my $parsed = $self->parse_data($line,$file);
 
       push @data, [$self->identify_data($line), $parsed] if $parsed;
     }
@@ -403,7 +403,7 @@ sub _get_data_pm {
     next unless $iter && $iter->{_};
 
     while(my $line = $tabix_obj->read($iter)) {
-      my $parsed = $self->parse_data($line);
+      my $parsed = $self->parse_data($line,$file);
 
       push @data, [$self->identify_data($line), $parsed] if $parsed;
     }
@@ -431,7 +431,7 @@ sub _get_data_cl {
       chomp;
       s/\r$//g;
 
-      my $parsed = $self->parse_data($_);
+      my $parsed = $self->parse_data($_,$file);
       
       push @data, [$self->identify_data($_), $parsed] if $parsed;
     }


### PR DESCRIPTION
## Description

This pull request is part of [CADD](https://github.com/Ensembl/VEP_plugins/pull/470) header refactor. Basically, it's necessary to give "$file" (filename) as input to `parse_data()`.

## Test

1) Make sure all vep plugins are not affected by this new attribute.