### PR TITLE
Improve COSMIC import by chromosome and cleanup

### DIFF
--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -91,19 +91,21 @@ sub performCleanup {
     $main_table =~ s/[0-9]+$//;
     next if $table eq $main_table;
 
+    warn "Moving $table contents to $main_table...\n";
     $dbVar->do("INSERT INTO $main_table SELECT * FROM $table;");
     delete_table($dbVar, $table);
   }
   $sth->finish();
 
   my ($dbname) = $dbh->selectrow_array("select DATABASE()");
-  my $tmptables = $dbname . "_tmptables";
-  $dbVar->do("CREATE DATABASE IF NOT EXISTS $tmptables;
-    RENAME TABLE $temp_table_prefix TO $tmptables.$temp_table_prefix;
-    RENAME TABLE $temp_phen_table_prefix TO $tmptables.$temp_phen_table_prefix;
-    RENAME TABLE $temp_varSyn_table_prefix TO $tmptables.$temp_varSyn_table_prefix;");
+  my $tmpdb = $dbname . "_tmptables";
+  warn "Moving tmp tables to $tmpdb...\n";
+  $dbVar->do("CREATE DATABASE IF NOT EXISTS $tmpdb;
+    RENAME TABLE $temp_table_prefix TO $tmpdb.$temp_table_prefix;
+    RENAME TABLE $temp_phen_table_prefix TO $tmpdb.$temp_phen_table_prefix;
+    RENAME TABLE $temp_varSyn_table_prefix TO $tmpdb.$temp_varSyn_table_prefix;");
 
-  print "Auxiliary COSMIC tables removed and their rows were aggregated into " .
+  warn "Auxiliary COSMIC tables removed and their rows were aggregated into " .
         "the following tables and moved to $tmptables:\n" .
         "  - $temp_table_prefix\n" .
         "  - $temp_phen_table_prefix\n" .

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -27,23 +27,23 @@ use Text::CSV;
 my ( $infile, $registry_file, $version, $help, $chromosome, $cleanup );
 
 GetOptions(
-  "import|i=s"       => \$infile,
-  "registry|r=s"     => \$registry_file,
-  "cosmic|version=s" => \$version,
-  "help|h"           => \$help,
-  "chromosome=s"     => \$chromosome,
-  "cleanup|c"        => \$cleanup,
+  "import|i=s"   => \$infile,
+  "registry|r=s" => \$registry_file,
+  "version=s"    => \$version,
+  "help|h"       => \$help,
+  "chromosome=s" => \$chromosome,
+  "cleanup|c"    => \$cleanup,
 );
 
 if ($help) {
     warn "
     Usage:
-      $0 --import <input_file> --registry <reg_file> --cosmic <cosmic_version>
+      $0 --import <input_file> --registry <reg_file> --version <cosmic_version>
     
     To import COSMIC variants per chromosome:
-      $0 --import <input_file> --registry <reg_file> --cosmic <cosmic_version> --chromosome 1
-      $0 --import <input_file> --registry <reg_file> --cosmic <cosmic_version> --chromosome X
-      $0 --import <input_file> --registry <reg_file> --cosmic <cosmic_version> --chromosome MT
+      $0 --import <input_file> --registry <reg_file> --version <cosmic_version> --chromosome 1
+      $0 --import <input_file> --registry <reg_file> --version <cosmic_version> --chromosome X
+      $0 --import <input_file> --registry <reg_file> --version <cosmic_version> --chromosome MT
       # clean up data
       $0 --registry <reg_file> --cleanup\n";
     exit(0);

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -97,16 +97,17 @@ sub performCleanup {
   }
   $sth->finish();
 
-  my ($dbname) = $dbh->selectrow_array("select DATABASE()");
-  my $tmpdb = $dbname . "_tmptables";
+  my $dbname = $dbVar->selectrow_array("select DATABASE()");
+  my $tmpdb  = $dbname . "_tmptables";
+  $dbVar->do("CREATE DATABASE IF NOT EXISTS $tmpdb");
+  
   warn "Moving tmp tables to $tmpdb...\n";
-  $dbVar->do("CREATE DATABASE IF NOT EXISTS $tmpdb;
-    RENAME TABLE $temp_table_prefix TO $tmpdb.$temp_table_prefix;
-    RENAME TABLE $temp_phen_table_prefix TO $tmpdb.$temp_phen_table_prefix;
-    RENAME TABLE $temp_varSyn_table_prefix TO $tmpdb.$temp_varSyn_table_prefix;");
+  $dbVar->do("RENAME TABLE $temp_table_prefix TO $tmpdb.$temp_table_prefix");
+  $dbVar->do("RENAME TABLE $temp_phen_table_prefix TO $tmpdb.$temp_phen_table_prefix");
+  $dbVar->do("RENAME TABLE $temp_varSyn_table_prefix TO $tmpdb.$temp_varSyn_table_prefix");
 
   warn "Auxiliary COSMIC tables removed and their rows were aggregated into " .
-        "the following tables and moved to $tmptables:\n" .
+        "the following tables and moved to $tmpdb:\n" .
         "  - $temp_table_prefix\n" .
         "  - $temp_phen_table_prefix\n" .
         "  - $temp_varSyn_table_prefix\n";

--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -95,8 +95,16 @@ sub performCleanup {
     delete_table($dbVar, $table);
   }
   $sth->finish();
+
+  my ($dbname) = $dbh->selectrow_array("select DATABASE()");
+  my $tmptables = $dbname . "_tmptables";
+  $dbVar->do("CREATE DATABASE IF NOT EXISTS $tmptables;
+    RENAME TABLE $temp_table_prefix TO $tmptables.$temp_table_prefix;
+    RENAME TABLE $temp_phen_table_prefix TO $tmptables.$temp_phen_table_prefix;
+    RENAME TABLE $temp_varSyn_table_prefix TO $tmptables.$temp_varSyn_table_prefix;");
+
   print "Auxiliary COSMIC tables removed and their rows were aggregated into " .
-        "the following tables:\n" .
+        "the following tables and moved to $tmptables:\n" .
         "  - $temp_table_prefix\n" .
         "  - $temp_phen_table_prefix\n" .
         "  - $temp_varSyn_table_prefix\n";


### PR DESCRIPTION
- Filter COSMIC import by chromosome (no need to split input file beforehand)
- When cleaning up, move tmp tables to new database with same name suffixed by `_tmptables`

Minor improvements:
- Allow to use `cosmic` argument instead of `version` to specify COSMIC version (to avoid confusing with Ensembl release version)
- Fix `cleanup` instructions
- Raise error if cleaning up without providing a registry file
- Print messages with progress of cleanup