### PR TITLE
Generate VEP examples using registry file

### DIFF
--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -140,7 +140,7 @@ SPECIES: foreach my $species(@all_species) {
       $sth->fetch();
       
       print OUT "$name\n" if $name;
-      push @{$web_data{"VEP_ID"}}, $name;
+      push @{$web_data{"VEP_ID"}}, $name if defined $name;
     }
     
     close OUT;


### PR DESCRIPTION
By using a registry file, we can provide databases from multiple hosts (specially useful for species with VCF backends).

Other changes:
* Remove warnings when certain types of IDs are not defined
* Usage documentation via `-help`
* Raise error when no Ensembl version is provided

### Testing
* Check if the help documentation seems reasonable
* Create an ensembl.registry file and check if it works:
```
#!/usr/bin/perl
use Bio::EnsEMBL::Variation::DBSQL::DBAdaptor;
use Bio::EnsEMBL::Registry;

# Core
Bio::EnsEMBL::DBSQL::DBAdaptor->new
  ( '-species' => "microtus_ochrogaster",
    '-port'    => 4519,
    '-host'    => 'mysql-ens-sta-1',
    '-user'    => 'ensro',
    '-pass'    => '',
    '-dbname'  => 'microtus_ochrogaster_core_108_10'
  );

# Variation
Bio::EnsEMBL::Variation::DBSQL::DBAdaptor->new
  ( '-species' => "microtus_ochrogaster",
    '-port'    => 4449,
    '-host'    => 'mysql-ens-var-prod-1',
    '-user'    => 'ensro',
    '-pass'    => '',
    '-dbname'  => 'microtus_ochrogaster_variation_108_10'
  );

Bio::EnsEMBL::Registry->add_alias("microtus_ochrogaster","prairie vole");

1;
```