### PR TITLE
Fix SIFT database version in SIFT/PolyPhen-2 Nextflow pipeline (e110)

### DIFF
--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -22,11 +22,11 @@ params.database = null
 // SIFT params
 params.sift_run_type = "NONE"
 params.median_cutoff = 2.75 // as indicated in SIFT's README
-params.blastdb       = null
+params.blastdb       = "/nfs/production/flicek/ensembl/variation/data/uniref90/uniref90.fasta"
 
 // PolyPhen-2 params
 params.pph_run_type = "NONE"
-params.pph_data     = null
+params.pph_data     = "/hps/software/users/ensembl/variation/polyphen-2.2.3/data"
 
 // Print usage
 if (params.help) {

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -16,7 +16,7 @@ process get_sift_db_version {
   /*
   Get version from UniRef release note file (if available)
   */
-  container "nunoagostinho/sift:6.2.1"
+  container "ensemblorg/sift:6.2.1"
   input:
     path db_dir
     path db

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -26,9 +26,9 @@ process get_sift_db_version {
   """
   release_note=${db_dir}/${db.baseName}.release_note
   if [ -f \${release_note} ]; then
-    version=$(grep -oE "[0-9]+_[0-9]+" \${release_note})
+    version=`grep -oE "[0-9]+_[0-9]+" \${release_note}`
   else
-    version=$(date -r ${db} -u +%Y_%m)
+    version=`date -r ${db} -u +%Y_%m`
   fi
   echo -n "${db.baseName} (\${version})"
   """

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -128,7 +128,7 @@ workflow update_sift_version {
 workflow update_sift_db_version {
   take: db
   main:
-    get_sift_db_version( db.parent, db.name )
+    get_sift_db_version( db.parent, db )
     update_meta("sift_db_version", get_sift_db_version.out)
 }
 

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -13,14 +13,24 @@ process get_sift_version {
 }
 
 process get_sift_db_version {
+  /*
+  Get version from UniRef release note file (if available)
+  */
   container "nunoagostinho/sift:6.2.1"
   input:
+    path db_dir
     path db
   output:
     stdout
 
   """
-  echo -n ${db.baseName} \\(`date -r ${db} -u +"%Y_%m"`\\)
+  release_note=${db_dir}/${db.baseName}.release_note
+  if [ -f \${release_note} ]; then
+    version=$(grep -oE "[0-9]+_[0-9]+" \${release_note})
+  else
+    version=$(date -r ${db} -u +%Y_%m)
+  fi
+  echo -n "${db.baseName} (\${version})"
   """
 }
 
@@ -118,7 +128,7 @@ workflow update_sift_version {
 workflow update_sift_db_version {
   take: db
   main:
-    get_sift_db_version( db )
+    get_sift_db_version( db.parent, db.name )
     update_meta("sift_db_version", get_sift_db_version.out)
 }
 


### PR DESCRIPTION
- Use UniRef release note file to get proper database version
- Add default paths to data for SIFT and PolyPhen-2
- Point to `ensemblorg`'s SIFT Docker image