### PR TITLE
Update ftp links to https

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF_human
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_GVF_human
@@ -31,10 +31,10 @@ Additionally, we provide for human:
     - NOTE:
         - files containing allele frequencies from several of the HapMap
           populations have been discontinued and are available from our archive sites,
-          the latest being ftp://ftp.ensembl.org/pub/release-97/variation/gvf/homo_sapiens/
+          the latest being https://ftp.ensembl.org/pub/release-97/variation/gvf/homo_sapiens/
         - files containing allele frequencies from populations from the
           Exome Sequencing Project have been discontinued and are available
-          from our archive sites, the latest being ftp://ftp.ensembl.org/pub/release-98/variation/gvf/homo_sapiens/
+          from our archive sites, the latest being https://ftp.ensembl.org/pub/release-98/variation/gvf/homo_sapiens/
 
 If available for this species, the file includes information on:
     - ancestral_allele

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF
@@ -34,7 +34,7 @@ Example content from the human germline VCF dump is shown below:
 ##fileformat=VCFv4.1
 ##fileDate=20140713
 ##source=ensembl;version=76;url=http://e76.ensembl.org/Gallus_gallus
-##reference=ftp://ftp.ensembl.org/pub/release-76/fasta/Gallus_gallus/dna/
+##reference=https://ftp.ensembl.org/pub/release-76/fasta/Gallus_gallus/dna/
 ##INFO=<ID=dbSNP_140,Number=0,Type=Flag,Description="Variants (including SNPs and indels) imported from dbSNP">
 ##INFO=<ID=TSA,Number=1,Type=String,Description="Type of sequence alteration. Child of term sequence_alteration as defined by the sequence ontology project.">
 ##INFO=<ID=E_Cited,Number=0,Type=Flag,Description="Cited.http://www.ensembl.org/info/docs/variation/data_description.html#evidence_status">

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF_human
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/README_VCF_human
@@ -29,10 +29,10 @@ Additionally, we provide for human:
     - NOTE:
         - files containing allele frequencies from several of the HapMap
           populations have been discontinued and are available from our archive sites,
-          the latest being ftp://ftp.ensembl.org/pub/release-97/variation/vcf/homo_sapiens/
+          the latest being https://ftp.ensembl.org/pub/release-97/variation/vcf/homo_sapiens/
         - files containing allele frequencies from populations from the
           Exome Sequencing Project have been discontinued and are available
-          from our archive sites, the latest being ftp://ftp.ensembl.org/pub/release-98/variation/vcf/homo_sapiens/
+          from our archive sites, the latest being https://ftp.ensembl.org/pub/release-98/variation/vcf/homo_sapiens/
 If available for this species, the file includes information on:
     - ancestral_allele
     - evidence
@@ -58,7 +58,7 @@ Example content from the human germline VCF dump is shown below:
 ##fileformat=VCFv4.1
 ##fileDate=20140713
 ##source=ensembl;version=76;url=http://e76.ensembl.org/Gallus_gallus
-##reference=ftp://ftp.ensembl.org/pub/release-76/fasta/Gallus_gallus/dna/
+##reference=https://ftp.ensembl.org/pub/release-76/fasta/Gallus_gallus/dna/
 ##INFO=<ID=dbSNP_140,Number=0,Type=Flag,Description="Variants (including SNPs and indels) imported from dbSNP">
 ##INFO=<ID=TSA,Number=1,Type=String,Description="Type of sequence alteration. Child of term sequence_alteration as defined by the sequence ontology project.">
 ##INFO=<ID=E_Cited,Number=0,Type=Flag,Description="Cited.http://www.ensembl.org/info/docs/variation/data_description.html#evidence_status">

--- a/modules/Bio/EnsEMBL/Variation/Utils/dbSNP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/dbSNP.pm
@@ -48,7 +48,7 @@ for each value specified in the field.
 
 The encoding is taken from the following NCBI document:
 
-ftp://ftp.ncbi.nlm.nih.gov/snp/specs/dbSNP_BitField_latest.pdf
+https://ftp.ncbi.nlm.nih.gov/snp/specs/dbSNP_BitField_latest.pdf
 
 An additional subroutine converts allele strings from dbSNP format
 to ensembl format, as used multiple times in the import pipeline.

--- a/modules/t/structuralVariation.t
+++ b/modules/t/structuralVariation.t
@@ -52,7 +52,7 @@ my $source = Bio::EnsEMBL::Variation::Source->new
 
 ## need Study object 
 my $study_name = 'estd59';
-my $study_url = 'ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project';
+my $study_url = 'https://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project';
 my $study_description = '1000 Genomes Project Consortium - Pilot Project. PMID:20981092';
 
 my $study = Bio::EnsEMBL::Variation::Study->new

--- a/modules/t/structuralVariationFeature.t
+++ b/modules/t/structuralVariationFeature.t
@@ -51,7 +51,7 @@ my $source = Bio::EnsEMBL::Variation::Source->new
 
 ## need Study object 
 my $study_name = 'estd59';
-my $study_url = 'ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project';
+my $study_url = 'https://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project';
 my $study_description = '1000 Genomes Project Consortium - Pilot Project. PMID:20981092';
 
 my $study = Bio::EnsEMBL::Variation::Study->new

--- a/modules/t/studyAdaptor.t
+++ b/modules/t/studyAdaptor.t
@@ -36,7 +36,7 @@ my $name         = 'estd1';
 my %study_list   = ( $name => 4237, 'estd55' => 4246 );
 my @study_IDs    = sort {$a <=> $b} values(%study_list);
 my $description  = 'Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]';
-my $url          = 'ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006';
+my $url          = 'https://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006';
 my $type         = 'Control Set';
 my $external_ref = 'pubmed/17122850';
 

--- a/modules/t/supportingStructuralVariation.t
+++ b/modules/t/supportingStructuralVariation.t
@@ -52,7 +52,7 @@ my $source = Bio::EnsEMBL::Variation::Source->new
 
 ## need Study object  
 my $study_name = 'estd1';
-my $study_url = 'ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006';
+my $study_url = 'https://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006';
 my $study_description = 'Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]';
 
 my $study = Bio::EnsEMBL::Variation::Study->new

--- a/modules/t/test-genome-DBs/homo_sapiens/variation/study.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/variation/study.txt
@@ -1,7 +1,7 @@
-4237	11	estd1	Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006	pubmed/17122850	Control Set
-4246	11	estd55	Pinto 2007 "Copy-number variation in control population cohorts." PMID:17911159 [remapped from build NCBI35]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd55_Pinto_et_al_2007	pubmed/17911159	Control Set
-4247	11	estd59	1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project	pubmed/20981092	\N
-4478	11	estd194	Bentley 2008 "Accurate whole human genome sequencing using reversible terminator chemistry" PMID:18987734 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd194_Bentley_et_al_2008	pubmed/18987734	Control Set
-4479	11	estd195	Altshuler 2010 "Integrating common and rare genetic variation in diverse human populations" PMID:20811451 [remapped from build NCBI36]	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd195_Altshuler_et_al_2010	pubmed/20811451	Control Set
+4237	11	estd1	Redon 2006 "Global variation in copy number in the human genome." PMID:17122850 [remapped from build NCBI35]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd1_Redon_et_al_2006	pubmed/17122850	Control Set
+4246	11	estd55	Pinto 2007 "Copy-number variation in control population cohorts." PMID:17911159 [remapped from build NCBI35]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd55_Pinto_et_al_2007	pubmed/17911159	Control Set
+4247	11	estd59	1000 Genomes Project Consortium - Pilot Project. PMID:20981092 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd59_1000_Genomes_Consortium_Pilot_Project	pubmed/20981092	\N
+4478	11	estd194	Bentley 2008 "Accurate whole human genome sequencing using reversible terminator chemistry" PMID:18987734 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd194_Bentley_et_al_2008	pubmed/18987734	Control Set
+4479	11	estd195	Altshuler 2010 "Integrating common and rare genetic variation in diverse human populations" PMID:20811451 [remapped from build NCBI36]	https://ftp.ebi.ac.uk/pub/databases/dgva/estd195_Altshuler_et_al_2010	pubmed/20811451	Control Set
 5000	23	asso_study	Test study for the associate_study table			\N
-28922	11	estd214	1000 Genomes Project Consortium - Phase 3	ftp://ftp.ebi.ac.uk/pub/databases/dgva/estd214_1000_Genomes_Consortium_Phase_3/	\N	Control Set
+28922	11	estd214	1000 Genomes Project Consortium - Phase 3	https://ftp.ebi.ac.uk/pub/databases/dgva/estd214_1000_Genomes_Consortium_Phase_3/	\N	Control Set

--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -399,7 +399,7 @@ sub study_table{
   $study =~ /(\w+\d+)\.?\d*/;
   my $study_ftp = $1;
   if ($source_name eq 'DGVa'){
-    $study_ftp = "ftp://ftp.ebi.ac.uk/pub/databases/dgva/$study_ftp\_$author";
+    $study_ftp = "https://ftp.ebi.ac.uk/pub/databases/dgva/$study_ftp\_$author";
   }
   else {
     $study_ftp = "https://www.ncbi.nlm.nih.gov/dbvar/studies/$study_ftp";
@@ -2136,7 +2136,7 @@ Options:
   -size_diff       : % difference allowed in size after mapping (optional)
   -version         : version number of the data (required)
   -registry        : registry file (optional)
-  -medgen_file     : Path to the unzipped MedGen file (see on ftp://ftp.ncbi.nlm.nih.gov/pub/medgen/csv/NAMES.csv.gz)
+  -medgen_file     : Path to the unzipped MedGen file (see on https://ftp.ncbi.nlm.nih.gov/pub/medgen/csv/NAMES.csv.gz)
   -hpo_file        : Path to the Human Phenotype Ontology (HPO) file (see on http://compbio.charite.de/hudson/job/hpo/lastSuccessfulBuild/artifact/hp/hp.obo)
   -replace         : flag to remove the existing study data from the database before import them (optional)
   -debug           : flag to keep the $temp_table table (optional)

--- a/scripts/misc/release/gvf2vcf.pl
+++ b/scripts/misc/release/gvf2vcf.pl
@@ -710,7 +710,7 @@ sub print_header {
       $url = 'https://'.$division.'.ensembl.org/'.$species_name;
     }
     my $vcf_source_field = "ensembl;version=$schema_version;url=$url";
-    my $reference_info = "ftp://ftp.ensembl.org/pub/release-$schema_version/fasta/$species_name/dna/";
+    my $reference_info = "https://ftp.ensembl.org/pub/release-$schema_version/fasta/$species_name/dna/";
 
     # Meta-information
     print $fh join("\n", '##fileformat=VCFv4.1', "##fileDate=$vcf_file_date", "##source=$vcf_source_field", "##reference=$reference_info"), "\n";

--- a/scripts/misc/veplotyper.pl
+++ b/scripts/misc/veplotyper.pl
@@ -110,7 +110,7 @@ sub configure {
   
   # defaults
   $config->{rest}              ||= 'http://rest.ensembl.org';
-  $config->{vcf_file}          ||= 'ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20110521/ALL.chr###CHR###.phase1_release_v3.20101123.snps_indels_svs.genotypes.vcf.gz';
+  $config->{vcf_file}          ||= 'https://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20110521/ALL.chr###CHR###.phase1_release_v3.20101123.snps_indels_svs.genotypes.vcf.gz';
   $config->{cache_region_size} ||= 1000000;
   $config->{chunk_size}        ||= 50000;
   $config->{compress}          ||= 'zcat';

--- a/scripts/remap_gnomad/README
+++ b/scripts/remap_gnomad/README
@@ -13,8 +13,8 @@ Rename trimmed files
 
 Run CrossMap
   dowload chain file and FASTA file
-    - GRCh38 reference genome: ftp://ftp.ensembl.org/pub/release-95/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
-    - Chain file: ftp://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/GRCh37_to_GRCh38.chain.gz
+    - GRCh38 reference genome: https://ftp.ensembl.org/pub/release-95/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
+    - Chain file: https://ftp.ensembl.org/pub/assembly_mapping/homo_sapiens/GRCh37_to_GRCh38.chain.gz
   create a sensible directory structure and update the scripts accordingly, for example
     working_directory/gnomad/Genomes
     working_directory/gnomad/Genomes/mapping_results


### PR DESCRIPTION
This PR updates all ftp URLs from `http://` and `ftp://` protocol to https.
The affected hostnames have been tested to work with https.
Other affected repos are listed in the JIRA ticket.

Webteam JIRA ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSWEB-6632
Sandbox: http://wp-np2-1d.ebi.ac.uk:1680