### PR TITLE
fix: Do not run if update_diff is wrong

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequencePreTasks.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequencePreTasks.pm
@@ -55,7 +55,7 @@ sub fetch_input {
     }
 
     # check for out of date seq_regions in variation database
-    my $sequences_ok = $self->check_seq_region();;
+    my $sequences_ok = $self->check_seq_region();
     die "Seq region ids are not compatible. Run ensembl-variation/scripts/misc/update_seq_region_ids.pl\n" unless $sequences_ok == 1;
 
     my $update_diff = $self->param('update_diff');

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequencePreTasks.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequencePreTasks.pm
@@ -55,10 +55,15 @@ sub fetch_input {
     }
 
     # check for out of date seq_regions in variation database
-    my $sequences_ok = $self->check_seq_region();
+    my $sequences_ok = $self->check_seq_region();;
     die "Seq region ids are not compatible. Run ensembl-variation/scripts/misc/update_seq_region_ids.pl\n" unless $sequences_ok == 1;
 
-    return if (-e $self->param('update_diff'));
+    my $update_diff = $self->param('update_diff');
+
+    if (defined($update_diff)) {
+      die "File used in flag --update_diff $update_diff does not exist\n" if !-e $update_diff;
+      return;
+    }
 
     my $core_dba = $self->get_species_adaptor('core');
     my $var_dba = $self->get_species_adaptor('variation');
@@ -88,7 +93,7 @@ sub fetch_input {
     my $mtmp = $self->param('mtmp_table');
 
       # set up MTMP table
-    if($mtmp && !-e $self->param('update_diff')) {
+    if($mtmp) {
         my @exclude = qw(transcript_variation_id hgvs_genomic hgvs_protein hgvs_transcript somatic codon_allele_string);
         my ($source_table, $table) = qw(transcript_variation MTMP_transcript_variation);
 


### PR DESCRIPTION
Jira: [Card](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5255)

## Description

While running update_mode, if you set a wrong `--update_diff` filename pipeline understands that you have started a full mode wrongly. This PR creates a `die` to crash in first task to advise that user need to introduce correct name.

## Test

1) Start a VariationConsequence pipeline with `--update_diff` followed by a wrong name.
2) It should get: `File used in flag --update_diff <PATH-TO>/<FILE> does not exist`
