### PR TITLE
Fix long allele_string for variant located after chromosome end

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/FastaSequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/FastaSequence.pm
@@ -616,6 +616,13 @@ sub _raw_seq {
       $start = 1;
     }
 
+    if ($start > $fa_length) {
+      print STDERR "SLICE HAS START > SEQ LENGTH\n" if $DEBUG;
+
+      # return only one N (same behaviour as when not using a Faidx/FASTA file)
+      return 'N';
+    }
+
     if($end > $fa_length) {
       print STDERR "SLICE HAS END > SEQ LENGTH\n" if $DEBUG;
 

--- a/modules/t/fastaSequence.t
+++ b/modules/t/fastaSequence.t
@@ -120,6 +120,8 @@ $slice1 = $sa->fetch_by_region('chromosome', 21, 1, 10);
 is($slice1->seq, 'N' x 10, "start of chrom");
 is($slice1->expand(10, 0)->seq, 'N' x 20, "expand beyond start of chrom");
 
+$slice1 = $sa->fetch_by_region('chromosome', 21, 46709993, 46709997);
+is($slice1->seq, 'N', "subseq out of bounds");
 
 # test synonyms
 clear_fasta_cache();


### PR DESCRIPTION
[ENSVAR-2554](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2554): Fixes https://github.com/Ensembl/ensembl-rest/issues/397 

## Description

When using VEP with a variant located after chromosome end and a FASTA file, a long allele_string of multiple `NNNNN`s is returned for `JSON` or `VCF` output (but not `TAB` or default `VEP output`).

Similar to how VEP behaves without a FASTA file, this PR intends to return only one `N` in these situations.

## Testing

The VCF (`--vcf`) and JSON (`--json`) output should be the same when using VEP with or without a FASTA file.

Example of running VEP for a variant located after chromosome end:

``` 
perl $vep --id '11:g.148657042delT' --hgvs \
          --cache $cachedir --cache_version 108 --db_version 108 \
          --fasta $fasta \
          --vcf -o vep.vcf
```
