### PR TITLE
feat: Create update old sets script

### DIFF
--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -1,0 +1,145 @@
+#!/usr/bin/perl
+
+## This script should get rs_names + variation_set_ids from last release
+## and "lift" all variation_id / variation_set_id to new dbSNP import.
+
+use strict;
+use DBI;
+
+## Connect to Databases
+
+my $dbname = "";
+my $old_dbname = "";
+
+my $host = "mysql-ens-var-prod-1";
+my $port = 4449;
+my $user = "ensadmin";
+my $pass = "";
+
+# Set TMP_DIR + TMP_FILE
+my $TMP_DIR = "<PATH-TO>/tmp";
+my $TMP_FILE = "variation_feature.txt";
+
+my $tmp_vset_table = "variation_set_variation_e109";
+
+# define variants and move through the list
+my $dbh = DBI->connect("DBI:mysql:database=${dbname};host=${host};port=${port}",
+                       $user, $pass);
+
+my $old_dbh = DBI->connect("DBI:mysql:database=${old_dbname};host=${host};port=${port}",
+                       $user, $pass);
+
+
+## Stable variation_set.variation_set_id's values
+my @stable = qw(
+    3, 4, 5, 6, 7, 8, 9, 10, 
+    11, 12, 13, 14, 15, 16, 17, 
+    27, 40, 43, 44, 45, 47, 48, 
+    49, 50, 51, 52, 53, 54, 55, 56, 57
+  );
+
+### Get old rs_names / variation_set_ids
+## It will create a tmp file with variation_feature table values
+
+sub dumpPreparedSQL {
+  my $dbVar = shift;
+  my $tmp_num = shift;
+  my $chunk = shift;
+
+  my $start = $chunk * $tmp_num;
+  my $end = $chunk + $start;
+  $end = $end < $size ? $end : $size;
+
+
+  my $sql = qq{SELECT * FROM variation_feature WHERE variation_feature_id > $start AND variation_feature_id <= $end};
+
+  my $sth = $dbVar->prepare( $sql );
+
+  local *FH;
+  open ( FH, ">>$TMP_DIR/$TMP_FILE" )
+      or die( "Cannot open $TMP_DIR/$TMP_FILE: $!" );
+
+  $sth->execute();
+
+  while ( my $aref = $sth->fetchrow_arrayref() ) {
+    my @a = map {defined($_) ? $_ : '\N'} @$aref;
+    print FH join("\t", @a), "\n";
+
+  }
+
+  close FH;
+  $sth->finish();
+
+  return $end, $tmp_num;
+}
+
+# Get Variation_feature size
+my $sql = qq{SELECT count(*) FROM variation_feature};
+my $sth = $old_dbh->prepare( $sql );
+$sth->execute();
+my $size = $sth->fetchall_arrayref()->[0]->[0];
+my $chunk = 1000000; # Buffer_size number to avoid memory issues
+
+for my $tmp_num (map { $_ } 0 .. $size/$chunk) {
+  dumpPreparedSQL($old_dbh, $tmp_num, $chunk);
+}
+
+system("awk '{if ($2) print $0;}' $TMP_DIR/$TMP_FILE > $TMP_DIR/$TMP_FILE.not_empty");
+
+### Dump new variation_set_variation / Update new variation_feature.variation_set_id
+
+my $var_ext_sth = $dbh->prepare(qq[ SELECT variation_id FROM variation WHERE name = ? limit 1]);
+my $syn_ext_sth = $dbh->prepare(qq[ SELECT variation_id FROM variation_synonym WHERE name= ? limit 1]);
+my $vfid_ext_sth = $dbh->prepare(qq[ SELECT variation_feature_id, variation_set_id from variation_feature WHERE variation_id = ? limit 1]);
+
+my $vsv_ins_sth = $dbh->prepare(qq[ CREATE TABLE $tmp_vset_table LIKE variation_set_variation ]);
+my $vsv_ins_sth = $dbh->prepare(qq[ INSERT IGNORE INTO $tmp_vset_table (variation_id, variation_set_id) VALUES (?,?)]);
+my $vf_upd_sth = $dbh->prepare(qq[ UPDATE variation_feature SET variation_set_id = ? WHERE variation_feature_id = ?]);
+
+open my $list, "$TMP_DIR/$TMP_FILE.not_empty" || die "Failed to open var list $ARGV[0] : $!\n"; 
+while(<$list>){
+  next unless /rs/; 
+  chomp;
+
+  my $rs  = (split)[0];
+  my $sets = (split)[1];
+
+  $var_ext_sth->execute($rs)||die;
+  my $id =   $var_ext_sth->fetchall_arrayref();
+
+  unless (defined $id->[0]->[0]){
+    $syn_ext_sth->execute($rs)||die;
+    $id =   $syn_ext_sth->fetchall_arrayref();
+  }
+
+  unless (defined $id->[0]->[0]){
+    print "Skipping $rs\t$sets\n";
+    next;
+  }
+
+  ## Insert into variation_feature
+  $vfid_ext_sth->execute($id->[0]->[0])||die;
+  my $vf = $vfid_ext_sth->fetchall_arrayref();
+  my $vf_id = $vf->[0]->[0];
+  my $vset_id = $vf->[0]->[1];
+
+  if ($vset_id ne ""){
+    warn "Skipping vf_id $vf_id with already filled sets $vset_id\n";
+    next;
+  };
+
+  warn "adding sets $sets to variation_feature_id $vf_id\n";
+  $vf_upd_sth->execute($sets, $vf_id);
+
+  ## Insert into variation_set_variation
+  my @sets = split/\,/, $sets;
+  foreach my $set (@sets){
+    next unless (grep { /$set/ } @stable);
+    warn "adding $rs  $id->[0]->[0] to set $set\n";
+    $vsv_ins_sth->execute( $id->[0]->[0], $set ) ||die "Error adding $set to $rs: $!\n";
+  }
+}
+
+# Remove temp files
+system("rm $TMP_DIR/$TMP_FILE $TMP_DIR/$TMP_FILE.not_empty");
+

--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -192,6 +192,13 @@ system("rm $TMP_DIR/$TMP_FILE $TMP_DIR/$TMP_FILE.not_empty $TMP_DIR/$TMP_FILE.du
 $dbh->do(qq{ DROP TABLE IF EXISTS variation_set_variation }) or die "Failed to drop variation_set_variation table";
 $dbh->do(qq{ ALTER TABLE $tmp_vset_table RENAME TO variation_set_variation }) or die "Failed to rename table";
 
+# Add Failed to variation set
+$dbh->do(qq{ 
+  INSERT IGNORE INTO variation_set_variation (variation_id, variation_set_id)
+  SELECT DISTINCT variation_id, 1 
+  FROM failed_variation; 
+}) or die "Failed to add failed to variation_set_variation table";
+
 sub usage {
 
   die "\n\tUsage: update_old_sets.pl -registry [registry file] -release [release number] -tmp [temp folder]\n\n";

--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -47,42 +47,6 @@ my @stable = qw(
     49, 50, 51, 52, 53, 54, 55, 56, 57
   );
 
-### Get old rs_names / variation_set_ids
-## It will create a tmp file with variation_feature table values
-
-sub dumpPreparedSQL {
-  my $dbVar = shift;
-  my $tmp_num = shift;
-  my $chunk = shift;
-  my $size = shift;
-
-  my $start = $chunk * $tmp_num;
-  my $end = $chunk + $start;
-  $end = $end < $size ? $end : $size;
-
-
-  my $sql = qq{SELECT variation_name, variation_set_id FROM variation_feature WHERE variation_feature_id > $start AND variation_feature_id <= $end};
-
-  my $sth = $dbVar->prepare( $sql );
-
-  local *FH;
-  open ( FH, ">>$TMP_DIR/$TMP_FILE" )
-      or die( "Cannot open $TMP_DIR/$TMP_FILE: $!" );
-
-  $sth->execute();
-
-  while ( my $aref = $sth->fetchrow_arrayref() ) {
-    my @a = map {defined($_) ? $_ : '\N'} @$aref;
-    print FH join("\t", @a), "\n";
-
-  }
-
-  close FH;
-  $sth->finish();
-
-  return $end, $tmp_num;
-}
-
 # Get Variation_feature size
 my $sql = qq{ SELECT MIN(variation_feature_id), MAX(variation_feature_id) FROM variation_feature };
 my $sth = $old_dbh->prepare( $sql );
@@ -198,6 +162,42 @@ $dbh->do(qq{
   SELECT DISTINCT variation_id, 1 
   FROM failed_variation; 
 }) or die "Failed to add failed to variation_set_variation table";
+
+### Get old rs_names / variation_set_ids
+## It will create a tmp file with variation_feature table values
+
+sub dumpPreparedSQL {
+  my $dbVar = shift;
+  my $tmp_num = shift;
+  my $chunk = shift;
+  my $size = shift;
+
+  my $start = $chunk * $tmp_num;
+  my $end = $chunk + $start;
+  $end = $end < $size ? $end : $size;
+
+
+  my $sql = qq{SELECT variation_name, variation_set_id FROM variation_feature WHERE variation_feature_id > $start AND variation_feature_id <= $end};
+
+  my $sth = $dbVar->prepare( $sql );
+
+  local *FH;
+  open ( FH, ">>$TMP_DIR/$TMP_FILE" )
+      or die( "Cannot open $TMP_DIR/$TMP_FILE: $!" );
+
+  $sth->execute();
+
+  while ( my $aref = $sth->fetchrow_arrayref() ) {
+    my @a = map {defined($_) ? $_ : '\N'} @$aref;
+    print FH join("\t", @a), "\n";
+
+  }
+
+  close FH;
+  $sth->finish();
+
+  return $end, $tmp_num;
+}
 
 sub usage {
 

--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -200,5 +200,5 @@ $dbh->do(qq{ ALTER TABLE $tmp_vset_table RENAME TO variation_set_variation }) or
 
 sub usage{
 
-  die "\n\tUsage: update_changed_sets.pl -registry [registry file] -release [release number] -tmp [temp folder]\n\n";
+  die "\n\tUsage: update_old_sets.pl -registry [registry file] -release [release number] -tmp [temp folder]\n\n";
 }

--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -100,8 +100,8 @@ system("awk '{if (\$2) print \$0;}' $TMP_DIR/$TMP_FILE | sort -u > $TMP_DIR/$TMP
 
 ### Dump new variation_set_variation / Update new variation_feature.variation_set_id
 
-  my $var_ext_sth = $dbh->prepare(qq[ SELECT variation_id FROM variation WHERE name = ? limit 1]);
-  my $vfid_ext_sth = $dbh->prepare(qq[ SELECT variation_set_id from variation_feature WHERE variation_id = ? limit 1]);
+my $var_ext_sth = $dbh->prepare(qq[ SELECT variation_id FROM variation WHERE name = ? limit 1]);
+my $vfid_ext_sth = $dbh->prepare(qq[ SELECT variation_set_id from variation_feature WHERE variation_id = ? limit 1]);
 
 my $vsv_create_sth = $dbh->prepare(qq[ CREATE TABLE IF NOT EXISTS $tmp_vset_table LIKE variation_set_variation ]);
 my $vsv_dis_sth = $dbh->prepare(qq[ ALTER TABLE $tmp_vset_table DISABLE KEYS ]);
@@ -192,7 +192,7 @@ system("rm $TMP_DIR/$TMP_FILE $TMP_DIR/$TMP_FILE.not_empty $TMP_DIR/$TMP_FILE.du
 $dbh->do(qq{ DROP TABLE IF EXISTS variation_set_variation }) or die "Failed to drop variation_set_variation table";
 $dbh->do(qq{ ALTER TABLE $tmp_vset_table RENAME TO variation_set_variation }) or die "Failed to rename table";
 
-sub usage{
+sub usage {
 
   die "\n\tUsage: update_old_sets.pl -registry [registry file] -release [release number] -tmp [temp folder]\n\n";
 }

--- a/scripts/import/dbSNP_v2/update_old_sets.pl
+++ b/scripts/import/dbSNP_v2/update_old_sets.pl
@@ -94,7 +94,7 @@ for my $tmp_num (map { $_ } 0 .. $size/$chunk) {
   dumpPreparedSQL($old_dbh, $tmp_num, $chunk, $size);
 }
 
-system("awk '{if (\$2) print \$0;}' $TMP_DIR/$TMP_FILE > $TMP_DIR/$TMP_FILE.not_empty");
+system("awk '{if (\$2) print \$0;}' $TMP_DIR/$TMP_FILE | sort -u > $TMP_DIR/$TMP_FILE.not_empty");
 
 ### Dump new variation_set_variation / Update new variation_feature.variation_set_id
 


### PR DESCRIPTION
Card: [JIRA](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5097)

## Description

This script is meant to be used every new dbSNP import to update values from variation_feature.variation_set_id + "lift" old variation_set_variation table.

## How-to-use

1) Setup a registry file with database that have new dbSNP import.
2) Make sure that host have same database name pattern with last version, i.e:
New database: homo\_sapiens\_variation\_**109**\_38 or dbSNP\_database\_test\_**109**\_38
Old database: homo\_sapiens\_variation\_**108**\_38 or dbSNP\_database\_test\_**108**\_38

3) Command-line demand:
* Registry file
* Release number
* Temp directory folder

Example: `perl <PATH-TO>/update_old_sets.pl -registry ensembl.registry -release 109 -tmp <PATH-TO-FOLDER>/`

## Test (Details on JIRA ticket)

1) Create old database with variation_feature, and new database with variation_feature, variation, variation_set_variation;
2) Run script pointing to new database.