### PR TITLE
Prevent gvf file corruption in Release dump pipeline

### DIFF
--- a/scripts/export/release/dump_gvf.pl
+++ b/scripts/export/release/dump_gvf.pl
@@ -102,6 +102,10 @@ init_sample_data($config) if (defined $config->{individual} || defined $config->
 $config->{sample} = $config->{individual} if (defined $config->{individual});
 init_consequence_data($config) if ($config->{incl_consequences});
 init_slices($config);
+# If the file already present delete it before starting from start again, otherwise the file gets corrupted
+if( -e $config->{gvf_file} && !-z $config->{gvf_file}){
+  unlink($config->{gvf_file}) or die $config->{gvf_file} . " already exists and can not delete it\n";
+}
 $config->{fh} = FileHandle->new($config->{gvf_file}, 'w');
 print_header($config);
 if ($config->{structural_variations}) {


### PR DESCRIPTION
If the release dump pipeline is stopped in the middle of gvf file dumping from DB and restarted again, it starts appending on the already existing file. It results in gvf file corruption.

To prevent this, check if file already there and is not empty and just delete the file before starting gvf dump all over again. 