### PR TITLE
Update TranscriptVariationAllele - revert PR 814

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1365,7 +1365,7 @@ sub hgvs_transcript {
   my $offset_to_add = defined($self->{shift_hash}) ? $self->{shift_hash}->{_hgvs_offset} : 0;# + ($no_shift ? 0 : (0 - $self->{_hgvs_offset}) );
   $self->{_hgvs_offset} = $offset_to_add;
   ## delete the shifting hash if we generated it for HGVS calculations
-  $self->{variation_feature_seq} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
+  $self->{variation_feature_seq_original} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
  
   ## return if a new transcript_variation_allele is not available - variation outside transcript
@@ -1702,7 +1702,7 @@ sub hgvs_protein {
   $hgvs_notation->{ref} = $ref->peptide; 
   
   ## delete the shifting hash if we generated it for HGVS calculations
-  $self->{variation_feature_seq} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
+  $self->{variation_feature_seq_original} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
   delete($ref->{shift_hash}) unless $ref_hash_already_defined;
 
@@ -2800,5 +2800,3 @@ sub _transcript_feature_Slice {
 
 
 1;
-
-

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1365,7 +1365,6 @@ sub hgvs_transcript {
   my $offset_to_add = defined($self->{shift_hash}) ? $self->{shift_hash}->{_hgvs_offset} : 0;# + ($no_shift ? 0 : (0 - $self->{_hgvs_offset}) );
   $self->{_hgvs_offset} = $offset_to_add;
   ## delete the shifting hash if we generated it for HGVS calculations
-  $self->{variation_feature_seq_original} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
  
   ## return if a new transcript_variation_allele is not available - variation outside transcript
@@ -1702,7 +1701,6 @@ sub hgvs_protein {
   $hgvs_notation->{ref} = $ref->peptide; 
   
   ## delete the shifting hash if we generated it for HGVS calculations
-  $self->{variation_feature_seq_original} = $self->{shift_hash}->{alt_orig_allele_string} if defined($self->{shift_hash});
   delete($self->{shift_hash}) unless $hash_already_defined;
   delete($ref->{shift_hash}) unless $ref_hash_already_defined;
 

--- a/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlapAllele.pm
@@ -280,22 +280,6 @@ sub variation_feature_seq {
     return $self->{variation_feature_seq};
 }
 
-=head2 variation_feature_seq_original
-
-  Args [1]   : The original allele sequence relative to the VariationFeature
-  Description: Get/set the sequence of the original allele relative to the associated VariationFeature.
-  Returntype : string
-  Exceptions : none
-  Status     : At Risk
-
-=cut
-
-sub variation_feature_seq_original {
-    my ($self, $variation_feature_seq_original) = @_;
-    $self->{variation_feature_seq_original} = $variation_feature_seq_original if $variation_feature_seq_original;
-    return $self->{variation_feature_seq_original};
-}
-
 =head2 seq_is_unambiguous_dna
 
   Description: identify if the sequence of this allele is unambiguous DNA 

--- a/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeatureOverlapAllele.pm
@@ -280,6 +280,22 @@ sub variation_feature_seq {
     return $self->{variation_feature_seq};
 }
 
+=head2 variation_feature_seq_original
+
+  Args [1]   : The original allele sequence relative to the VariationFeature
+  Description: Get/set the sequence of the original allele relative to the associated VariationFeature.
+  Returntype : string
+  Exceptions : none
+  Status     : At Risk
+
+=cut
+
+sub variation_feature_seq_original {
+    my ($self, $variation_feature_seq_original) = @_;
+    $self->{variation_feature_seq_original} = $variation_feature_seq_original if $variation_feature_seq_original;
+    return $self->{variation_feature_seq_original};
+}
+
 =head2 seq_is_unambiguous_dna
 
   Description: identify if the sequence of this allele is unambiguous DNA 


### PR DESCRIPTION
A user reported an issue in the HGVS protein returned by the plugin ProteinSeqs ([ticket](https://github.com/Ensembl/ensembl-vep/issues/1350))
The HGVSp is not the same as the one returned by VEP.

The issue is caused by this code update: https://github.com/Ensembl/ensembl-variation/pull/814/files 
`$self->{variation_feature_seq}` is updated to store the original alt allele however this has a downstream impact -> the hgvs protein calculated by the plugin is based on the **original alt allele** but the hgvs protein calculated by VEP is calculated based on the **shifted alt allele**. 

The plugins are going to be updated to not use `variation_feature_seq`.

[ENSVAR-5501](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5501)

