### PR TITLE
fix: Rebuild indexes not working in normal mode

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -225,6 +225,7 @@ sub pipeline_analyses {
             -rc_name   => 'default',
             -flow_into => {
               1 => ['gene_factory'],
+              2 => ['rebuild_tv_indexes'],
             },
             -input_ids  => [{}],
           },
@@ -341,9 +342,6 @@ sub pipeline_analyses {
           },
           { -logic_name => 'web_index_load',
             -module => 'Bio::EnsEMBL::Variation::Pipeline::LoadWebIndexFiles',
-            -flow_into => {
-              1 => ['rebuild_tv_indexes'],
-            },
             -parameters => {
               @common_params,
             },
@@ -355,6 +353,7 @@ sub pipeline_analyses {
               @common_params,
             },
             -rc_name   => 'default',
+            -wait_for => 'web_index_load',
             -flow_into => {
               1 => ['update_variation_feature'],
             },


### PR DESCRIPTION
## Description

When running full mode, I noticed that rebuilding indexes was not working properly. This PR fix workflow logic to run properly index rebuild after running web_index_load

## Test

1) Just need to check that rebuild indexes is triggered by init_transcript_effect as previsouly.