### PR TITLE
Fix: facilitate updating `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
 - export ENSEMBL_BRANCH=main
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-test.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl.git
-- git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-hive.git
+- git clone --branch main            --depth 1 https://github.com/Ensembl/ensembl-hive.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-io.git
 - git clone --branch $ENSEMBL_BRANCH --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
 - git clone --branch release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git

--- a/modules/t/alleleAdaptor.t
+++ b/modules/t/alleleAdaptor.t
@@ -27,7 +27,6 @@ use FileHandle;
 my $multi = Bio::EnsEMBL::Test::MultiTestDB->new('homo_sapiens');
 my $vdba = $multi->get_DBAdaptor('variation');
 
-
 my $name = 'rs144235347';
 
 my $va = $vdba->get_VariationAdaptor();


### PR DESCRIPTION
`travis.yml` should always get `main` branch from `ensembl-hive` no matter the value of `$ENSEMBL_BRANCH`. This small change reinforces that idea and reflects our [internal docs](https://www.ebi.ac.uk/seqdb/confluence/display/EV/Release+coordination#Releasecoordination-ensembl-variation).