### PR TITLE
Fix Human GO dump filenames for web VEP

### DIFF
--- a/scripts/export/dump_GO_terms.pl
+++ b/scripts/export/dump_GO_terms.pl
@@ -102,6 +102,8 @@ while (my ($dbname) = $sth_h->fetchrow_array) {
   $dbname =~ /^(.+)_variation_.+_(.+)/;
   my $s_name = $1;
   my $assembly = $2;
+  # Add GRCh prefix as expected by web VEP
+  $assembly = "GRCh" . $assembly if $s_name eq 'homo_sapiens';
 
   # Check core database
   my $dbcore = $dbname;


### PR DESCRIPTION
The human assembly in Web VEP should be GRCh37 / GRCh38, unlike the assembly in CLI (37 / 38, respectively). As such, when dumping GO terms for humans, we need to manually add the prefix, like done by the script to dump Phenotypes GFF files.