### PR TITLE
Improve SIFT/PolyPhen-2 Nextflow pipeline

### DIFF
--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -97,6 +97,10 @@ if (!params.translated) {
   }
 }
 
+if (!params.host || !params.port || !params.user || !params.pass || !params.database) {
+  exit 1, "Error: --host, --port, --user, --pass and --database need to be defined"
+}
+
 // Check run type for each protein function predictor
 def check_run_type ( run ) {
   run_types = ["NONE", "UPDATE", "FULL"]

--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -8,28 +8,24 @@ profiles {
   }
 
   lsf {
-    process {
-      executor = 'lsf'
-      queue = 'production'
-      // withLabel: default {
-      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
-      // }
-      // withLabel: medmem {
-      //   clusterOptions = '-R"select[mem>8000] rusage[mem=8000]" -M8000'
-      // }
-      // withLabel: urgent {
-      //  clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
-      // }
-      // withLabel: higmem {
-      //   clusterOptions = '-R"select[mem>16000] rusage[mem=16000]" -M16000'
-      // }
-      // withLabel: long {
-      //   clusterOptions = '-R"select[mem>2000] rusage[mem=2000]" -M2000'
-      // }
+    executor {
+      name = 'lsf'
+      queueSize = 500
+      submitRateLimit = '100/1sec'
     }
+
     singularity {
       enabled = true
       autoMounts = true
+    }
+
+    process {
+      queue = 'production'
+      memory = '2GB'
+      withLabel: medmem { memory =  '8 GB' }
+      withLabel: urgent { memory =  '2 GB' }
+      withLabel: higmem { memory = '24 GB' }
+      withLabel: long   { memory =  '2 GB' }
     }
   }
 

--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -26,10 +26,11 @@ process {
   withLabel: higmem { memory = '24 GB' }
   withLabel: long   { memory =  '2 GB' }
 
-  // avoid Nextflow job submission issues, e.g., "Request from non-LSF host rejected"
-  errorStrategy = { task.exitStatus = 255 ? 'retry' : 'finish' }
+  // avoid Nextflow job submission issues (exit status: 255)
+  // e.g., "Request from non-LSF host rejected"
+  errorStrategy = { task.exitStatus == 255 ? 'retry' : 'finish' }
   withLabel: error-ignore {
-    errorStrategy = { task.exitStatus = 255 ? 'retry' : 'ignore' }
+    errorStrategy = { task.exitStatus == 255 ? 'retry' : 'ignore' }
   }
   maxRetries = 3
 }

--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -45,12 +45,14 @@ profiles {
 
 trace {
     enabled = true
+    overwrite = true
     file = "reports/trace.txt"
     //fields = 'task_id,name,status,exit,realtime,%cpu,rss'
 }
 
 dag {
     enabled = true
+    overwrite = true
     file = "reports/flowchart.html"
 }
 
@@ -62,5 +64,6 @@ timeline {
 
 report {
     enabled = true
+    overwrite = true
     file = "reports/report.html"
 }

--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -29,7 +29,7 @@ process {
   // avoid Nextflow job submission issues (exit status: 255)
   // e.g., "Request from non-LSF host rejected"
   errorStrategy = { task.exitStatus == 255 ? 'retry' : 'finish' }
-  withLabel: error-ignore {
+  withLabel: retry_error_then_ignore {
     errorStrategy = { task.exitStatus == 255 ? 'retry' : 'ignore' }
   }
   maxRetries = 3

--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -1,42 +1,37 @@
 profiles {
-  standard {
-    process.executor = 'local'
-    singularity {
-      enabled = true
-      autoMounts = true
-    }
-  }
+  standard { process.executor = 'local' }
 
   lsf {
     executor {
-      name = 'lsf'
-      queueSize = 500
-      submitRateLimit = '100/1sec'
-    }
-
-    singularity {
-      enabled = true
-      autoMounts = true
-    }
-
-    process {
-      queue = 'production'
-      memory = '2GB'
-      withLabel: medmem { memory =  '8 GB' }
-      withLabel: urgent { memory =  '2 GB' }
-      withLabel: higmem { memory = '24 GB' }
-      withLabel: long   { memory =  '2 GB' }
+      name            = 'lsf'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
     }
   }
 
-  //untested 
-  slurm {
-    process.executor = 'slurm'
-    singularity {
-      enabled = true
-      autoMounts = true
-    }
-  }  
+  //untested
+  slurm { process.executor = 'slurm' }
+}
+
+singularity {
+  enabled    = true
+  autoMounts = true
+}
+
+process {
+  queue  = 'production'
+  memory = '2 GB'
+  withLabel: medmem { memory =  '8 GB' }
+  withLabel: urgent { memory =  '2 GB' }
+  withLabel: higmem { memory = '24 GB' }
+  withLabel: long   { memory =  '2 GB' }
+
+  // avoid Nextflow job submission issues, e.g., "Request from non-LSF host rejected"
+  errorStrategy = { task.exitStatus = 255 ? 'retry' : 'finish' }
+  withLabel: error-ignore {
+    errorStrategy = { task.exitStatus = 255 ? 'retry' : 'ignore' }
+  }
+  maxRetries = 3
 }
 
 trace {

--- a/nextflow/ProteinFunction/nf_modules/polyphen2.nf
+++ b/nextflow/ProteinFunction/nf_modules/polyphen2.nf
@@ -30,7 +30,7 @@ process run_pph2_on_all_aminoacid_substitutions {
   container "ensemblorg/polyphen-2:2.2.3"
   containerOptions "--bind ${params.pph_data}:/opt/pph2/data"
   label 'highmem'
-  errorStrategy 'ignore'
+  label 'error-ignore'
 
   input:
     val peptide
@@ -72,7 +72,7 @@ process run_weka {
 
   //tag "${pph2_out.baseName} $model"
   container "ensemblorg/polyphen-2:2.2.3"
-  errorStrategy 'ignore'
+  label 'error-ignore'
 
   input:
     each model

--- a/nextflow/ProteinFunction/nf_modules/polyphen2.nf
+++ b/nextflow/ProteinFunction/nf_modules/polyphen2.nf
@@ -29,7 +29,7 @@ process run_pph2_on_all_aminoacid_substitutions {
   tag "${peptide.md5}"
   container "ensemblorg/polyphen-2:2.2.3"
   containerOptions "--bind ${params.pph_data}:/opt/pph2/data"
-  memory '4 GB'
+  label 'highmem'
   errorStrategy 'ignore'
 
   input:

--- a/nextflow/ProteinFunction/nf_modules/polyphen2.nf
+++ b/nextflow/ProteinFunction/nf_modules/polyphen2.nf
@@ -30,7 +30,7 @@ process run_pph2_on_all_aminoacid_substitutions {
   container "ensemblorg/polyphen-2:2.2.3"
   containerOptions "--bind ${params.pph_data}:/opt/pph2/data"
   label 'highmem'
-  label 'error-ignore'
+  label 'retry_error_then_ignore'
 
   input:
     val peptide
@@ -72,7 +72,7 @@ process run_weka {
 
   //tag "${pph2_out.baseName} $model"
   container "ensemblorg/polyphen-2:2.2.3"
-  label 'error-ignore'
+  label 'retry_error_then_ignore'
 
   input:
     each model

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -32,7 +32,7 @@ process align_peptides {
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
   label 'medmem'
-  label 'error-ignore'
+  label 'retry_error_then_ignore'
 
   input:
     val peptide
@@ -70,7 +70,7 @@ process run_sift_on_all_aminoacid_substitutions {
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
   label 'medmem'
-  label 'error-ignore'
+  label 'retry_error_then_ignore'
   publishDir "${params.outdir}/sift"
 
   input:

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -32,7 +32,7 @@ process align_peptides {
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
   label 'medmem'
-  errorStrategy 'ignore'
+  label 'error-ignore'
 
   input:
     val peptide
@@ -70,7 +70,7 @@ process run_sift_on_all_aminoacid_substitutions {
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
   label 'medmem'
-  errorStrategy 'ignore'
+  label 'error-ignore'
   publishDir "${params.outdir}/sift"
 
   input:

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -31,7 +31,7 @@ process align_peptides {
 
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
-  memory '4 GB'
+  label 'medmem'
   errorStrategy 'ignore'
 
   input:
@@ -69,7 +69,7 @@ process run_sift_on_all_aminoacid_substitutions {
 
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
-  memory '4 GB'
+  label 'medmem'
   errorStrategy 'ignore'
   publishDir "${params.outdir}/sift"
 

--- a/nextflow/ProteinFunction/nf_modules/translations.nf
+++ b/nextflow/ProteinFunction/nf_modules/translations.nf
@@ -16,7 +16,7 @@ process translate_fasta {
 
   tag "${gtf} + ${fasta}"
   container "quay.io/biocontainers/agat:0.9.0--pl5321hdfd78af_0"
-  memory '20 GB'
+  label 'highmem'
   publishDir "${params.outdir}"
 
   input:


### PR DESCRIPTION
- Add memory limits using configurable labels (like in eHive pipeline)
- Increase default `queueSize`
- Avoid Nextflow job submission issues 
    - Add `submitRateLimit` to limit number of jobs sent by Nextflow to LSF
    - Retry Nextflow job submission errors (`255` error code)
- Validate database input parameters
- Overwrite log/report files by default
- Generalise `nextflow.config`