### PR TITLE
Some (more) HGVS updates

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -2167,16 +2167,22 @@ sub _clip_alleles {
   ### check if clipping suggests a type change 
 
   ## no protein change - use transcript level annotation 
-  $hgvs_notation->{type} = "="   if( defined $hgvs_notation->{'numbering'} && 
-                                     $hgvs_notation->{'numbering'} eq 'p' &&
-                                     $hgvs_notation->{alt} eq $hgvs_notation->{ref});      
-
-  if(length ($check_ref) == 0 && length ($check_alt) >= 1){
+  if( $check_ref eq $check_alt) {
+      $hgvs_notation->{type} = "=";
+  }   
+  
+  ## re-set as > not delins
+  elsif( length ($check_ref) == 1 && length ($check_alt) == 1 && $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+      $hgvs_notation->{type} = ">";
+  }
+  
+  ### re-set as ins/dup not delins 
+  elsif(length ($check_ref) == 0 && length ($check_alt) >= 1){
       ### re-set as dup not delins
       my $prev_str = substr($preseq, length($preseq) - length($check_alt));
       if($check_alt eq $prev_str) {
         $hgvs_notation->{type} = "dup";
-        $hgvs_notation->{start} = $hgvs_notation->{start} - length($check_alt);
+        $hgvs_notation->{start} -= length($check_alt);
       }
     
       ### re-set as ins not delins
@@ -2184,8 +2190,11 @@ sub _clip_alleles {
         $hgvs_notation->{type} ="ins";
       }
   }
+  
   ### re-set as del not delins  
-  $hgvs_notation->{type}  = "del" if(length ($check_ref) >=1 && length ($check_alt) == 0);      
+  elsif(length ($check_ref) >=1 && length ($check_alt) == 0){
+    $hgvs_notation->{type}  = "del" ;      
+  }
 
   print "clipped :  $check_ref &  $check_alt\n" if $DEBUG ==1;
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1377,8 +1377,16 @@ sub hgvs_transcript {
   }
   ## this may be different to the input one for insertions/deletions
     print "vfs: $variation_feature_sequence &  $self->{_slice_start} -> $self->{_slice_end}\n" if $DEBUG ==1;
-  if($variation_feature_sequence && $vf->strand() != $refseq_strand) {    
-    reverse_comp(\$variation_feature_sequence) ;
+  if($variation_feature_sequence && $vf->strand != $refseq_strand) {
+    if($vf->strand == 1){
+      reverse_comp(\$variation_feature_sequence);
+    }
+    else{
+      # if varitaion feature in +1 strand and transctipt is in -1 strand only complementing is 
+      # enough as variation feature sequence will be from reverse strand but in 3'-5' direction
+      $variation_feature_sequence =~
+        tr/acgtrymkswhbvdnxACGTRYMKSWHBVDNX/tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX/;
+    }
   };
   ## delete consequences if we have an offset. This is only in here for when we want HGVS to shift but not consequences.
   ## TODO add no_shift flag test

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1382,7 +1382,7 @@ sub hgvs_transcript {
       reverse_comp(\$variation_feature_sequence);
     }
     else{
-      # if varitaion feature in +1 strand and transctipt is in -1 strand only complementing is 
+      # if variation feature is in + strand and transcript in - strand only complementing is 
       # enough as variation feature sequence will be from reverse strand but in 3'-5' direction
       $variation_feature_sequence =~
         tr/acgtrymkswhbvdnxACGTRYMKSWHBVDNX/tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX/;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1986,8 +1986,10 @@ sub hgvs_genomic {
     if( $hgvs_notation->{type} eq 'delins'){
 
       ## check the start
+      my $preseq = "";
       while( $hgvs_notation->{ref} && $hgvs_notation->{alt} &&
              substr($hgvs_notation->{ref}, 0, 1) eq substr($hgvs_notation->{alt}, 0, 1)) {
+        $preseq .= substr($hgvs_notation->{ref}, 0, 1);
         $hgvs_notation->{ref} = substr($hgvs_notation->{ref}, 1);
         $hgvs_notation->{alt} = substr($hgvs_notation->{alt}, 1);
         $hgvs_notation->{start}++;
@@ -2004,12 +2006,32 @@ sub hgvs_genomic {
       ## fix alleles and types if necessary
       $hgvs_notation->{ref} ||= '-';
       $hgvs_notation->{alt} ||= '-';
-      $hgvs_notation->{type} = 'del' if $hgvs_notation->{alt} eq '-';
-      if ($hgvs_notation->{ref} eq '-') {
-        $hgvs_notation->{type} = 'ins';
-        ## fix position for ins
-        $hgvs_notation->{start}--;
-        $hgvs_notation->{end} = $hgvs_notation->{start} + 1;
+      
+      if( $hgvs_notation->{ref} eq $hgvs_notation->{alt}) {
+          $hgvs_notation->{type} = "=";
+      }   
+      
+      elsif( length ($hgvs_notation->{ref}) == 1 && length ($hgvs_notation->{alt}) == 1 && $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+          $hgvs_notation->{type} = ">";
+      }
+      
+      elsif ($hgvs_notation->{ref} eq '-' && length ($hgvs_notation->{alt}) >=1) {
+        my $prev_str = substr($preseq, length($preseq) - length($hgvs_notation->{alt}));
+        if ($hgvs_notation->{alt} eq $prev_str){
+          $hgvs_notation->{type} = 'dup';
+          ## fix position for dup
+          $hgvs_notation->{start} -= length($hgvs_notation->{alt});
+        }
+        else {
+          $hgvs_notation->{type} = 'ins';
+          ## fix position for ins
+          $hgvs_notation->{start}--;
+          $hgvs_notation->{end} = $hgvs_notation->{start} + 1;
+        }
+      }
+      
+      elsif (length ($hgvs_notation->{ref}) >=1 && $hgvs_notation->{alt} eq '-') {
+        $hgvs_notation->{type} = 'del';
       }
     }
 


### PR DESCRIPTION
- [ENSVAR-5765](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5765): VEP incorrectly term HGVS type as ins when it should be dup. This happens when the variant strand is in reverse and transcript strand is forward. 
- [ENSVAR-5625](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5625): We are clipping alleles when the HGVS type is `delins` and update type and co-ordinates. We are not considering type changing to `dup` currrently. Related issue - https://github.com/Ensembl/ensembl-vep/issues/500 
- [ENSVAR-2140](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-2140): Add new argument `--hgvsp_use_prediction` to output HGVSp in prediction format. Related issue - https://github.com/Ensembl/ensembl-vep/issues/861

_Test data are in the respective JIRA tickets_