### PR TITLE
Update script import_vcf.pl to import all types of chromosomes

### DIFF
--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -99,6 +99,7 @@ sub configure {
 
     'help|h',
     'input_file|i=s',
+    'output_file=s',
     'tmpdir=s',
     'tmpfile=s',
     'config=s',
@@ -985,11 +986,20 @@ sub main {
 
   my $max_length = (sort {$a <=> $b} map {length($_)} (keys %{$config->{skipped}}, keys %{$config->{rows_added}}))[-1];
 
+  # write to output file
+  if($config->{output_file}) {
+    open(FH, '>>', $config->{output_file}) or die $!;
+  }
+
   # rows added
   debug($config, (defined($config->{test}) ? "(TEST) " : "")."Rows added:");
 
   for my $key(sort keys %{$config->{rows_added}}) {
     debug($config, (defined($config->{forked}) ? "STATS\t" : "").$key.(' ' x (($max_length - length($key)) + 4)).$config->{rows_added}->{$key});
+
+    if($config->{output_file}) {
+      print FH "Rows added\t".$key."\t".$config->{rows_added}->{$key}."\n";
+    }
   }
 
   # vars skipped
@@ -997,9 +1007,17 @@ sub main {
 
   for my $key(sort keys %{$config->{skipped}}) {
     debug($config, (defined($config->{forked}) ? "SKIPPED\t" : "").$key.(' ' x (($max_length - length($key)) + 4)).$config->{skipped}->{$key});
+
+    if($config->{output_file}) {
+      print FH "Lines skipped\t".$key."\t".$config->{skipped}->{$key}."\n";
+    }
   }
 
   store_session($config, "FINISHED");
+
+  if($config->{output_file}) {
+    close(FH);
+  }
 
   debug($config, "Finished!".(defined($config->{forked}) ? " (".$config->{forked}.")" : ""));
 }

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -735,7 +735,13 @@ sub main {
       }
 
       if(defined($config->{chr_synonyms_list})) {
-        $chromosome = $config->{chr_synonyms_list}->{$data->{tmp_vf}->{chr}};
+        # Mastermind always uses the chromosome synonyms
+        if($config->{source} eq 'Mastermind') {
+          $chromosome = $config->{chr_synonyms_list}->{$data->{tmp_vf}->{chr}};
+        }
+        elsif($config->{chr_synonyms_list}->{$data->{tmp_vf}->{chr}}) {
+          $chromosome = $config->{chr_synonyms_list}->{$data->{tmp_vf}->{chr}};
+        }
       }
 
       if(!defined($config->{seq_region_ids}->{$chromosome})) {
@@ -2000,7 +2006,13 @@ sub variation_feature {
   my $existing_vfs = [];
 
   my $chromosome = $vf->{chr};
-  $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}} if $config->{chr_synonyms};
+  # Mastermind always uses the chromosome synonyms
+  if($config->{source} eq 'Mastermind') {
+    $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}};
+  }
+  else {
+    $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}} if $config->{chr_synonyms} && $config->{chr_synonyms_list}->{$vf->{chr}};
+  }
 
   $existing_vfs = $vfa->fetch_all_by_Variation($data->{variation}) if($var_in_db && !defined($config->{no_merge}));
 

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -2007,7 +2007,7 @@ sub variation_feature {
 
   my $chromosome = $vf->{chr};
   # Mastermind always uses the chromosome synonyms
-  if($config->{source} eq 'Mastermind') {
+  if($config->{chr_synonyms} && $config->{source} eq 'Mastermind') {
     $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}};
   }
   elsif($config->{chr_synonyms} && $config->{chr_synonyms_list}->{$vf->{chr}}) {

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -1293,7 +1293,7 @@ sub run_forks {
       # point the file handle to a tabix pipe
       my $in_file_handle = FileHandle->new;
 
-      $in_file_handle->open("tabix -h ".$config->{input_file}." $chr | ");
+      $in_file_handle->open("tabix -h ".$config->{input_file}." '$chr' | ");
       $config->{in_file_handle} = $in_file_handle;
 
       $config->{pid} = $$;

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -2010,8 +2010,8 @@ sub variation_feature {
   if($config->{source} eq 'Mastermind') {
     $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}};
   }
-  else {
-    $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}} if $config->{chr_synonyms} && $config->{chr_synonyms_list}->{$vf->{chr}};
+  elsif($config->{chr_synonyms} && $config->{chr_synonyms_list}->{$vf->{chr}}) {
+    $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}};
   }
 
   $existing_vfs = $vfa->fetch_all_by_Variation($data->{variation}) if($var_in_db && !defined($config->{no_merge}));

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -3045,8 +3045,6 @@ sub progress {
   my $prev_pm = $config->{progress_update} / ($prev_elapsed / 60);
   my $total_pm = $count / ($total_elapsed / 60);
 
-  # printf("\r%s - Processed %8i variants (%8.2f per min / %8.2f per min overall ) ( %2i process%2s )", getTime, $count, $prev_pm, $total_pm, $proc, ($proc > 1 ? 'es' : '  '));
-
   $config->{prev_time} = [gettimeofday];
 }
 

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -2007,7 +2007,7 @@ sub variation_feature {
 
   my $chromosome = $vf->{chr};
   # Mastermind always uses the chromosome synonyms
-  if($config->{chr_synonyms} && $config->{source} eq 'Mastermind') {
+  if($config->{source} eq 'Mastermind') {
     $chromosome = $config->{chr_synonyms_list}->{$vf->{chr}};
   }
   elsif($config->{chr_synonyms} && $config->{chr_synonyms_list}->{$vf->{chr}}) {


### PR DESCRIPTION
1. Update import_vcf.pl to import all chromosomes in the same run even the chr synonyms;
2. Add option `--output_file` to write how many lines were skipped - prints warning with the total of skipped lines. This can be useful for the pipeline;
3. Add option `--sort_vf` to sort the table variation_feature after import;
4. Remove old comments;
5. Remove the progress bar prints.
6. Fix issue when reading a chromosome with semi-colon (example to test: dog)

The script was tested on LSF and SLURM.