### PR TITLE
Fix warning when transcript/translation version is not defined

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1413,7 +1413,7 @@ sub hgvs_transcript {
   ### create reference name - transcript name & seq version
   my $stable_id = $tr_stable_id;
   $stable_id .= "." . $tr->version() 
-     unless ($stable_id =~ /\.\d+$/ || $stable_id =~ /LRG/); ## no version required for LRG's
+     unless (!defined $tr->version() || $stable_id =~ /\.\d+$/ || $stable_id =~ /LRG/); ## no version required for LRG's
   $hgvs_notation->{'ref_name'} = $stable_id;
 
 
@@ -1666,7 +1666,7 @@ sub hgvs_protein {
 
   # Add seq version unless LRG 
   $hgvs_notation->{ref_name} .= "." . $tr->translation->version() 
-    unless ($hgvs_notation->{ref_name}=~ /\.\d+$/ || $hgvs_notation->{ref_name} =~ /LRG/ || $self->{remove_hgvsp_version});
+    unless (!defined $tr->translation->version() || $hgvs_notation->{ref_name}=~ /\.\d+$/ || $hgvs_notation->{ref_name} =~ /LRG/ || $self->{remove_hgvsp_version});
 
   $hgvs_notation->{'numbering'} = 'p';
 


### PR DESCRIPTION
For some transcripts the version can be undefined and can cause warning when appending to stable id / hgvs reference. For example, (for yeast) YDL149W_mRNA.

This got caught while running IntAct plugin. An example command to reproduce the issue - 
```
PLENV_VERSION=5.14.4 perl /hps/software/users/ensembl/repositories/snhossain/ensembl-vep/vep --i ../data/test_yeast --o ../output/out_intact.txt --fork 4 --database --db_version 107 --force_overwrite --hgvs --plugin IntAct,feature_ac=1,mutation_file=/hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-3250/data/mutations.tsv,mapping_file=/hps/nobackup/flicek/ensembl/variation/snhossain/issues/ensvar-3250/data/rat/mutation_gc_remap.txt.gz --species saccharomyces_cerevisiae --assembly R64-1-1 
```

with input data - 
```
##fileformat=VCFv4.2
#CHROM POS ID REF ALT QUAL FILTER INFO
IV	1404772 .	AAA     AT	.	.	.
VII     306962  .	GGA     GAA     .	.	.
X	451443  .	TAC     TTT     .	.	.
```