### PR TITLE
Improve script to generate VEP plugins public docs

### DIFF
--- a/scripts/misc/update_web_vep_plugins_documentation.pl
+++ b/scripts/misc/update_web_vep_plugins_documentation.pl
@@ -136,8 +136,7 @@ while (my $file = readdir($dh)) {
   push (@files, $file);
   read_plugin_file($file);
 }
-warn join("\n  - ", "The following plugins were NOT documented:", @skipped),
-     "\n";
+warn join("\n  - ", "The following plugins were NOT documented:", @skipped), "\n" if @skipped;
 
 # Print output HTML
 open OUT, "> $output_file" or die $!;
@@ -297,12 +296,13 @@ sub read_plugin_file {
 
       while ($desc_flag != 0) {
         $line = <F>;
+        
         if ($line =~ /^\s*=head1/ || $line =~ /^\s*=cut/) {
           $desc_flag = 0;
         }
         else {
           if ($desc ne '' || $line !~ /^\s+$/) {
-            # Three types of code blocks:
+            # Add code block -- three types of code blocks:
             #   1. to show a code script
             #        start: line starts with ##### or contains # BEGIN
             #        end:   line contains # END 
@@ -381,6 +381,7 @@ sub read_plugin_file {
     $desc =~ s/<\/p><p>/$desc_link<\/p><div id="div_$lc_name" style="display:none;"><p>/;
     $desc .= '</div>';
   }
+
   $data{$file} = {'name' => $name, 'desc' => $desc, 'developer' => \@developer, 'libs' => \%libs};
 }
 

--- a/scripts/misc/update_web_vep_plugins_documentation.pl
+++ b/scripts/misc/update_web_vep_plugins_documentation.pl
@@ -66,17 +66,7 @@ my %data = ();
 my %data_section = ();
 
 my %plugins_to_skip = (
-  'CCDSFilter.pm' => 1,
-  'CSN.pm' => 1,
-  'DAS.pm' => 1,
-  'GXA.pm' => 1,
-  'HGVSReferenceBase.pm' => 1,
-  'miRNA.pm' => 1,
-  'NonSynonymousFilter.pm' => 1,
-  'PolyPhen_SIFT.pm' => 1,
-  'RankFilter.pm' => 1,
-  'RefSeqHGVS.pm' => 1,
-  'ExAC.pm' => 1,
+#  'RankFilter.pm' => 1,
 );
 
 
@@ -134,8 +124,15 @@ close(P);
 # Parse each plugin to extract some information
 my $dh;
 opendir($dh,$git_dir) or die $!;
+my @skipped;
 while (my $file = readdir($dh)) {
-  next if ($file !~ /\.pm$/ || $plugins_to_skip{$file});
+  my $name = $file;
+  $name =~ s/\.pm$//g;
+
+  if ($file !~ /\.pm$/ || $plugins_to_skip{$file} || !$data_section{$name}) {
+    push @skipped, $file if $file =~ /\.pm$/;
+    next;
+  }
   push (@files, $file);
   read_plugin_file($file);
 }

--- a/scripts/misc/update_web_vep_plugins_documentation.pl
+++ b/scripts/misc/update_web_vep_plugins_documentation.pl
@@ -323,6 +323,9 @@ sub read_plugin_file {
     }  
   }
   close(F);
+
+  # Make URLs clickable
+  $desc =~ s|((http\|ftp)s?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9():]{0,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*[^\)\.,;:\s]))|<a href="$1">$1</a>|g;
   
   # Postprocess the description content (reformatting)
   $desc = "<p>$desc</p>";

--- a/scripts/misc/update_web_vep_plugins_documentation.pl
+++ b/scripts/misc/update_web_vep_plugins_documentation.pl
@@ -136,7 +136,8 @@ while (my $file = readdir($dh)) {
   push (@files, $file);
   read_plugin_file($file);
 }
-
+warn join("\n  - ", "The following plugins were NOT documented:", @skipped),
+     "\n";
 
 # Print output HTML
 open OUT, "> $output_file" or die $!;
@@ -160,7 +161,6 @@ my %plugin_class_list;
 
 # 1 Plugin file <=> 1 row in the output table
 foreach my $file (@sorted_files) {
-  print "Plugin: $file\n";
   my $plugin_name  = $data{$file}{'name'};
   my $plugin_class = ($data_section{$plugin_name} && $data_section{$plugin_name}{'section'}) ? $data_section{$plugin_name}{'section'} : 'ND'; 
   my $plugin_class_colour = $class_colour{$plugin_class} ? $class_colour{$plugin_class} : get_random_colour($plugin_class);

--- a/scripts/misc/update_web_vep_plugins_documentation.pl
+++ b/scripts/misc/update_web_vep_plugins_documentation.pl
@@ -377,11 +377,10 @@ sub read_plugin_file {
   if ($desc =~ /<\/p><p>/) {
     my $lc_name = lc($name);
        $lc_name =~ s/ /_/g;
-    my $desc_link = qq{ ... <a class="button" href="#$lc_name" style="padding:3px 8px 0px 8px !important;height:18px" onclick="show_hide('$lc_name');" id="a_$lc_name">more</a>};
+    my $desc_link = qq{ <a class="button" href="#$lc_name" style="padding:3px 8px 0px 8px !important;height:18px" onclick="show_hide('$lc_name');" id="a_$lc_name">more</a>};
     $desc =~ s/<\/p><p>/$desc_link<\/p><div id="div_$lc_name" style="display:none;"><p>/;
     $desc .= '</div>';
   }
-  
   $data{$file} = {'name' => $name, 'desc' => $desc, 'developer' => \@developer, 'libs' => \%libs};
 }
 


### PR DESCRIPTION
[ENSVAR-5395](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5395): Web docs: improve VEP plugins public docs

Also made small improvements to docs of some VEP plugins: https://github.com/Ensembl/VEP_plugins/pull/573

## Changes
- Make URLs clickable
- Improve display of variant location examples ([NMD](https://github.com/Ensembl/VEP_plugins/blob/release/109/NMD.pm) and [SpliceRegion](https://github.com/Ensembl/VEP_plugins/blob/release/109/SpliceRegion.pm)) by using code blocks
- Display scripts in code blocks ([EVE](https://github.com/Ensembl/VEP_plugins/blob/release/109/EVE.pm))
- Properly show common bash commands in contiguous code blocks (e.g., [MTR](https://github.com/Ensembl/VEP_plugins/blob/release/109/MTR.pm) and [LOEUF](https://github.com/Ensembl/VEP_plugins/blob/release/109/LOEUF.pm))
- Automatically skip documentation of plugins not mentioned in [`plugin_config.txt`](https://github.com/Ensembl/VEP_plugins/blob/release/109/plugin_config.txt)
  - Avoids the need to hard-code which plugins to skip
- Print skipped plugins
- Remove ellipsis (`...`) before the `more` button (redundant)

## Test
- Compare changes in my sandbox: VEP plugins documentation [before](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html) and [after](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins_2.html) changes.
    - Compare changes to variant location examples for NMD and SpliceRegion plugins
    - Compare changes to code blocks for MTR and LOEUF plugins
    - Compare changes to script in EVE plugin
- Run the script and check if it prints the non-documented plugins:
```
perl ensembl-variation/scripts/misc/update_web_vep_plugins_documentation.pl \
     -git_dir VEP_plugins -version 109 \
     -i public-plugins/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html \
     -o public-plugins/docs/htdocs/info/docs/tools/vep/script/vep_plugins.html
```

Expected output:
```
The following plugins were NOT documented:
  - CCDSFilter.pm
  - CSN.pm
  - DAS.pm
  - GXA.pm
  - HGVSReferenceBase.pm
  - NonSynonymousFilter.pm
  - PolyPhen_SIFT.pm
  - RefSeqHGVS.pm
  - RankFilter.pm
```