### PR TITLE
feat: dbSNP import - Add other + cleaning

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/DBSNPImport_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/DBSNPImport_conf.pm
@@ -56,6 +56,7 @@ sub default_options {
 
     pipeline_name           => 'dbsnp_import',
     species                 => 'homo_sapiens',
+    clean                   => 0,
     assembly                => $self->o('assembly'),
     pipeline_dir            => $self->o('pipeline_dir'),
     data_dir                => $self->o('pipeline_dir') . '/split-src',
@@ -86,6 +87,7 @@ sub pipeline_wide_parameters {
     ensembl_registry     => $self->o('registry_file'),
     species              => $self->o('species'),
     assembly             => $self->o('assembly'),
+    clean                => $self->o('clean'),
     
     data_dir             => $self->o('data_dir'),
     rpt_dir              => $self->o('rpt_dir'),

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/InitDBSNPImport.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/InitDBSNPImport.pm
@@ -62,16 +62,20 @@ sub run {
   }
 
   if (! -d $rpt_dir) {
-    die("No rpt directory ($rpt_dir)");
+    mkdir $rpt_dir or die("No rpt directory ($rpt_dir)");
   }
 
   my @sub_dirs = map('chr' . $_, @chrs);
+  
+  # Add an additional folder to others
+  push @sub_dirs, "chr_other";
+
   for my $sub_dir (@sub_dirs) {
     if (! -d "$data_dir/$sub_dir") {
       die("No data directory for ${data_dir}/${sub_dir}");
     }
     if (! -d "$rpt_dir/$sub_dir") {
-      die("No rpt directory for ${rpt_dir}/${sub_dir}");
+      mkdir "$rpt_dir/$sub_dir" or die("No rpt directory for ${rpt_dir}/${sub_dir}");
     }
   }
   # set up the list of sub_dir

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/LoadDBSNPFile.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DBSNPImport/LoadDBSNPFile.pm
@@ -61,6 +61,7 @@ sub run {
   my $fasta_file = $self->param_required('fasta_file');
   my $script_dir = $self->param_required('script_dir');
   my $assembly = $self->param_required('assembly');
+  my $clean = $self->param_required('clean');
 
   $self->warning("filename ($filename)");
   $self->warning("subdir ($sub_dir)");
@@ -96,7 +97,9 @@ sub run {
   my ($return_value, $stderr, $flat_cmd) = $self->run_system_command($cmd);
   if ($return_value) {
       die("there was an error running as ($flat_cmd: $stderr)");
-  }  
+  } else {
+    $self->run_system_command("rm $input_file") if ($clean);
+  }
 }
 
 1;


### PR DESCRIPTION
## Description

We still do not include refsnp-other in pipeline and do not delete files after import is finished. This PR implement both features to dbSNP-import pipeline.

## Test

1) Create DB + run dbSNP import with:
* chr_other folder inside `split-src` folder.
* using flag `--clean 1` and check if split-src files were deleted when pipeline finishes.