### PR TITLE
Update VariationFeatureAdaptor to support HGVSp multi-exon

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2354,9 +2354,36 @@ sub get_reference{
 
   my @coords = defined($pos2) ? $tr_mapper->pep2genomic($pos, $pos2) : $tr_mapper->pep2genomic($pos, $pos);  
 
-  my $start  = $coords[0]->start();
-  my $end    = $coords[0]->end();
+  my $start;
+  my $end;
   my $strand = $coords[0]->strand();
+
+  # Assign start and end when we have two coordinates
+  # This is the most common alternative
+  if(scalar(@coords) == 2){
+    if(($coords[0]->end() - $coords[0]->start() + 1) % 2 == 0) {
+      if($strand == 1) {
+        $start = $coords[0]->start();
+        $end = $start + 2;
+      }
+      else {
+        $end = $coords[0]->end();
+        $start = $end - 2;
+      }
+    }
+    elsif($strand == 1) {
+      $end = $coords[1]->end();
+      $start = $end - 2;
+    }
+    else {
+      $start = $coords[0]->start();
+      $end = $start + 2;
+    }
+  }
+  else{
+    $start = $coords[0]->start();
+    $end   = $coords[0]->end();
+  }
 
   my $seq_length = $type_del == 1 ? ($end-$start) + 1 : 3;  
 


### PR DESCRIPTION
When the input is an HGVS protein the method `get_reference()` only considers that the genomic `start` and `end` are within the same exon which is not true for some cases.
More details in: [ENSVAR-2537](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2537)

This PR is similar to https://github.com/Ensembl/ensembl-variation/pull/938
