### PR TITLE
Revise consequences for breakend variants

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -423,8 +423,8 @@ sub _bvf_preds {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }
-    elsif($class_SO_term =~ /breakend/) {
-      $self->_update_preds($bvf_preds, 'breakend', 1, \$pred_digest);
+    elsif($class_SO_term =~ /chromosome_breakpoint/) {
+      $self->_update_preds($bvf_preds, 'chromosome_breakpoint', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
     }
   }

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -423,6 +423,10 @@ sub _bvf_preds {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }
+    elsif($class_SO_term =~ /breakend/) {
+      $self->_update_preds($bvf_preds, 'breakend', 1, \$pred_digest);
+      $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
+    }
   }
   
   # otherwise for sequence variants, log the reference length here

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -108,11 +108,18 @@ sub _intron_overlap {
 }
 
 sub within_feature {
-    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    my ($bvfoa, $feat, $bvfo, $bvf, $match_chromosome) = @_;
     $bvf  ||= $bvfoa->base_variation_feature;
     $feat ||= $bvfoa->feature;
-    
-    return overlap(
+    $match_chromosome ||= 0;
+
+    my $cmp_chr = 1;
+    if ($match_chromosome) {
+      my $chr  = $bvf->{chr} || $bvf->{slice}->{seq_region_name};
+      $cmp_chr = $chr eq $feat->{slice}->{seq_region_name};
+    }
+
+    return $cmp_chr && overlap(
         $bvf->{start}, 
         $bvf->{end},
         $feat->{start}, 
@@ -260,6 +267,18 @@ sub tandem_duplication {
     }
 }
 
+sub breakend {
+  my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+  $bvf ||= $bvfoa->base_variation_feature;
+
+  if ($bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature')) {
+    return (
+      ($bvf->class_SO_term(undef, 1) eq 'breakend') or
+      ($bvf->class_SO_term(undef, 1) =~ /breakend/i)
+    );
+  }
+}
+
 sub feature_ablation {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $feat ||= $bvfoa->base_variation_feature_overlap->feature;
@@ -288,10 +307,20 @@ sub feature_elongation {
 
 sub feature_truncation {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    $bvf  ||= $bvfoa->base_variation_feature;
     $feat ||= $bvfoa->base_variation_feature_overlap->feature;
     
     return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele');
     
+    if(breakend(@_)) {
+        my $chr;
+        for my $alt (@{$bvf->{_parsed_allele}}) {
+            # iterate over breakends to check if feature is located within
+            return 1 if within_feature($bvfoa, $feat, $bvfo, $alt, 1);
+        }
+        return 1 if within_feature($bvfoa, $feat, $bvfo, $bvf, 1);
+    }
+
     return (
         (
             partial_overlap_feature($bvfoa, $feat, $bvfo, $bvf) or

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -267,14 +267,14 @@ sub tandem_duplication {
     }
 }
 
-sub breakend {
+sub chromosome_breakpoint {
   my ($bvfoa, $feat, $bvfo, $bvf) = @_;
   $bvf ||= $bvfoa->base_variation_feature;
 
   if ($bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature')) {
     return (
-      ($bvf->class_SO_term(undef, 1) eq 'breakend') or
-      ($bvf->class_SO_term(undef, 1) =~ /breakend/i)
+      ($bvf->class_SO_term(undef, 1) eq 'chromosome_breakpoint') or
+      ($bvf->class_SO_term(undef, 1) =~ /chromosome_breakpoint/i)
     );
   }
 }
@@ -312,10 +312,10 @@ sub feature_truncation {
     
     return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele');
     
-    if(breakend(@_)) {
+    if(chromosome_breakpoint(@_)) {
         my $chr;
         for my $alt (@{$bvf->{_parsed_allele}}) {
-            # iterate over breakends to check if feature is located within
+            # iterate over breakends to check if within_feature
             return 1 if within_feature($bvfoa, $feat, $bvfo, $alt, 1);
         }
         return 1 if within_feature($bvfoa, $feat, $bvfo, $bvf, 1);

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -313,7 +313,6 @@ sub feature_truncation {
     return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele');
     
     if(chromosome_breakpoint(@_)) {
-        my $chr;
         for my $alt (@{$bvf->{_parsed_allele}}) {
             # iterate over breakends to check if within_feature
             return 1 if within_feature($bvfoa, $feat, $bvfo, $alt, 1);


### PR DESCRIPTION
[ENSVAR-2086](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2086) and related with Ensembl/ensembl-vep#1399

- Adds breakend predicate statements
- If a breakend position is located within a feature, VEP returns `feature_truncation` as a consequence (together with other consequences that also make sense)

This is an example output for some BND variants:

```
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000424587 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=4915;STRAND=-1
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000441866 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=44;STRAND=-1
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000442116 Transcript      feature_truncation,non_coding_transcript_exon_variant   1056-?  -       -       -       -       -       IMPACT=HIGH;STRAND=-1;OverlapBP=237;OverlapPC=3.45
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000448958 Transcript      feature_truncation,non_coding_transcript_exon_variant   2063-?  -       -       -       -       -       IMPACT=HIGH;STRAND=-1;OverlapBP=188;OverlapPC=1.72
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000450734 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=468;STRAND=-1
gnomAD_v2_BND_1_4       1:251749-258100 <BND>   ENSG00000228463 ENST00000634344 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=424;STRAND=-1

ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000211674 ENST00000390320 Transcript      feature_truncation,coding_sequence_variant      90      90      30      -       -       -       IMPACT=HIGH;STRAND=1;FLAGS=cds_start_NF,cds_end_NF;SYMBOL=IGLJ1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:5863;OverlapBP=1;OverlapPC=0.79
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000211675 ENST00000390321 Transcript      upstream_gene_variant   -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1594;STRAND=1;FLAGS=cds_start_NF;SYMBOL=IGLC1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:5855
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000226420 ENST00000432300 Transcript      intergenic_variant      -       -       -       -       -       -       IMPACT=MODIFIER;STRAND=1;SYMBOL=IGLV3-4;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:5915
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000253234 ENST00000522922 Transcript      intergenic_variant      -       -       -       -       -       -       IMPACT=MODIFIER;STRAND=1;SYMBOL=IGLV2-5;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:5894
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000254709 ENST00000526893 Transcript      feature_truncation,coding_sequence_variant      526     288     96      -       -       -       IMPACT=HIGH;STRAND=1;SYMBOL=IGLL5;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:38476;OverlapBP=1;OverlapPC=0.01
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000254709 ENST00000531372 Transcript      feature_truncation,intron_variant       -       -       -       -       -       -       IMPACT=HIGH;STRAND=1;SYMBOL=IGLL5;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:38476;OverlapBP=1;OverlapPC=0.01
ref_panel_1kg_v1_BND_chr22_33_M2        22:22893781     ]chr22:22857058]G       ENSG00000254709 ENST00000532223 Transcript      feature_truncation,coding_sequence_variant      565     291     97      -       -       -       IMPACT=HIGH;STRAND=1;SYMBOL=IGLL5;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:38476;OverlapBP=1;OverlapPC=0.01

BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000352993 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=110;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000357654 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=110;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000235665 ENST00000426969 Transcript      feature_truncation      -       -       -       -       -       -       IMPACT=HIGH;STRAND=-1;SYMBOL=LINC00298;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:49257
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000235665 ENST00000456681 Transcript      feature_truncation      -       -       -       -       -       -       IMPACT=HIGH;STRAND=-1;SYMBOL=LINC00298;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:49257
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000461221 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1493;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000468300 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=620;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000471181 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=110;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000491747 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1493;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000493795 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1444;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000586385 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1378;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000591534 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1378;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000591849 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=1378;STRAND=-1;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000012048 ENST00000644379 Transcript      downstream_gene_variant -       -       -       -       -       -       IMPACT=MODIFIER;DISTANCE=901;STRAND=-1;FLAGS=cds_start_NF;SYMBOL=BRCA1;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:1100
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000286857 ENST00000655474 Transcript      feature_truncation      -       -       -       -       -       -       IMPACT=HIGH;STRAND=1
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000235665 ENST00000663636 Transcript      feature_truncation      -       -       -       -       -       -       IMPACT=HIGH;STRAND=-1;SYMBOL=LINC00298;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:49257
BND_BRCA1       17:43044185     ]2:7938377]C    ENSG00000235665 ENST00000664226 Transcript      intergenic_variant      -       -       -       -       -       -       IMPACT=MODIFIER;STRAND=-1;SYMBOL=LINC00298;SYMBOL_SOURCE=HGNC;HGNC_ID=HGNC:49257
```

## Potential improvements

- Return which breakend mate is associated with each feature consequence
- If possible, avoid returning `feature_truncation` without more information on which features are affected (UTR, exon, etc.)
- Add unit tests