### PR TITLE
fix: Splice_polyrimide_tract term over-annotation

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -303,7 +303,7 @@ sub feature_truncation {
     );
 }
 
-sub protein_altering_variant{
+sub protein_altering_variant {
 
     ## check in protein
     my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
@@ -322,15 +322,6 @@ sub protein_altering_variant{
 
     return 1;
 }
-
-#sub transcript_fusion {
-#    #my ($bvfoa, $feat, $bvfo, $bvf) = @_;
-#    #my $bvf   = $bvfoa->base_variation_feature;
-#    
-#    return 0;
-#    
-#    #my $transcripts = $bvf->_get_overlapping_Transcripts();
-#}
 
 sub _before_start {
     my ($bvf, $feat, $dist) = @_;
@@ -530,6 +521,7 @@ sub splice_polypyrimidine_tract_variant  {
     $feat ||= $bvfo->feature;
     my $ie = $bvfoa->_intron_effects($feat, $bvfo, $bvf);
 
+    return 0 if acceptor_splice_site(@_);
     return $feat->strand == 1 ? $ie->{polypyrimidine_splice_site} : $ie->{polypyrimidine_splice_site_reverse};
 }
 
@@ -537,8 +529,6 @@ sub splice_region {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvfo ||= $bvfoa->base_variation_feature_overlap;
     
-    return 0 if donor_splice_site(@_);
-    return 0 if acceptor_splice_site(@_);
     return 0 if essential_splice_site(@_);
     return 0 if splice_donor_region_variant(@_);
     return 0 if splice_donor_5th_base_variant(@_);

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -543,7 +543,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $exon_start-10,
         end     => $exon_end+10,
-        effects => [qw(intron_variant splice_donor_5th_base_variant splice_polypyrimidine_tract_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
+        effects => [qw(intron_variant splice_donor_5th_base_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
     }, {
         comment => 'long sequence var where middle is identical but overlaps splice site',
         alleles => 'ATGTACTGCCTATGTGTGCTGTGAGTATGATACGGTGGACT',
@@ -756,7 +756,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_end-2,
         end     => $intron_end+3,
-        effects => [qw( splice_acceptor_variant coding_sequence_variant splice_polypyrimidine_tract_variant intron_variant)],
+        effects => [qw( splice_acceptor_variant coding_sequence_variant intron_variant)],
     }, {
         comment => 'deletion overlapping UTR and start site, start lost 1',
         alleles => '-',
@@ -1242,7 +1242,7 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_start - 3,
         end     => $intron_start + 2,
-        effects => [qw( splice_acceptor_variant splice_polypyrimidine_tract_variant coding_sequence_variant intron_variant)],
+        effects => [qw( splice_acceptor_variant coding_sequence_variant intron_variant)],
     }, {
         alleles => '-',
         start   => $cds_end - 2,


### PR DESCRIPTION
## Description

During SV annotation, we are over-annotating `splice_polypyrimidine_tract_variant` in every SV that overlaps splice region related to this type of variant (+3 til +17 next to 3' acceptor_site).

## Test

1) Check `splice_polypyrimidine_tract_variant` in different scenarios.

PS. coverage decreased due to commented code removal.