### PR TITLE
refactor: Avoid over-annotation of splice_polypyrimide_tract_variant

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -554,7 +554,8 @@ our %OVERLAP_CONSEQUENCES = (
   'feature_class' => 'Bio::EnsEMBL::Transcript',
   'impact' => 'LOW',
   'include' => {
-                 'intron' => 1
+                 'intron' => 1,
+                 'exon' => 0,
                },
   'label' => 'splice polypyrimidine tract variant',
   'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::splice_polypyrimidine_tract_variant',

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -543,7 +543,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $exon_start-10,
         end     => $exon_end+10,
-        effects => [qw(intron_variant splice_donor_5th_base_variant splice_polypyrimidine_tract_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
+        effects => [qw(intron_variant splice_donor_5th_base_variant splice_acceptor_variant splice_donor_variant coding_sequence_variant )],
     }, {
         comment => 'long sequence var where middle is identical but overlaps splice site',
         alleles => 'ATGTACTGCCTATGTGTGCTGTGAGTATGATACGGTGGACT',
@@ -756,7 +756,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_end-2,
         end     => $intron_end+3,
-        effects => [qw( splice_acceptor_variant coding_sequence_variant splice_polypyrimidine_tract_variant intron_variant)],
+        effects => [qw( splice_acceptor_variant coding_sequence_variant intron_variant)],
     }, {
         comment => 'deletion overlapping UTR and start site, start lost 1',
         alleles => '-',
@@ -1242,7 +1242,7 @@ $transcript_tests->{$tr->stable_id}->{tests} = [
         alleles => '-',
         start   => $intron_start - 3,
         end     => $intron_start + 2,
-        effects => [qw( splice_acceptor_variant splice_polypyrimidine_tract_variant coding_sequence_variant intron_variant)],
+        effects => [qw( splice_acceptor_variant coding_sequence_variant intron_variant)],
     }, {
         alleles => '-',
         start   => $cds_end - 2,


### PR DESCRIPTION
## Description

During SV annotation, we are over-annotating `splice_polypyrimidine_tract_variant` in every SV that overlaps splice region related to this type of variant (+3 til +17 next to 3' acceptor_site). It was decided that when variant touches exon, it should not deliver splice_polypyrimidine_tract_variant as a term.

## Test

1) Check `splice_polypyrimidine_tract_variant` in different scenarios.

PS. coverage decreased due to commented code removal.