### PR TITLE
Check also synonyms when getting vcf file object

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
+++ b/modules/Bio/EnsEMBL/Variation/VCFCollection.pm
@@ -1291,9 +1291,21 @@ sub _get_vcf_by_chr {
   if(!exists($self->{files}) || !exists($self->{files}->{$chr})) {
     my $obj;
     
-    # check we have this chromosome
+    # check we have this chromosome or its synonym
     if(my $chrs = $self->list_chromosomes) {
-      return unless grep {$chr eq $_} @$chrs;
+      unless ( (grep {$chr eq $_} @$chrs) || !$self->use_seq_region_synonyms) {
+        my @synonyms = @{$self->_get_synonyms_by_chr($chr)};
+
+        # also check with 'chr' prefix
+        push @synonyms, 'chr'.$chr;
+
+        my $matched = 0;
+        foreach my $synonym (@synonyms) {
+          $matched = 1 if grep {$synonym eq $_} @$chrs;
+        }
+
+        return unless $matched;
+      }
     }
     
     my $file = $self->_get_vcf_filename_by_chr($chr);


### PR DESCRIPTION
When getting the vcf file object we should also check if the synonym of the chromosome (or seq region) of interest matches what we have in the file or in the `chromosomes` list (if mentioned in the vcf config file). It will be checked only if `use_seq_region_synonyms` option is set in the vcf config file.

This is particularly helpful when we have large set of synonyms in the vcf file and mentioning their corresponding seq region in the `chromosomes` list is not feasible/pretty (e.g. -  pike perch in rapid release and pangenomes). In case the synonyms list is small their corresponding seq region can be mentioned in the `chromosomes` list in vcf config (see rabbit in main site). This extra check does not break this behavior.

### Testing
Tested with 4 species in rapid release - 
pike perch
Crab-eating macaque
Collared flycatcher
Fruit fly

Tested with japanese quail and 1000 genome in main site