### PR TITLE
Add a boolean flag in VCF config to fetch consequences from VCF file

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseAnnotation.pm
@@ -81,6 +81,7 @@ sub new {
     $adaptor,
     $use_seq_region_synonyms,
     $tmpdir,
+    $use_vcf_consequences,
   ) = rearrange(
     [qw(
       ID
@@ -98,6 +99,7 @@ sub new {
       ADAPTOR
       USE_SEQ_REGION_SYNONYMS
       TMPDIR
+      USE_VCF_CONSEQUENCES
     )],
     @_
   ); 
@@ -124,6 +126,7 @@ sub new {
     updated => $updated,
     is_remapped => $is_remapped,
     use_seq_region_synonyms => $use_seq_region_synonyms,
+    use_vcf_consequences => $use_vcf_consequences,
     tmpdir => $tmpdir || cwd(),
   );
   
@@ -327,6 +330,25 @@ sub use_seq_region_synonyms {
   my $self = shift;
   $self->{use_seq_region_synonyms} = shift if @_;
   return $self->{use_seq_region_synonyms};
+}
+
+=head2 use_vcf_consequences
+
+  Arg [1]    : int $use_vcf_consequences(optional)
+               The new value to set the use_vcf_consequences attribute to
+  Example    : my $use_vcf_consequences = $collection->use_vcf_consequences()
+  Description: Getter/Setter for the parameter that tells the API to 
+               fetch consequences from VCF
+  Returntype : bool
+  Caller     : general
+  Status     : Stable
+
+=cut
+
+sub use_vcf_consequences {
+  my $self = shift;
+  $self->{use_vcf_consequences} = shift if @_;
+  return $self->{use_vcf_consequences};
 }
 
 =head2 created

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm
@@ -218,6 +218,7 @@ sub new {
       -is_remapped => $hash->{is_remapped} ||0,
       -adaptor => $self,
       -tmpdir => $hash->{tmpdir} || $tmpdir,
+      -use_vcf_consequences => $hash->{use_vcf_consequences} ||0,
       -ref_freq_index => $hash->{ref_freq_index},
     ));
   }

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VCFCollectionAdaptor.pm
@@ -218,7 +218,7 @@ sub new {
       -is_remapped => $hash->{is_remapped} ||0,
       -adaptor => $self,
       -tmpdir => $hash->{tmpdir} || $tmpdir,
-      -use_vcf_consequences => $hash->{use_vcf_consequences} ||0,
+      -use_vcf_consequences => $hash->{use_vcf_consequences} || undef,
       -ref_freq_index => $hash->{ref_freq_index},
     ));
   }

--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -107,6 +107,7 @@ my $MAX_OPEN_FILES = 2;
   Arg [-STRICT_NAME_MATCH]:      boolean
   Arg [-REF_FREQ_INDEX]:         int - index position of ref frequency in INFO field, if given
   Arg [-USE_SEQ_REGION_SYNONYMS]:boolean
+  Arg [-USE_VCF_CONSEQUENCES]:boolean
   Arg [-ADAPTOR]:                Bio::EnsEMBL::Variation::DBSQL::VCFCollectionAdaptor
 
   Example    : my $collection = Bio::EnsEMBL::Variation::VCFCollection->new(
@@ -499,6 +500,7 @@ sub get_all_VariationFeatures_by_Slice {
             foreach my $transcript_var ( @transcript_vars ){
               my @transcript_split = split('\|',$transcript_var);
               my %transcript_map = zip @info_format, @transcript_split;
+              next if not defined($transcript_map{'Feature_type'});
               if ( $transcript_map{'Feature_type'} eq 'Transcript') {
                 my $tv = Bio::EnsEMBL::Variation::TranscriptVariation->new_fast({
                   variation_feature  => $vf,

--- a/modules/t/VCFCollection.t
+++ b/modules/t/VCFCollection.t
@@ -48,6 +48,7 @@ my $c = Bio::EnsEMBL::Variation::VCFCollection->new(
     'HG00099' => ['pop4']
 },
   -use_seq_region_synonyms => 1,
+  -use_vcf_consequences => 1,
 );
 
 
@@ -58,6 +59,7 @@ ok($c->filename_template() eq $dir.'/test-genome-DBs/homo_sapiens/variation/test
 ok($c->sample_prefix() eq "s_prefix:", "sample_prefix");
 ok($c->population_prefix() eq "p_prefix:", "population_prefix");
 ok($c->use_seq_region_synonyms() eq "1", "use_seq_region_synonyms");
+ok($c->use_vcf_consequences() eq "1", "use_vcf_consequences");
 ok($c->tmpdir() eq cwd(), "tmpdir");
 
 # tell it not to use the DB
@@ -149,9 +151,11 @@ ok($coll->assembly() eq "GRCh37", "assembly");
 ok($coll->source_name() eq "1000genomes", "source name");
 ok($coll->source_url() eq "http://www.1000genomes.org", "source URL");
 
+
 ok($coll->created() eq "1432745640000", "created");
 ok($coll->updated() eq "1432745640000", "updated");
 ok($coll->is_remapped() eq "1", "is_remapped");
+ok($coll->use_vcf_consequences() eq "1", "use vcf consequences");
 
 ok($coll->vcf_collection_close, 'close VCF collection filehandle');
 

--- a/modules/t/vcf_config.json
+++ b/modules/t/vcf_config.json
@@ -13,7 +13,8 @@
       "source_url": "http://www.1000genomes.org",
       "created": "1432745640000",
       "updated": "1432745640000",
-      "is_remapped": "1"
+      "is_remapped": "1",
+      "use_vcf_consequences": "1"
     }, 
     {
       "id": "ExAC_0.3_corrected_INFO",


### PR DESCRIPTION
[ENSVAR-4961](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4961)

This PR attempts to add a boolean flag to VCF config file that allows fetching consequences from VCF file instead of calculating on fly

This flag is then used to set dont_fetch_vf_overlaps in get_all_VariationFeatures_by_Slice in https://github.com/Ensembl/ensembl-webcode/blob/78c0e72a29ee87ea9e2ee9f2981a95cccb49cb34/modules/EnsEMBL/Web/Query/GlyphSet/Variation.pm#L236

