### PR TITLE
feat: Add truncation in minor_allele exception + OPTIONS

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/DBSNPImport_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/DBSNPImport_conf.pm
@@ -49,8 +49,8 @@ sub default_options {
     hive_no_init            => 0, # setting it to 1 will skip pipeline_create_commands (useful for topping up)
 
     # the location of your checkout of the ensembl API
-    hive_root_dir           => $ENV{'HOME'} . '/bin/ensembl-hive',
-    ensembl_cvs_root_dir    => $ENV{'HOME'} . '/bin',
+    ensembl_cvs_root_dir    => $ENV{'ENSEMBL_ROOT_DIR'} || $self->o('ensembl_cvs_root_dir'),
+    hive_root_dir           => $self->o('ensembl_cvs_root_dir') . '/ensembl-hive',
 
     debug                   => 0,
 
@@ -99,10 +99,10 @@ sub resource_classes {
     my ($self) = @_;
     return {
         %{$self->SUPER::resource_classes},  # inherit 'default' from the parent class
-            'test_mem'    => { 'LSF' => '-R"select[mem>100] rusage[mem=100]" -M100'},
-            'default_mem' => { 'LSF' => '-R"select[mem>1000] rusage[mem=1000]" -M1000'},
-            'medium_mem'  => { 'LSF' => '-R"select[mem>4000] rusage[mem=4000]" -M4000'},
-            'high_mem'    => { 'LSF' => '-R"select[mem>8000] rusage[mem=8000]" -M8000'},
+            'test_mem'    => { 'LSF' => '-qproduction -R"select[mem>100] rusage[mem=100]" -M100'},
+            'default_mem' => { 'LSF' => '-qproduction -R"select[mem>1000] rusage[mem=1000]" -M1000'},
+            'medium_mem'  => { 'LSF' => '-qproduction -R"select[mem>4000] rusage[mem=4000]" -M4000'},
+            'high_mem'    => { 'LSF' => '-qproduction -R"select[mem>8000] rusage[mem=8000]" -M8000'},
     };
 }
 

--- a/scripts/import/dbSNP_v2/init_load_dbsnp.pl
+++ b/scripts/import/dbSNP_v2/init_load_dbsnp.pl
@@ -267,7 +267,7 @@ sub usage {
 
   Creates seq region lookup tables for dbsnp-v2 import.
   
-  Poplulates seq_region table and creates tables for synonym lookups (NC, NW, NT)
+  Populates the seq_region table and creates tables for synonym lookups (NC, NW, NT)
 
   Options:
   -h | --help          Displays this message and quit

--- a/scripts/import/dbSNP_v2/load_dbsnp.pl
+++ b/scripts/import/dbSNP_v2/load_dbsnp.pl
@@ -2009,7 +2009,7 @@ sub get_study_frequency {
   if (@{$study_freq->{'alleles'}} <= 1) {
     $allele_errors{4}++;
   } else {
-    my ($maf, $minor_allele, $minor_allele_count) = get_maf($study_freq->{'alleles'});
+    my ($maf, $minor_allele, $minor_allele_count) = get_maf($study_freq->{'alleles'}, $data->{'refsnp_id'});
     $study_freq->{'MAF'} = $maf;
     $study_freq->{'minor_allele'} = $minor_allele;
     $study_freq->{'minor_allele_count'} = $minor_allele_count;
@@ -2081,7 +2081,7 @@ sub get_align_diff {
 }
 
 sub get_maf {
-  my ($alleles_ref) = @_;
+  my ($alleles_ref, $rsid) = @_;
 
   #print Dumper($alleles_ref);
   my @sorted_alleles = sort {
@@ -2093,6 +2093,18 @@ sub get_maf {
   my $maf = sprintf("%.6f", $sorted_alleles[1]->{'allele_count'}/$sorted_alleles[1]->{'total_count'});
   my $minor_allele = $sorted_alleles[1]->{'observation'}->{'inserted_sequence'};
   my $minor_allele_count = $sorted_alleles[1]->{'allele_count'};
+
+  my $var_name = "rs$rsid";
+
+  if (length($minor_allele) > 50) {
+    my $msg = 'truncated_minor_allele';
+    my $info = join(";", 'rsid='. $var_name,
+                          'minor_allele=' . $minor_allele);
+    $minor_allele = substr($minor_allele,0,50);
+    log_errors($config, $var_name, $msg, $info);
+  }
+
+
   #print "Minor Allele Frequence = ($maf)\n";
   #print "Minor allelele = ($minor_allele)\n";
   #print "Minor allele count = ($minor_allele_count)\n";
@@ -2278,6 +2290,10 @@ No reference checking
 =item B<--no_assign_ancestral_allele>
 
 No ancestral allele assignment
+
+=item B<--no_maf>
+
+Not include MAF information
 
 =item B<--debug>
 

--- a/scripts/import/dbSNP_v2/load_dbsnp.pl
+++ b/scripts/import/dbSNP_v2/load_dbsnp.pl
@@ -267,7 +267,8 @@ sub parse_refsnp {
   ($data->{'snp_support'}, $data->{'freq_support'})  = get_support($rs_json);
 
   # 1000Genomes data
-  $data->{'1000Genomes'} = get_study_frequency($rs_json, '1000Genomes');
+  # Do not add 1000Genomes data
+  # $data->{'1000Genomes'} = get_study_frequency($rs_json, '1000Genomes');
 
   # If: 
   # - the assembly is GRCh38
@@ -1221,7 +1222,7 @@ sub import_variation_feature {
 
     if (defined $seen_vf{$loc}) {
       # Keep a record of the location and alleles in the JSON file
-      import_placement_allele($dbh, $variation_id, $vf->{'alleles'});
+      import_placement_allele($dbh, $variation_id, $vf->{'alleles'}, $vf->{'variation_name'});
 
       # Log only the location not the alleles in the error file
       my $info = join(";",
@@ -1264,7 +1265,7 @@ sub import_variation_feature {
     }
 
     # insert the placement allele
-    import_placement_allele($dbh, $variation_id, $vf->{'alleles'});
+    import_placement_allele($dbh, $variation_id, $vf->{'alleles'}, $vf->{'variation_name'});
     
     # Log those with aln_opposite but seq_region_strand +1
     if ($vf->{'aln_opposite'} && ($vf->{'seq_region_strand'} == 1)) {
@@ -1280,7 +1281,7 @@ sub import_variation_feature {
 }
 
 sub import_placement_allele {
-  my ($dbh, $variation_id, $alleles) = @_;
+  my ($dbh, $variation_id, $alleles, $var_name) = @_;
 
   debug("import_placement_allele") if ($debug);
  
@@ -1326,14 +1327,48 @@ sub import_placement_allele {
     #print "insereted sequence = $spdi->{'inserted_sequence'}\n";
     #print "hgvs = $allele->{'hgvs'}\n";
 
+    # The placement_allele table defines deleted_sequence, inserted_sequence
+    # and hgvs to varchar(255)
+    # Only the first 255 characters of these fields are stored and truncations flagged
+    # TODO - alter the schema for placement allele
+    #
+    check_spdi_lengths($spdi, $variation_id, $var_name);
+
+    my $pa_hgvs = $allele->{'hgvs'};
+    if (length($pa_hgvs) > 255) {
+      $pa_hgvs = substr($pa_hgvs,0,255);
+      my $msg = 'truncated_pa_hgvs';
+      my $info = join(";", 'variant_id='. $variation_id,
+                           'hgvs=' . $pa_hgvs);
+      log_errors($config, $var_name, $msg, $info);
+    }
+
     $sth->execute($variation_id,
                   $spdi->{'seq_id'},
                   $spdi->{'position'},
                   $spdi->{'deleted_sequence'},
                   $spdi->{'inserted_sequence'},
-                  $allele->{'hgvs'});
+                  $pa_hgvs);
   }
 }
+
+
+sub check_spdi_lengths {
+  my ($spdi, $var_id, $var_name) = @_;
+
+  my $msg = 'spdi_seq_gt_255';
+
+  my @fields = ('deleted_sequence', 'inserted_sequence');
+  for my $field (@fields) {
+    if (length($spdi->{$field}) > 255) {
+      $spdi->{$field} = substr($spdi->{$field}, 0,255);
+      my $info = join(";", 'variant_id='. $var_id,
+                         $field . '=' . $spdi->{$field});
+      log_errors($config, $var_name, $msg, $info);
+    }
+  }
+}
+
 
 # Stores the SPDI allele errors - for local use only
 sub import_failed_alleles {


### PR DESCRIPTION
JIRA [ENSVAR-4677](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4677)

## Description

@helensch added a few alterations (https://github.com/Ensembl/ensembl-variation/pull/789) to `load_dbsnp.pl`. This PR updates OPTIONS adding add_maf to command description and also truncate minor_allele in case of minor allele is bigger than 50bp.

## Test

1. Run `load_dbsnp.pl` with `--add_maf` flag. Make sure it has a minor_allele, i.e

```sh
2022-03-29 09:43:42     rs55689549      truncated_minor_allele  rsid=rs55689549;minor_allele=ATTTAATTATTAATTAAATAATTTAATTTATTTATTATTATAAATTTATTAATATAAATTAAATA
2022-03-29 09:45:04     rs67288656      truncated_minor_allele  rsid=rs67288656;minor_allele=TTCTTAGGATGGCTCTGTATTCATTATGGATTTCATAAGTCACATGGCTGGAAGGTACCTGATA
2022-03-29 09:45:05     rs67673721      truncated_minor_allele  rsid=rs67673721;minor_allele=ATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATAAAATACAATAAAATAAA
```

If you need some input files, go to JIRA card