### PR TITLE
Update VCF config for salmon

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/vcf_config.json
@@ -711,7 +711,7 @@
       "assembly": "Ssal_v3.1",
       "type": "remote",
       "use_as_source" : 1,
-      "filename_template" : "https://ftp.ensembl.org/pub/data_files/salmo_salar/Ssal_v3.1/variation_genotype/Salmon_SNP_80_samples_freebayes_EBI_noINFO.vcf.gz",
+      "filename_template" : "https://ftp.ensembl.org/pub/data_files/salmo_salar/Ssal_v3.1/variation_genotype/Salmon_SNP_80_samples_freebayes_EBI_noINFO_remap.vcf.gz",
       "chromosomes": [
         "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29"
       ]


### PR DESCRIPTION
While running the G2P plugin VEP throws a warning:
`WARNING: Cannot read from file https://ftp.ensembl.org/pub/data_files/salmo_salar/Ssal_v3.1/variation_genotype/Salmon_SNP_80_samples_freebayes_EBI_noINFO.vcf.gz for species salmo_salar at /hps/software/users/ensembl/repositories/dlemos/ensembl-variation/modules/Bio/EnsEMBL/Variation/DBSQL/BaseAnnotationAdaptor.pm line 253.`

The correct filename is `Salmon_SNP_80_samples_freebayes_EBI_noINFO_remap.vcf.gz` available in https://ftp.ensembl.org/pub/data_files/salmo_salar/Ssal_v3.1/variation_genotype/ 
