### PR TITLE
Renaming master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Ensembl Variation API
 
-[![GitHub](https://img.shields.io/github/license/Ensembl/ensembl-variation.svg)](https://github.com/Ensembl/ensembl-variation/blob/master/LICENSE)
-[![Build Status](https://travis-ci.org/Ensembl/ensembl-variation.png?branch=master)](https://travis-ci.org/Ensembl/ensembl-variation)
-[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-variation/badge.svg?branch=master)](https://coveralls.io/github/Ensembl/ensembl-variation?branch=master)
+[![GitHub](https://img.shields.io/github/license/Ensembl/ensembl-variation.svg)](https://github.com/Ensembl/ensembl-variation/blob/main/LICENSE)
+[![Build Status](https://travis-ci.org/Ensembl/ensembl-variation.png?branch=main)](https://travis-ci.org/Ensembl/ensembl-variation)
+[![Coverage Status](https://coveralls.io/repos/github/Ensembl/ensembl-variation/badge.svg?branch=main)](https://coveralls.io/github/Ensembl/ensembl-variation?branch=main)
 
 [travis]: https://travis-ci.org/Ensembl/ensembl-variation
 [coveralls]: https://coveralls.io/r/Ensembl/ensembl-variation

--- a/tools/linkage_disequilibrium/README.md
+++ b/tools/linkage_disequilibrium/README.md
@@ -14,7 +14,7 @@ There is a [web tool](http://www.ensembl.org/Multi/Tools/LD) version with an int
 ---
 <a name="usage"></a>
 ### Usage
-The script wraps around the LD calculation code in the Ensembl Variation API. Before running the ld_tool script follow the [installation instructions](https://github.com/Ensembl/ensembl-variation/blob/master/C_code/README.txt).
+The script wraps around the LD calculation code in the Ensembl Variation API. Before running the ld_tool script follow the [installation instructions](https://github.com/Ensembl/ensembl-variation/blob/main/C_code/README.txt).
 
 #### Running the script
 ```bash

--- a/travisci/trigger-dependent-build.sh
+++ b/travisci/trigger-dependent-build.sh
@@ -47,9 +47,9 @@ endspin() {
    printf "\r%s\n" "$@"
 }
 
-# Only run for master builds. Pull request builds have the branch set to master,
+# Only run for main builds. Pull request builds have the branch set to main,
 # so ignore those too.
-if [ "${TRAVIS_BRANCH}" != "master" ] || [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
+if [ "${TRAVIS_BRANCH}" != "main" ] || [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
   exit 0
 fi
 
@@ -75,7 +75,7 @@ for dep_repo in "${dep_repos[@]}"; do
     body="{
  \"request\": {
  \"message\": \"Build triggered by upstream $TRAVIS_REPO_SLUG repo (commit: $TRAVIS_COMMIT, branch: $TRAVIS_BRANCH).\",
- \"branch\": \"master\"
+ \"branch\": \"main\"
 }}"
 
     # Make the request to trigger the build and get the ID of the request


### PR DESCRIPTION
Renaming master to main for files dependent on `ensembl-variation` repo

For file, travisci/trigger-dependent-build.sh, there are some inconsistent lines as ensembl-rest is on main and ensembl-vep is on master. For now, keeping them the same and updating them after `ensembl-vep` is renamed to main