### PR TITLE
Variation docs: sort similar clinical significance terms together

### DIFF
--- a/scripts/misc/generate_clin_significance_tables.pl
+++ b/scripts/misc/generate_clin_significance_tables.pl
@@ -138,11 +138,16 @@ sub transform_clin_sign_for_sorting {
   my $var = shift;
 
   # change order of adjectives to group similar terms together
+  # adjectives are put in the end: likely pathogenic -> pathogenic_likely
+  # example:  1. pathogenic        -> pathogenic
+  #           2. likely pathogenic -> pathogenic-likely
   my @adjectives = ("likely", "established");
   my $words = join("|", @adjectives);
   my $res = $var =~ s/($words) (.*)/$2-$1/gr;
 
   # change order of "low penetrance" to come after other similar terms
+  # example:  1. likely pathogenic                -> pathogenic-likely
+  #           2. likely pathogenic low penetrance -> pathogenic-likely-low penetrance
   $res =~ s/(.*)( low penetrance)(.*)/$1$3-$2/g;
 
   # group undefined values in the bottom of the list

--- a/scripts/misc/generate_clin_significance_tables.pl
+++ b/scripts/misc/generate_clin_significance_tables.pl
@@ -132,9 +132,17 @@ foreach my $type_stmt (@{$info{'clin_sign'}}) {
 # Clinical significance examples
 my $html_content = add_table_header($info{'label'});
 
+sub sort_clin_sign_terms {
+  my @terms = @_;
+  # change order of adjectives to group similar terms together
+  my @adjectives = ("likely", "established", "uncertain");
+  my $words = join("|", @adjectives);
+  return sort { ($a =~ s/($words) (.*)/$2 $1/gr) cmp ($b =~ s/($words) (.*)/$2 $1/gr) } @terms;
+}
+
 my $count = 0;
 my $cs_term_count = scalar (keys %clin_sign);
-foreach my $cs_term (sort(keys %clin_sign)) {
+foreach my $cs_term (sort_clin_sign_terms(keys %clin_sign)) {
   $count ++;
   my $icon_label = $cs_term;
      $icon_label =~ s/ /-/g;

--- a/scripts/misc/generate_clin_significance_tables.pl
+++ b/scripts/misc/generate_clin_significance_tables.pl
@@ -132,12 +132,30 @@ foreach my $type_stmt (@{$info{'clin_sign'}}) {
 # Clinical significance examples
 my $html_content = add_table_header($info{'label'});
 
+sub transform_clin_sign_for_sorting {
+  # transfroms clinical significance terms in order to sort them as needed
+
+  my $var = shift;
+
+  # change order of adjectives to group similar terms together
+  my @adjectives = ("likely", "established");
+  my $words = join("|", @adjectives);
+  my $res = $var =~ s/($words) (.*)/$2-$1/gr;
+
+  # change order of "low penetrance" to come after other similar terms
+  $res =~ s/(.*)( low penetrance)(.*)/$1$3-$2/g;
+
+  # group undefined values in the bottom of the list
+  my @uncertain = ("uncertain", "not provided", "other");
+  $words = join("|", @uncertain);
+  $res =~ s/($words)/z$1/g;
+
+  return $res;
+}
+
 sub sort_clin_sign_terms {
   my @terms = @_;
-  # change order of adjectives to group similar terms together
-  my @adjectives = ("likely", "established", "uncertain");
-  my $words = join("|", @adjectives);
-  return sort { ($a =~ s/($words) (.*)/$2 $1/gr) cmp ($b =~ s/($words) (.*)/$2 $1/gr) } @terms;
+  sort { transform_clin_sign_for_sorting($a) cmp transform_clin_sign_for_sorting($b) } @terms;
 }
 
 my $count = 0;


### PR DESCRIPTION
This PR allows to group similar clinical significance terms together in Variation docs.

See: http://wp-np2-11.ebi.ac.uk:6070/info/genome/variation/phenotype/phenotype_annotation.html