### PR TITLE
fix: CADD while using --hgvs flag

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1365,6 +1365,7 @@ sub hgvs_transcript {
   my $offset_to_add = defined($self->{shift_hash}) ? $self->{shift_hash}->{_hgvs_offset} : 0;# + ($no_shift ? 0 : (0 - $self->{_hgvs_offset}) );
   $self->{_hgvs_offset} = $offset_to_add;
   ## delete the shifting hash if we generated it for HGVS calculations
+  $self->{variation_feature_seq} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
  
   ## return if a new transcript_variation_allele is not available - variation outside transcript
@@ -1678,9 +1679,6 @@ sub hgvs_protein {
   ## Incase the user wants shifted HGVS but not shifted consequences, we run the shifting method  
   my $ref_hash_already_defined = defined($ref->{shift_hash});
   $ref->_return_3prime(1) unless $ref_hash_already_defined;
-
-  my $previous_vfs = $self->{variation_feature_seq};
-
   ## get default reference & alt peptides  [changed later to hgvs format]
   if(defined($self->{shift_hash}) && defined($self->{shift_hash}->{shift_length})  && $self->{shift_hash}->{shift_length} != 0) {
     delete($self->{peptide});
@@ -1704,6 +1702,7 @@ sub hgvs_protein {
   $hgvs_notation->{ref} = $ref->peptide; 
   
   ## delete the shifting hash if we generated it for HGVS calculations
+  $self->{variation_feature_seq} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
   delete($ref->{shift_hash}) unless $ref_hash_already_defined;
 
@@ -1728,8 +1727,6 @@ sub hgvs_protein {
 
   ##### String formatting
   my $hgvs_notation_output = $self->_get_hgvs_protein_format($hgvs_notation);
-  # Undo variation_feature_seq alteration
-  $self->{variation_feature_seq} = $previous_vfs;
   return $hgvs_notation_output;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1726,8 +1726,7 @@ sub hgvs_protein {
   }
 
   ##### String formatting
-  my $hgvs_notation_output = $self->_get_hgvs_protein_format($hgvs_notation);
-  return $hgvs_notation_output;
+  return $self->_get_hgvs_protein_format($hgvs_notation);
 }
 
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1678,6 +1678,9 @@ sub hgvs_protein {
   ## Incase the user wants shifted HGVS but not shifted consequences, we run the shifting method  
   my $ref_hash_already_defined = defined($ref->{shift_hash});
   $ref->_return_3prime(1) unless $ref_hash_already_defined;
+
+  my $previous_vfs = $self->{variation_feature_seq};
+
   ## get default reference & alt peptides  [changed later to hgvs format]
   if(defined($self->{shift_hash}) && defined($self->{shift_hash}->{shift_length})  && $self->{shift_hash}->{shift_length} != 0) {
     delete($self->{peptide});
@@ -1724,7 +1727,10 @@ sub hgvs_protein {
   }
 
   ##### String formatting
-  return $self->_get_hgvs_protein_format($hgvs_notation);
+  my $hgvs_notation_output = $self->_get_hgvs_protein_format($hgvs_notation);
+  # Undo variation_feature_seq alteration
+  $self->{variation_feature_seq} = $previous_vfs;
+  return $hgvs_notation_output;
 }
 
 


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4859)

## Description

An user (https://github.com/Ensembl/ensembl-vep/issues/812) found out that while we are using VEP output from CADD is incomplete. This PR fix absence of CADD results while using --hgvs or --hgvsp

## Technical description

* When `hgvs_protein` function in `TranscriptVariationAllele.pm` tries to output hgvs_protein string, several alterations are made in $vfoa object. HGVS alterations might alter any --custom / --plugin outputs since these flags are launched after hgvsp output.
* It can be important to look up if `--hgvs` flag might alter other output that use` $vfoa`.

## Test

1) Try annotate VCF with `--hgvs` using or not this PR, use for example:

```sh
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT  NA12878_58
chr1    78024345        .       C       CTAT    1777    .       SAP=26;ABP=0;MQM=60     GT:DP:AO        1/1:61:59
chr1    152681680       .       C       CAGCTCTGGGGGCTGCTGT     2922    .       SAP=21;ABP=0;MQM=59     GT:DP:AO        1/1:107:101
```

## Dependencies

If this PR is approved, https://github.com/Ensembl/ensembl-variation/pull/628 will be no longer necessary.