### PR TITLE
fix: Renaming sus_scrofa subfolder to conventional

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -1152,7 +1152,7 @@
       "species": "sus_scrofa",
       "assembly": "Sscrofa11.1",
       "type": "remote",
-      "filename_template" : "https://ftp.ensembl.org/pub/data_files/sus_scrofa/Sscrofa11.1/variation/ALL_pCADD-PHRED-scores.tsv.gz",
+      "filename_template" : "https://ftp.ensembl.org/pub/data_files/sus_scrofa/Sscrofa11.1/variation_annotation/ALL_pCADD-PHRED-scores.tsv.gz",
       "annotation_type": "cadd"
     }
   ]


### PR DESCRIPTION
## Description

Just need to rename subfolder to a standard convention.