### PR TITLE
There should be no frequency when allele count is 0

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -771,10 +771,13 @@ sub get_all_Alleles_by_VariationFeature {
     }
 
     foreach my $a(keys %{$freqs->{$pop_id}}) {
+
+      my $count = $counts && $counts->{$pop_id} ? ($counts->{$pop_id}->{$a} || 0) : undef;
+
       push @alleles, Bio::EnsEMBL::Variation::Allele->new_fast({
         allele     => $a,
-        count      => $counts && $counts->{$pop_id} ? ($counts->{$pop_id}->{$a} || 0) : undef,
-        frequency  => $freqs->{$pop_id}->{$a},
+        count      => $count,
+        frequency  => defined $count && $count > 0 ? $freqs->{$pop_id}->{$a} : undef,
         population => $pop,
         variation  => $variation,
         adaptor    => $allele_adaptor,


### PR DESCRIPTION
When for some allele the allele count is 0 or undef we should set the frequency to be undef too. Currently it is set to AF (or 1 - AF depending on whether it is reference) which gives wrong information.

This happens only when reading from VCF. In the following figure China_south population do not have any T alleles but still get frequency of .078 from VCF file.

![image](https://user-images.githubusercontent.com/12125986/164241701-17d7e62c-1cb3-4eac-86e2-4eccabd309ba.png)

