### PR TITLE
fix: Delete from GeneFactory in smaller chunks

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
@@ -76,6 +76,24 @@ sub fetch_input {
         } if $status ne "deleted";
 
         push @delete_transcripts, $transcript_id if $status eq "deleted";
+
+        # Remove Deleted transcripts
+        if (@delete_transcripts > 500){
+            my $joined_ids = '"' . join('", "', @delete_transcripts) . '"';
+            return if $joined_ids == "";
+            $dbc->do(qq{
+                      DELETE FROM  transcript_variation
+                      WHERE   feature_stable_id IN ($joined_ids)
+            });
+
+            $dbc->do(qq{
+                      DELETE FROM  MTMP_transcript_variation
+                      WHERE   feature_stable_id IN ($joined_ids)
+            }) if($mtmp);
+
+            # Reset delete_transcripts list
+            @delete_transcripts = ();
+        }
       }
 
     } elsif ( grep {defined($_)} @$biotypes ) {  # If array is not empty  

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
@@ -53,7 +53,7 @@ sub fetch_input {
     my $core_dba = $self->get_species_adaptor('core');
     my $var_dba = $self->get_species_adaptor('variation');
     
-    my $dbc = $var_dba->dbc();
+    my $dbc = $var_dba->dbc;
 
     my $ga = $core_dba->get_GeneAdaptor or die "Failed to get gene adaptor";
 
@@ -80,15 +80,15 @@ sub fetch_input {
         # Remove Deleted transcripts
         if (@delete_transcripts > 500){
             my $joined_ids = '"' . join('", "', @delete_transcripts) . '"';
-            return if $joined_ids == "";
+            
             $dbc->do(qq{
                       DELETE FROM  transcript_variation
-                      WHERE   feature_stable_id IN ($joined_ids)
-            });
+                      WHERE   feature_stable_id IN ($joined_ids);
+            }) or die "Deleting stable ids failed";
 
             $dbc->do(qq{
                       DELETE FROM  MTMP_transcript_variation
-                      WHERE   feature_stable_id IN ($joined_ids)
+                      WHERE   feature_stable_id IN ($joined_ids);
             }) if($mtmp);
 
             # Reset delete_transcripts list
@@ -137,11 +137,11 @@ sub fetch_input {
     # Remove Deleted transcripts
     if (-e $self->param('update_diff')){
         my $joined_ids = '"' . join('", "', @delete_transcripts) . '"';
-        return if $joined_ids == "";
+        return if $joined_ids eq "";
         $dbc->do(qq{
                   DELETE FROM  transcript_variation
-                  WHERE   feature_stable_id IN ($joined_ids)
-        });
+                  WHERE   feature_stable_id IN ($joined_ids);
+        }) or die "Deleting stable ids failed";
 
         $dbc->do(qq{
                   DELETE FROM  MTMP_transcript_variation

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/GeneFactory.pm
@@ -86,11 +86,6 @@ sub fetch_input {
                       WHERE   feature_stable_id IN ($joined_ids);
             }) or die "Deleting stable ids failed";
 
-            $dbc->do(qq{
-                      DELETE FROM  MTMP_transcript_variation
-                      WHERE   feature_stable_id IN ($joined_ids);
-            }) if($mtmp);
-
             # Reset delete_transcripts list
             @delete_transcripts = ();
         }
@@ -142,11 +137,6 @@ sub fetch_input {
                   DELETE FROM  transcript_variation
                   WHERE   feature_stable_id IN ($joined_ids);
         }) or die "Deleting stable ids failed";
-
-        $dbc->do(qq{
-                  DELETE FROM  MTMP_transcript_variation
-                  WHERE   feature_stable_id IN ($joined_ids)
-        }) if($mtmp);
 
     }
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/UpdateVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/UpdateVariationFeature.pm
@@ -96,7 +96,7 @@ sub run {
         }
 
         my $joined_ids = '"' . join('", "', @update_transcripts) . '"';
-        next if($joined_ids != "");
+        next if($joined_ids eq "");
 
         $dbc->do(qq{
             INSERT IGNORE INTO $temp_table (variation_feature_id, consequence_types)


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5019)

## Description

As reported by Jamie, we had a few transcripts that were not deleted during update mode for VariationConsequence Pipeline. This PR divides `DELETE FROM` command in smaller chunks similar to UpdateVariationFeature task to avoid any long string problem.

## Test

1) Running VariationConsequence Pipeline and checking after `GeneFactory` if all deleted transcripts were removed.