### PR TITLE
Improve COSMIC scripts

### DIFF
--- a/scripts/import/import_cosmic.pl
+++ b/scripts/import/import_cosmic.pl
@@ -87,11 +87,12 @@ sub performCleanup {
                      $temp_varSyn_table_prefix);
 
   my $sth = $dbVar->prepare("SHOW TABLES LIKE '$temp_table_prefix%';");
-  my $rc = $sth->execute();
+  $sth->execute();
   while ( my $table = $sth->fetchrow_array) {
     # Copy contents to new table and delete
     my $main_table = $table;
-    $main_table =~ s/[0-9]+$//;
+    $main_table =~ s/([0-9]|X|Y|MT)+$//;
+
     next if $table eq $main_table;
 
     print "Moving $table contents to $main_table...\n";
@@ -109,8 +110,8 @@ sub performCleanup {
   $dbVar->do("RENAME TABLE $temp_phen_table_prefix TO $tmpdb.$temp_phen_table_prefix");
   $dbVar->do("RENAME TABLE $temp_varSyn_table_prefix TO $tmpdb.$temp_varSyn_table_prefix");
 
-  print "Auxiliary COSMIC tables removed and their rows were aggregated into " .
-        "the following tables and moved to $tmpdb:\n" .
+  print "Auxiliary COSMIC tables removed. Their contents were aggregated into " .
+        "the following tables in $tmpdb:\n" .
         "  - $temp_table_prefix\n" .
         "  - $temp_phen_table_prefix\n" .
         "  - $temp_varSyn_table_prefix\n";

--- a/scripts/import/remove_cosmic_or_hgmd.pl
+++ b/scripts/import/remove_cosmic_or_hgmd.pl
@@ -116,6 +116,7 @@ my $tv_del_sth = $dbh->prepare(qq[ SELECT vf.variation_feature_id from variation
 $tv_del_sth->execute() or die "Error selecting variation feature from $source_name\n";
 my $tv_to_del = $tv_del_sth->fetchall_arrayref();
 
+# Prepare SQL statements before for loop
 my $del_vf_sth = $dbh->prepare(qq[ DELETE FROM variation_feature WHERE variation_feature_id = ? ]);
 my $del_sth = $dbh->prepare(qq[ DELETE FROM transcript_variation WHERE variation_feature_id = ? ]);
 my $del_mtmp_sth = $dbh->prepare(qq[ DELETE FROM MTMP_transcript_variation WHERE variation_feature_id = ? ]);

--- a/scripts/import/remove_cosmic_or_hgmd.pl
+++ b/scripts/import/remove_cosmic_or_hgmd.pl
@@ -46,12 +46,12 @@ GetOptions(
 );
 
 unless ($registry_file) {
-    print "Must supply a registry file...\n" unless $help;
+    warn "Must supply a registry file...\n" unless $help;
     $help = 1;
 }
 
 unless ($source_name) {
-    print "Must supply a source name...\n" unless $help;
+    warn "Must supply a source name...\n" unless $help;
     $help = 1;
 }
 
@@ -90,7 +90,7 @@ my ($source_id) = $get_source_sth->fetchrow_array;
 die "Didn't find $source_name source_id, does this database have $source_name data?"
     unless defined $source_id;
 
-print "Found $source_name source ID: $source_id\n";
+warn "Found $source_name source ID: $source_id\n";
 
 # now delete stuff...
 
@@ -103,7 +103,7 @@ $dbh->do(qq{
     WHERE   fv.variation_id = v.variation_id
     AND     v.source_id = $source_id
 });
-print "- 'failed_variation' entries deleted\n";
+warn "- 'failed_variation' entries deleted\n";
 
 
 # variation_feature, transcript_variation and MTMP_transcript_variation
@@ -123,7 +123,7 @@ foreach my $to_del (@{$tv_to_del}){
   $del_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from transcript_variation\n";
   $del_mtmp_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from MTMP_transcript_variation\n";
 }
-print "- 'variation_feature', 'transcript_variation' and 'MTMP_transcript_variation' entries deleted\n";
+warn "- 'variation_feature', 'transcript_variation' and 'MTMP_transcript_variation' entries deleted\n";
 
 # phenotype_feature_attrib
 $dbh->do(qq{
@@ -132,14 +132,14 @@ $dbh->do(qq{
     WHERE   pf.phenotype_feature_id=pfa.phenotype_feature_id
     AND     pf.source_id = $source_id
 });
-print "- 'phenotype_feature_attrib' entries deleted\n";
+warn "- 'phenotype_feature_attrib' entries deleted\n";
 
 
 # phenotype_feature
 $dbh->do(qq{
     DELETE FROM phenotype_feature WHERE source_id = $source_id
 });
-print "- 'phenotype_feature' entries deleted\n";
+warn "- 'phenotype_feature' entries deleted\n";
 
 
 # variation_set_variation - variation_id
@@ -149,20 +149,20 @@ $dbh->do(qq{
     WHERE   vsv.variation_set_id = vs.variation_set_id
     AND     vs.name LIKE "\%$source_name\%"
 });
-print "- 'variation_set_variation' entries deleted\n";
+warn "- 'variation_set_variation' entries deleted\n";
 
 
 # variation_synonym
 $dbh->do(qq{
     DELETE FROM variation_synonym WHERE source_id = $source_id
 });
-print "- 'variation_synonym' entries deleted\n";
+warn "- 'variation_synonym' entries deleted\n";
 
 # variation
 $dbh->do(qq{
     DELETE FROM variation WHERE source_id = $source_id
 });
-print "- 'variation' entries deleted\n";
+warn "- 'variation' entries deleted\n";
 
 
-print "Deleted all $source_name variation associated data\n";
+warn "Deleted all $source_name variation associated data\n";

--- a/scripts/import/remove_cosmic_or_hgmd.pl
+++ b/scripts/import/remove_cosmic_or_hgmd.pl
@@ -110,16 +110,18 @@ print "- 'failed_variation' entries deleted\n";
 my $tv_del_sth = $dbh->prepare(qq[ SELECT vf.variation_feature_id from variation_feature vf
                                           WHERE vf.source_id = $source_id;
                                          ]);
-$tv_del_sth->execute() || die "Error selecting variation feature from $source_name\n";
+$tv_del_sth->execute() or die "Error selecting variation feature from $source_name\n";
 my $tv_to_del = $tv_del_sth->fetchall_arrayref();
+
+my $del_vf_sth = $dbh->prepare(qq[ DELETE FROM variation_feature WHERE variation_feature_id = ? ]);
+my $del_sth = $dbh->prepare(qq[ DELETE FROM transcript_variation WHERE variation_feature_id = ? ]);
+my $del_mtmp_sth = $dbh->prepare(qq[ DELETE FROM MTMP_transcript_variation WHERE variation_feature_id = ? ]);
+
 foreach my $to_del (@{$tv_to_del}){
   my $vf_id_del = $to_del->[0];
-  my $del_vf_sth = $dbh->prepare(qq[ DELETE FROM variation_feature WHERE variation_feature_id = $vf_id_del ]);
-  my $del_sth = $dbh->prepare(qq[ DELETE FROM transcript_variation WHERE variation_feature_id = $vf_id_del ]);
-  my $del_mtmp_sth = $dbh->prepare(qq[ DELETE FROM MTMP_transcript_variation WHERE variation_feature_id = $vf_id_del ]);
-  $del_vf_sth->execute() || die "Could not delete entry with variation_feature_id = $vf_id_del from variation_feature\n";
-  $del_sth->execute() || die "Could not delete entry with variation_feature_id = $vf_id_del from transcript_variation\n";
-  $del_mtmp_sth->execute() || die "Could not delete entry with variation_feature_id = $vf_id_del from MTMP_transcript_variation\n";
+  $del_vf_sth->execute($vf_id_del) or die "Error deleting variation_feature_id $vf_id_del from variation_feature\n";
+  $del_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from transcript_variation\n";
+  $del_mtmp_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from MTMP_transcript_variation\n";
 }
 print "- 'variation_feature', 'transcript_variation' and 'MTMP_transcript_variation' entries deleted\n";
 

--- a/scripts/import/remove_cosmic_or_hgmd.pl
+++ b/scripts/import/remove_cosmic_or_hgmd.pl
@@ -35,6 +35,9 @@ use Getopt::Long;
 
 use Bio::EnsEMBL::Registry;
 
+use IO::Handle;
+STDOUT->autoflush(1); # flush STDOUT buffer immediately
+
 my $registry_file;
 my $source_name;
 my $help;
@@ -46,12 +49,12 @@ GetOptions(
 );
 
 unless ($registry_file) {
-    warn "Must supply a registry file...\n" unless $help;
+    print "Must supply a registry file...\n" unless $help;
     $help = 1;
 }
 
 unless ($source_name) {
-    warn "Must supply a source name...\n" unless $help;
+    print "Must supply a source name...\n" unless $help;
     $help = 1;
 }
 
@@ -90,7 +93,7 @@ my ($source_id) = $get_source_sth->fetchrow_array;
 die "Didn't find $source_name source_id, does this database have $source_name data?"
     unless defined $source_id;
 
-warn "Found $source_name source ID: $source_id\n";
+print "Found $source_name source ID: $source_id\n";
 
 # now delete stuff...
 
@@ -103,7 +106,7 @@ $dbh->do(qq{
     WHERE   fv.variation_id = v.variation_id
     AND     v.source_id = $source_id
 });
-warn "- 'failed_variation' entries deleted\n";
+print "- 'failed_variation' entries deleted\n";
 
 
 # variation_feature, transcript_variation and MTMP_transcript_variation
@@ -123,7 +126,7 @@ foreach my $to_del (@{$tv_to_del}){
   $del_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from transcript_variation\n";
   $del_mtmp_sth->execute($vf_id_del) or die "Error deleting variation_feature_id = $vf_id_del from MTMP_transcript_variation\n";
 }
-warn "- 'variation_feature', 'transcript_variation' and 'MTMP_transcript_variation' entries deleted\n";
+print "- 'variation_feature', 'transcript_variation' and 'MTMP_transcript_variation' entries deleted\n";
 
 # phenotype_feature_attrib
 $dbh->do(qq{
@@ -132,14 +135,14 @@ $dbh->do(qq{
     WHERE   pf.phenotype_feature_id=pfa.phenotype_feature_id
     AND     pf.source_id = $source_id
 });
-warn "- 'phenotype_feature_attrib' entries deleted\n";
+print "- 'phenotype_feature_attrib' entries deleted\n";
 
 
 # phenotype_feature
 $dbh->do(qq{
     DELETE FROM phenotype_feature WHERE source_id = $source_id
 });
-warn "- 'phenotype_feature' entries deleted\n";
+print "- 'phenotype_feature' entries deleted\n";
 
 
 # variation_set_variation - variation_id
@@ -149,20 +152,20 @@ $dbh->do(qq{
     WHERE   vsv.variation_set_id = vs.variation_set_id
     AND     vs.name LIKE "\%$source_name\%"
 });
-warn "- 'variation_set_variation' entries deleted\n";
+print "- 'variation_set_variation' entries deleted\n";
 
 
 # variation_synonym
 $dbh->do(qq{
     DELETE FROM variation_synonym WHERE source_id = $source_id
 });
-warn "- 'variation_synonym' entries deleted\n";
+print "- 'variation_synonym' entries deleted\n";
 
 # variation
 $dbh->do(qq{
     DELETE FROM variation WHERE source_id = $source_id
 });
-warn "- 'variation' entries deleted\n";
+print "- 'variation' entries deleted\n";
 
 
-warn "Deleted all $source_name variation associated data\n";
+print "Deleted all $source_name variation associated data\n";


### PR DESCRIPTION
- Put prepare statements outside `for` loop
- Flush STDOUT buffer immediately to get real-time log
- Fix cleanup of tmp tables (it was ignoring chromosomes X, Y and MT)