### PR TITLE
Fix consequences for SVs overlapping full transcripts

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -450,6 +450,11 @@ sub _bvfo_preds {
   if ( $bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature') &&
        $vf_start <= $feat->{start} && $vf_end >= $feat->{end} ) {
     $self->_update_preds($bvfo_preds, 'complete_overlap', 1, \$pred_digest);
+    $self->_update_preds($bvfo_preds, 'within_feature',   1, \$pred_digest);
+
+    if($preds->{feature_class} eq 'Bio::EnsEMBL::Transcript') {
+      $self->_update_preds($bvfo_preds, $feat->biotype, 1, \$pred_digest);
+    }
 
     $bvfo_preds->{_digest} = $pred_digest;
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Config.pm
@@ -835,6 +835,24 @@ our @OVERLAP_CONSEQUENCES = (
         }
     },
     {
+        SO_accession => 'SO:0001968',
+        SO_term => 'coding_transcript_variant',
+        display_term => 'CODING_TRANSCRIPT_VARIANT',
+        feature_SO_term => 'mRNA',
+        feature_class => 'Bio::EnsEMBL::Transcript',
+        variant_feature_class => 'Bio::EnsEMBL::Variation::BaseVariationFeature',
+        rank => '23',
+        tier => '3',
+        predicate => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::coding_transcript_variant',
+        description => 'A transcript variant of a protein coding gene',
+        label => 'coding transcript variant',
+        impact => 'MODIFIER',
+        include => {
+            within_feature => 1,
+            protein_coding => 1
+        }
+    },
+    {
         SO_accession => 'SO:0001566',
         SO_term => 'regulatory_region_variant',
         display_term => 'REGULATORY_REGION',

--- a/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Constants.pm
@@ -54,6 +54,7 @@ our @EXPORT_OK = qw(
   SO_TERM_ALU_DELETION
   SO_TERM_ALU_INSERTION
   SO_TERM_CODING_SEQUENCE_VARIANT
+  SO_TERM_CODING_TRANSCRIPT_VARIANT
   SO_TERM_COMPLEX_CHROMOSOMAL_REARRANGEMENT
   SO_TERM_COMPLEX_STRUCTURAL_ALTERATION
   SO_TERM_COMPLEX_SUBSTITUTION
@@ -172,6 +173,7 @@ our %EXPORT_TAGS = (
     SO_TERM_3_PRIME_UTR_VARIANT
     SO_TERM_5_PRIME_UTR_VARIANT
     SO_TERM_CODING_SEQUENCE_VARIANT
+    SO_TERM_CODING_TRANSCRIPT_VARIANT
     SO_TERM_DOWNSTREAM_GENE_VARIANT
     SO_TERM_FEATURE_ELONGATION
     SO_TERM_FEATURE_TRUNCATION
@@ -353,6 +355,7 @@ use constant SO_TERM_NON_CODING_TRANSCRIPT_VARIANT => 'non_coding_transcript_var
 use constant SO_TERM_NON_CODING_TRANSCRIPT_EXON_VARIANT => 'non_coding_transcript_exon_variant';
 use constant SO_TERM_MATURE_MIRNA_VARIANT => 'mature_miRNA_variant';
 use constant SO_TERM_CODING_SEQUENCE_VARIANT => 'coding_sequence_variant';
+use constant SO_TERM_CODING_TRANSCRIPT_VARIANT => 'coding_transcript_variant';
 use constant SO_TERM_REGULATORY_REGION_VARIANT => 'regulatory_region_variant';
 use constant SO_TERM_TF_BINDING_SITE_VARIANT => 'TF_binding_site_variant';
 use constant SO_TERM_TRANSCRIPT_ABLATION => 'transcript_ablation';
@@ -1157,6 +1160,25 @@ our %OVERLAP_CONSEQUENCES = (
   'label' => 'coding sequence variant',
   'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::coding_unknown',
   'rank' => '16',
+  'tier' => '3',
+  'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
+}
+),
+'coding_transcript_variant' => Bio::EnsEMBL::Variation::OverlapConsequence->new_fast({
+  'SO_accession' => 'SO:0001968',
+  'SO_term' => 'coding_transcript_variant',
+  'description' => 'A transcript variant of a protein coding gene',
+  'display_term' => 'CODING_TRANSCRIPT_VARIANT',
+  'feature_SO_term' => 'mRNA',
+  'feature_class' => 'Bio::EnsEMBL::Transcript',
+  'impact' => 'MODIFIER',
+  'include' => {
+                 'protein_coding' => 1,
+                 'within_feature' => 1
+               },
+  'label' => 'coding transcript variant',
+  'predicate' => 'Bio::EnsEMBL::Variation::Utils::VariationEffect::coding_transcript_variant',
+  'rank' => '23',
   'tier' => '3',
   'variant_feature_class' => 'Bio::EnsEMBL::Variation::BaseVariationFeature'
 }

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -412,6 +412,17 @@ sub within_nmd_transcript {
     return ( within_transcript(@_) and ($feat->biotype eq 'nonsense_mediated_decay') );
 }
 
+sub within_coding_gene {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    $feat ||= $bvfoa->base_variation_feature_overlap->feature;
+
+    return ( within_transcript(@_) and $feat->translation );
+}
+
+sub coding_transcript_variant {
+    return ( (not coding_unknown(@_)) and complete_overlap_feature(@_) and within_coding_gene(@_) );
+}
+
 sub within_non_coding_gene {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $feat ||= $bvfoa->base_variation_feature_overlap->feature;
@@ -423,7 +434,7 @@ sub non_coding_exon_variant {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvfo ||= $bvfoa->base_variation_feature_overlap;
     
-    return 0 if $feat->translation or within_mature_miRNA(@_);
+    return 0 if complete_overlap_feature(@_) or $feat->translation or within_mature_miRNA(@_);
     
     # get overlapped exons
     # this may include some non-overlapping ones in the case of transcripts with frameshift introns
@@ -1345,7 +1356,9 @@ sub coding_unknown {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvfo ||= $bvfoa->base_variation_feature_overlap;
     $bvf  ||= $bvfo->base_variation_feature;
-    
+
+    return 0 if complete_overlap_feature(@_);
+
     # sequence variant
     if($bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele')) {
         return (


### PR DESCRIPTION
[ENSVAR-4796](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4796)

## Description

The consequence for SVs overlapping full transcripts is being calculated as **intergenic variant** (given that no other consequence is appropriate). For instance:
<img width="1181" alt="Screenshot 2023-01-20 at 15 16 03" src="https://user-images.githubusercontent.com/3199157/213733950-8792cc60-fbd1-4ed2-b3cf-ba27772aeb9f.png">

To avoid displaying this incorrect consequence in these cases, we opted to return [`coding_transcript_variant`](http://www.sequenceontology.org/browser/current_release/term/SO:0001968) if overlapping protein-coding transcripts or [`non_coding_transcript_variant`](http://www.sequenceontology.org/browser/current_release/term/SO:0001619), otherwise.

## Changes

* Add required pre-checks predictions to structural variants with `complete_overlap`:
    * `within_feature` to generalise the already existing `non_coding_transcript_variant` consequence
    * `biotype` to check if transcripts are protein-coding
* Add new `coding_transcript_variant` consequence

## Testing

Check if the consequences for these examples make sense:
* [nsv5666340](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=17:19058404-19067645;sv=nsv5666340;svf=127308051;vdb=variation)
* [nsv1067809](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=17:19058404-19067645;sv=nsv1067809;svf=123110731;vdb=variation)
* [nsv1154324](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=17:19058404-19067645;sv=nsv1154324;svf=123110019;vdb=variation)
* [nsv1154328](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=17:19058404-19067645;svf=123110310;vdb=variation;sv=nsv1154328)
* [nsv1197376](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=17:19058404-19067645;sv=nsv1197376;svf=123066650;vdb=variation)