### PR TITLE
Print PolyPhen-2 pipeline errors in eHive

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunPolyPhen.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunPolyPhen.pm
@@ -167,7 +167,7 @@ sub run {
               "run_pph.pl -A -d $output_dir -s $protein_file $subs_file " .
               "1> $output_file 2> $error_file";
 
-    system($cmd) == 0 or die "Failed to run $cmd: $?";
+    system($cmd) == 0 or die `echo "Failed to run $cmd:" && cat "$filename"`;
     
     $self->dbc->disconnect_when_inactive(0);
     

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunWeka.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/RunWeka.pm
@@ -94,7 +94,7 @@ sub run {
                   "--bind $pph_data:/opt/pph2/data $pph_dir/polyphen-2_2.2.3.sif " .
                   "run_weka.pl -l $model $input_file 1> $output_file 2> $error_file";
 
-        system($cmd) == 0 or die "Failed to run $cmd: $?";
+        system($cmd) == 0 or die `echo "Failed to run $cmd:" && cat "$filename"`;
 
         if (-s $error_file) {
             warn "run_weka.pl STDERR output in $error_file\n";


### PR DESCRIPTION
Since changing ProteinFunction pipeline to run PolyPhen-2 via Singularity, any errors raised only state that the Singularity instance failed. This PR intends to properly display the errors from PolyPhen-2 as before it was run in Singularity.