### PR TITLE
feat: remove YPAR skip conditions

### DIFF
--- a/scripts/import/dbSNP_v2/load_dbsnp.pl
+++ b/scripts/import/dbSNP_v2/load_dbsnp.pl
@@ -874,11 +874,6 @@ sub get_variant_vf_fails {
   my $num_no_variation = 0;
 
   for my $vf (@{$rs_data->{'vfs'}}) {
-    # If in PAR region do not check
-    if ($vf->{'par'}) {
-      next;
-    }
-
     # If had allele_errors that could not be resolved
     # allele string set to dbSNP_, do not QC the variant feature
     if ($vf->{'allele_string'} =~ /^dbSNP_/) {
@@ -1214,7 +1209,6 @@ sub import_variation_feature {
   my %seen_vf;
 
   for my $vf (@$vfs) {
-    next if ($vf->{'par'});
     # The import can contain duplicate VFs based on
     # seq_region_id, seq_region_start, seq_region_end
     # These can arise when NTs map to same position as NCs


### PR DESCRIPTION
Card: [here](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5407)
## Description

Last dbSNP imports we could not deal with YPAR regions. Being that we only added YPAR variants to X chromosome. Now it should be added to both chromosomes, X and Y.

## Test

Check JIRA card for recent dbSNP import runnings;
