### PR TITLE
Report number of rows before and after imports (111)

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/Reports.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Reports.pm
@@ -1,0 +1,97 @@
+=head1 LICENSE
+
+Copyright [1999-2015] Wellcome Trust Sanger Institute and the EMBL-European Bioinformatics Institute
+Copyright [2016-2023] EMBL-European Bioinformatics Institute
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+=cut
+
+
+=head1 CONTACT
+
+ Please email comments or questions to the public Ensembl
+ developers list at <http://lists.ensembl.org/mailman/listinfo/dev>.
+
+ Questions may also be sent to the Ensembl help desk at
+ <http://www.ensembl.org/Help/Contact>.
+
+=cut
+
+=head1 NAME
+
+Bio::EnsEMBL::Variation::Utils::Reports
+
+=head1 DESCRIPTION
+
+Create files with reports
+
+=cut
+
+package Bio::EnsEMBL::Variation::Utils::Reports;
+
+use strict;
+use warnings;
+use base qw(Exporter);
+use Bio::EnsEMBL::Variation::Utils::QCUtils qw(count_rows);
+use Bio::EnsEMBL::Variation::Utils::Date qw(log_time);
+
+
+our @EXPORT_OK = qw(report_counts);
+
+
+=head2 report_counts
+
+  Example     : report_counts($dba, $flag, $tables);
+  Description : writes to file the number of rows for each table before/after an import
+  ReturnType  : None
+  Exceptions  : None
+  Caller      : General
+
+
+=cut
+
+sub report_counts {
+  my $dba    = shift;
+  my $flag   = shift;
+  my $tables = shift;
+  my $output_file = shift;
+
+  die ("ERROR: cannot report the number of variation counts\n") unless ($dba && $flag && $tables);
+
+  my $file_counts = $output_file ? $output_file : "report_variation_counts.txt";
+
+  # Open file to write
+  my $type;
+  my $message;
+  if($flag eq 'before') {
+    $type = ">";
+    $message = "(" . log_time() . ") Counts before import:";
+  }
+  else {
+    $type = ">>";
+    $message = "\n" . "(" . log_time() . ") Counts after import:";
+  }
+
+  open(my $fh, $type, $file_counts) or die "Cannot write to file: $!\n";
+  print $fh $message . "\n";
+
+  foreach my $table (@{$tables}) {
+    my $count = count_rows($dba, $table);
+    print $fh $table . "\t" . $count . "\n";
+  }
+
+  close($fh);
+}
+
+1;

--- a/modules/Bio/EnsEMBL/Variation/Utils/Reports.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Reports.pm
@@ -69,7 +69,7 @@ sub report_counts {
 
   die ("ERROR: cannot report the number of variation counts\n") unless ($dba && $flag && $tables);
 
-  my $file_counts = $output_file ? $output_file : "report_variation_counts.txt";
+  my $file_counts = $output_file ? $output_file : "report_row_counts.txt";
 
   # Open file to write
   my $type;

--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -33,6 +33,7 @@ use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Utils::Exception qw(verbose throw warning);
 use Bio::EnsEMBL::Utils::Argument qw( rearrange );
 use Bio::EnsEMBL::Variation::Utils::SpecialChar qw(replace_char decode_text);
+use Bio::EnsEMBL::Variation::Utils::Reports qw(report_counts);
 
 use FindBin qw( $Bin );
 use Getopt::Long;
@@ -158,6 +159,10 @@ our $default_cs = $csa->fetch_by_name("chromosome");
 
 my $int_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'intvar');
 
+# count number of rows before import
+my @count_tables = qw(structural_variation structural_variation_feature structural_variation_sample structural_variation_association);
+report_counts($dba, "before", \@count_tables);
+
 # set the target assembly
 $target_assembly ||= $default_cs->version;
 
@@ -279,6 +284,9 @@ meta_coord();
 update_internal_db();
 verifications(); # URLs
 cleanup() if (!defined($debug));
+
+# count number of rows after import
+report_counts($dba, "after", \@count_tables);
 
 debug(localtime()." All done!");
 

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -58,6 +58,7 @@ use Bio::EnsEMBL::Variation::Utils::Sequence qw( get_hgvs_alleles SO_variation_c
 use Bio::EnsEMBL::Variation::Utils::SpecialChar qw(replace_char decode_text);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
 use Bio::EnsEMBL::Variation::Utils::Config qw(%ATTRIBS);
+use Bio::EnsEMBL::Variation::Utils::QCUtils qw(count_rows);
 use Bio::EnsEMBL::Variation::VariationFeature;
 use Bio::EnsEMBL::Slice;
 use Bio::DB::Fasta;
@@ -114,6 +115,9 @@ my $pheno_evidence_id = get_attrib_id('evidence',$phenotype_evidence);
 ## pre-load submitter ids - shortcutting the API for speed
 ## get ClinVar submitters names from the database
 my $submitters = get_submitter_ids($dba);
+
+# count number of rows before import
+print_counts($dba, 1);
 
 ## remove old data
 clean_old_data() if defined $clean; 
@@ -196,6 +200,9 @@ while($reader->read) {
 }
 
 close ($data_file_fh);
+
+# count number of rows after import
+print_counts($dba, 0);
 
 
 sub process_clinvar_set {
@@ -1682,6 +1689,36 @@ sub clean_phenotype_desc {
   $description =~ s/\'//g;
 
   return $description;
+}
+
+sub print_counts {
+  my $dba = shift;
+  my $flag = shift;
+
+  my $file_counts = "report_variation_counts.txt";
+
+  # Open file to write
+  my $type;
+  my $message;
+  if($flag == 1) {
+    $type = ">";
+    $message = "Counts before import:";
+  }
+  else {
+    $type = ">>";
+    $message = "\nCounts after import:";
+  }
+
+  open(my $fh, $type, $file_counts) or die "Cannot write to file: $!\n";
+  print $fh $message . "\n";
+
+  my @count_tables = qw(variation variation_feature transcript_variation);
+  foreach my $table (@count_tables) {
+    my $count = count_rows($dba, $table);
+    print $fh $table . "\t" . $count . "\n";
+  }
+
+  close($fh);
 }
 
 sub usage{

--- a/scripts/import/import_clinvar_xml
+++ b/scripts/import/import_clinvar_xml
@@ -58,7 +58,7 @@ use Bio::EnsEMBL::Variation::Utils::Sequence qw( get_hgvs_alleles SO_variation_c
 use Bio::EnsEMBL::Variation::Utils::SpecialChar qw(replace_char decode_text);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap);
 use Bio::EnsEMBL::Variation::Utils::Config qw(%ATTRIBS);
-use Bio::EnsEMBL::Variation::Utils::QCUtils qw(count_rows);
+use Bio::EnsEMBL::Variation::Utils::Reports qw(report_counts);
 use Bio::EnsEMBL::Variation::VariationFeature;
 use Bio::EnsEMBL::Slice;
 use Bio::DB::Fasta;
@@ -117,7 +117,8 @@ my $pheno_evidence_id = get_attrib_id('evidence',$phenotype_evidence);
 my $submitters = get_submitter_ids($dba);
 
 # count number of rows before import
-print_counts($dba, 1);
+my @count_tables = qw(variation variation_feature transcript_variation);
+report_counts($dba, "before", \@count_tables);
 
 ## remove old data
 clean_old_data() if defined $clean; 
@@ -202,7 +203,7 @@ while($reader->read) {
 close ($data_file_fh);
 
 # count number of rows after import
-print_counts($dba, 0);
+report_counts($dba, "after", \@count_tables);
 
 
 sub process_clinvar_set {
@@ -1689,36 +1690,6 @@ sub clean_phenotype_desc {
   $description =~ s/\'//g;
 
   return $description;
-}
-
-sub print_counts {
-  my $dba = shift;
-  my $flag = shift;
-
-  my $file_counts = "report_variation_counts.txt";
-
-  # Open file to write
-  my $type;
-  my $message;
-  if($flag == 1) {
-    $type = ">";
-    $message = "Counts before import:";
-  }
-  else {
-    $type = ">>";
-    $message = "\nCounts after import:";
-  }
-
-  open(my $fh, $type, $file_counts) or die "Cannot write to file: $!\n";
-  print $fh $message . "\n";
-
-  my @count_tables = qw(variation variation_feature transcript_variation);
-  foreach my $table (@count_tables) {
-    my $count = count_rows($dba, $table);
-    print $fh $table . "\t" . $count . "\n";
-  }
-
-  close($fh);
 }
 
 sub usage{

--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -42,6 +42,7 @@ use Time::Piece;
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Variation::Source;
+use Bio::EnsEMBL::Variation::Utils::Reports qw(report_counts);
 
 our $DEBUG = 0;
 
@@ -77,6 +78,9 @@ my $dba = $reg->get_DBAdaptor($species, 'variation');
 ## include failed variants to avoid missing any links
 $dba->include_failed_variations(1);
 
+# count number of rows before import
+my @count_tables = qw(variation_synonym);
+report_counts($dba, "before", \@count_tables, $source_name . "_report_variation_counts.txt");
 
 ## collect synonyms by source
 if($source_name eq 'PharmGKB') { 
@@ -208,7 +212,11 @@ elsif($source_name eq 'pig_chip') {
 
 else{
     die "data source : $source_name not supported\n";
-} 
+}
+
+# count number of rows after import
+report_counts($dba, "after", \@count_tables, $source_name . "_report_variation_counts.txt");
+
 
 =head2 download_file
 

--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -80,7 +80,7 @@ $dba->include_failed_variations(1);
 
 # count number of rows before import
 my @count_tables = qw(variation_synonym);
-report_counts($dba, "before", \@count_tables, $source_name . "_report_variation_counts.txt");
+report_counts($dba, "before", \@count_tables, $source_name . "_report_row_counts.txt");
 
 ## collect synonyms by source
 if($source_name eq 'PharmGKB') { 
@@ -215,7 +215,7 @@ else{
 }
 
 # count number of rows after import
-report_counts($dba, "after", \@count_tables, $source_name . "_report_variation_counts.txt");
+report_counts($dba, "after", \@count_tables, $source_name . "_report_row_counts.txt");
 
 
 =head2 download_file


### PR DESCRIPTION
Add a new module to report the number of rows for variation tables before and after an import.
Update:
- ClinVar
- Variation synonyms
- SVs

Ticket: ENSVAR-5524