### PR TITLE
fix: variation_hgvs table missing values

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
@@ -130,23 +130,6 @@ sub fetch_input {
                   WHERE   feature_stable_id IN ($joined_ids)
         }) if($mtmp);
 
-        $dbc->do(qq{
-                  DELETE WHOLE FROM variation_hgvs WHOLE
-                  INNER JOIN 
-                  (SELECT var_id.variation_id AS variation_id, SUBSTRING_INDEX(hgvs_transcript, ":", -1) AS hgvs_name
-                  FROM transcript_variation, (select variation_id from variation_feature WHERE variation_feature_id IN (
-                    SELECT DISTINCT(variation_feature_id) from transcript_variation WHERE feature_stable_id IN ($joined_ids) AND hgvs_transcript IS NOT NULL
-                    )) as var_id
-                  WHERE variation_feature_id = (SELECT variation_feature_id FROM variation_feature WHERE variation_id = var_id.variation_id) AND hgvs_transcript IS NOT NULL
-                  UNION ALL
-                  SELECT var_id.variation_id AS variation_id, SUBSTRING_INDEX(hgvs_protein, ":", -1) AS hgvs_name
-                  FROM transcript_variation, (select variation_id from variation_feature WHERE variation_feature_id IN (
-                    SELECT DISTINCT(variation_feature_id) from transcript_variation WHERE feature_stable_id IN ($joined_ids) AND hgvs_protein IS NOT NULL
-                    )) as var_id
-                  WHERE variation_feature_id = (SELECT variation_feature_id FROM variation_feature WHERE variation_id = var_id.variation_id) AND hgvs_protein IS NOT NULL) SUBSET
-                  ON WHOLE.variation_id=SUBSET.variation_id AND WHOLE.hgvs_name=SUBSET.hgvs_name;
-        });
-
     }
 
 }

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/LoadWebIndexFiles.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/LoadWebIndexFiles.pm
@@ -70,6 +70,10 @@ sub run {
     load($dbc, qw(variation_hgvs variation_id hgvs_name));
   }
 
+  $dbc->do(qq{
+            DELETE from variation_hgvs where variation_id not in (select variation_id from variation);
+          }) if(-e $self->param('update_diff'));
+
   return;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -345,6 +345,7 @@ sub pipeline_analyses {
               1 => ['rebuild_tv_indexes'],
             },
             -parameters => {
+              update_diff => $self->o('update_diff'),
               @common_params,
             },
             -rc_name   => 'default',


### PR DESCRIPTION
## Description

Datachecks pointed out that we have non-existent variation_id from variation table in variation_hgvs table. I.e,

```sh
variation_id	hgvs_name	variation_id	source_id	name	flipped	class_attrib_id	somatic	minor_allele	minor_allele_freq	minor_allele_count	clinical_significance	evidence_attribs	display
741221451	c.110+4G>T	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221451	c.212-1690G>T	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221451	c.700+4G>T	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221451	n.1800G>T	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221452	n.124_125insACGTAGACATTCCT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221452	n.125_126insACGTAGACATTCCT	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221453	c.*402G>A	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221453	c.*729G>A	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221453	c.1061G>A	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
741221453	c.1076G>A	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
```

This PR will fix this problem improving how we delete variation_hgvs deprecated ids.

## Test

```sh
## Datacheck pointed - 461239 non-existent variation_id from variation table in variation_hgvs table
select count(*) from variation_hgvs where variation_id not in (select variation_id from variation);
+----------+
| count(*) |
+----------+
|   461239 |
+----------+
1 row in set (1 hour 42 min 35.59 sec)
```
