### PR TITLE
Update PF pipeline to have correct old server uri

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -228,10 +228,11 @@ sub fetch_input {
     my $var_dbc = $self->get_species_adaptor($group)->dbc;
     unless (defined $old_server_uri) {
         my $user     = $var_dbc->user;
+        my $pass     = $var_dbc->pass;
         my $port     = $var_dbc->port;
         my $host     = $var_dbc->host;
         my $release  = $self->param('ensembl_release') - 1;
-        $old_server_uri ||= sprintf("mysql://%s@%s:%s/%s", $user, $host, $port, $release);
+        $old_server_uri ||= sprintf("mysql://%s:%s@%s:%s/%s", $user, $pass, $host, $port, $release);
     }
 
     # set up our list of output ids

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/InitJobs.pm
@@ -230,12 +230,8 @@ sub fetch_input {
         my $user     = $var_dbc->user;
         my $port     = $var_dbc->port;
         my $host     = $var_dbc->host;
-        my $species  = $self->param('species');
         my $release  = $self->param('ensembl_release') - 1;
-        my $assembly = $self->param('assembly');
-        $old_server_uri ||= sprintf("mysql://%s@%s:%s/%s_%s_%s_%s",
-                                    $user, $host, $port,
-                                    $species, $group, $release, $assembly);
+        $old_server_uri ||= sprintf("mysql://%s@%s:%s/%s", $user, $host, $port, $release);
     }
 
     # set up our list of output ids


### PR DESCRIPTION
Old server uri should be of following format to avoid wrong database name being configured (e.g. `horse_variation_109_3`) - 
`mysql://[user]:[pass]@[host]:[port]/[old version]`

Needed to use password in the uri because the registry contains user with write permission to update protein function table.

Test pipeline link:
http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_ehive_protein_function_109_equ_cab3.0_horse&passwd=xxxxx

