### PR TITLE
SIFT/PolyPhen-2 Nextflow pipeline improvements

### DIFF
--- a/nextflow/ProteinFunction/nextflow.config
+++ b/nextflow/ProteinFunction/nextflow.config
@@ -4,8 +4,9 @@ profiles {
   lsf {
     executor {
       name            = 'lsf'
-      queueSize       = 500
+      queueSize       = 2000
       submitRateLimit = '50/10sec'
+      retry.reason    = "Request from non-LSF host rejected. Job not submitted."
     }
   }
 
@@ -20,17 +21,16 @@ singularity {
 
 process {
   queue  = 'production'
-  memory = '2 GB'
-  withLabel: medmem { memory =  '8 GB' }
-  withLabel: urgent { memory =  '2 GB' }
-  withLabel: higmem { memory = '24 GB' }
-  withLabel: long   { memory =  '2 GB' }
+  withLabel: long { queue = 'long' }
 
-  // avoid Nextflow job submission issues (exit status: 255)
-  // e.g., "Request from non-LSF host rejected"
-  errorStrategy = { task.exitStatus == 255 ? 'retry' : 'finish' }
-  withLabel: retry_error_then_ignore {
-    errorStrategy = { task.exitStatus == 255 ? 'retry' : 'ignore' }
+  memory = { ["500 MB", "4 GB", "12 GB", "80 GB"][task.attempt - 1] }
+
+  // Exit status codes:
+  // - 130: job exceeded LSF allocated memory
+  // - 140: job exceeded SLURM allocated resources (memory, CPU, time)
+  errorStrategy = { task.exitStatus in [130, 140] ? 'retry' : 'finish' }
+  withLabel: retry_before_ignoring {
+    errorStrategy = { task.exitStatus in [130, 140] ? 'retry' : 'ignore' }
   }
   maxRetries = 3
 }

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -31,8 +31,7 @@ process align_peptides {
 
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
-  label 'medmem'
-  label 'retry_error_then_ignore'
+  label 'retry_before_ignoring'
 
   input:
     val peptide
@@ -69,8 +68,7 @@ process run_sift_on_all_aminoacid_substitutions {
 
   tag "${peptide.md5}"
   container "ensemblorg/sift:6.2.1"
-  label 'medmem'
-  label 'retry_error_then_ignore'
+  label 'retry_before_ignoring'
   publishDir "${params.outdir}/sift"
 
   input:
@@ -92,6 +90,8 @@ process run_sift_on_all_aminoacid_substitutions {
 process store_sift_scores {
   tag "${peptide.id}"
   container "ensemblorg/ensembl-vep:latest"
+
+  cache false
 
   input:
     val ready

--- a/nextflow/ProteinFunction/nf_modules/translations.nf
+++ b/nextflow/ProteinFunction/nf_modules/translations.nf
@@ -16,7 +16,6 @@ process translate_fasta {
 
   tag "${gtf} + ${fasta}"
   container "quay.io/biocontainers/agat:0.9.0--pl5321hdfd78af_0"
-  label 'highmem'
   publishDir "${params.outdir}"
 
   input:


### PR DESCRIPTION
- Use increasing amounts of memory when jobs fail because of memory limits
- Retry jobs when LSF job submission fails
- Use tuples to ensure expected pair of arguments (giving two ordered arguments is not safe, as Nextflow may reorder their values when running)
- Increase default number of simultaneous jobs
- Only show jobs as failed if they effectively failed (jobs that finished successfully without output are considered successful now, although downstream jobs will not be run given that there is no output)