### PR TITLE
Calculate CNV consequences based on supporting variants

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -426,11 +426,11 @@ sub _bvf_preds {
       $is_CNV_insertion = grep(/insertion|duplication|gain/i, @support_terms);
     }
 
-    if($class_SO_term =~ /deletion/ || $is_CNV_deletion) {
+    if($class_SO_term =~ /deletion|loss/ || $is_CNV_deletion) {
       $self->_update_preds($bvf_preds, 'deletion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
     }
-    elsif($class_SO_term =~ /insertion|duplication/ || $is_CNV_insertion) {
+    elsif($class_SO_term =~ /insertion|gain|duplication/ || $is_CNV_insertion) {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -410,16 +410,27 @@ sub _bvf_preds {
   
   my $is_sv = $bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature') ? 1 : 0;
   $self->_update_preds($bvf_preds, 'sv', $is_sv, \$pred_digest);
-  
+
   # use SO term to determine class
   if($is_sv) {
     my $class_SO_term = $bvf->class_SO_term;
 
-    if($class_SO_term =~ /deletion/) {
+    my $is_CNV = $class_SO_term eq "copy_number_variation";
+    my $is_CNV_deletion  = 0;
+    my $is_CNV_insertion = 0;
+    if ($is_CNV) {
+      my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
+      my @support_terms = map { $_->class_SO_term } @{$support_vars};
+
+      $is_CNV_deletion  = grep(/deletion|loss/i,              @support_terms);
+      $is_CNV_insertion = grep(/insertion|duplication|gain/i, @support_terms);
+    }
+
+    if($class_SO_term =~ /deletion/ || $is_CNV_deletion) {
       $self->_update_preds($bvf_preds, 'deletion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
     }
-    elsif($class_SO_term =~ /insertion|duplication/) {
+    elsif($class_SO_term =~ /insertion|duplication/ || $is_CNV_insertion) {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -418,7 +418,7 @@ sub _bvf_preds {
     my $is_CNV = $class_SO_term eq "copy_number_variation";
     my $is_CNV_deletion  = 0;
     my $is_CNV_insertion = 0;
-    if ($is_CNV) {
+    if ($is_CNV and defined $bvf->structural_variation) {
       my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
       my @support_terms = map { $_->class_SO_term } @{$support_vars};
 

--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -426,11 +426,11 @@ sub _bvf_preds {
       $is_CNV_insertion = grep(/insertion|duplication|gain/i, @support_terms);
     }
 
-    if($class_SO_term =~ /deletion|loss/ || $is_CNV_deletion) {
+    if($class_SO_term =~ /deletion|loss/i || $is_CNV_deletion) {
       $self->_update_preds($bvf_preds, 'deletion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
     }
-    elsif($class_SO_term =~ /insertion|gain|duplication/ || $is_CNV_insertion) {
+    elsif($class_SO_term =~ /insertion|duplication|gain/i || $is_CNV_insertion) {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -159,6 +159,7 @@ sub _supporting_cnv_terms {
   my $bvf = shift;
 
   return if $bvf->class_SO_term(undef, 1) ne "copy_number_variation";
+  return unless defined $bvf->structural_variation;
 
   my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
   my @support_terms = map { $_->class_SO_term } @{$support_vars};

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -169,11 +169,22 @@ sub deletion {
     
     # structural variant depends on class
     if($bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature')) {
-        return (
-            ($bvf->class_SO_term(undef, 1) eq 'deletion') or
-            ($bvf->class_SO_term(undef, 1) =~ /deletion/i) or
-            ($bvf->class_SO_term(undef, 1) =~ /loss/i)
-        );
+      my $class_SO_term = $bvf->class_SO_term(undef, 1);
+
+      # check if the CNV harbours any deletion or copy number loss
+      my $is_CNV_deletion = 0;
+      if ($class_SO_term eq "copy_number_variation") {
+        my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
+        my @support_terms = map { $_->class_SO_term } @{$support_vars};
+        $is_CNV_deletion = grep(/deletion|loss/i, @support_terms);
+      }
+
+      return (
+          ($class_SO_term eq 'deletion') or
+          ($class_SO_term =~ /deletion/i) or
+          ($class_SO_term =~ /loss/i) or
+          $is_CNV_deletion
+      );
     }
     
     else { return 0; }
@@ -194,13 +205,25 @@ sub insertion {
     
     # structural variant depends on class
     if($bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature')) {
-        return (
-            duplication(@_) or
-            tandem_duplication(@_) or
-            ($bvf->class_SO_term(undef, 1) eq 'insertion') or
-            ($bvf->class_SO_term(undef, 1) =~ /insertion/i) or
-            ($bvf->class_SO_term(undef, 1) =~ /gain/i)
-        );
+      my $class_SO_term = $bvf->class_SO_term(undef, 1);
+
+      # check if the CNV harbours any insertion or copy number gain
+      my $is_CNV_insertion = 0;
+      if ( $class_SO_term eq "copy_number_variation" ) {
+        my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
+        my @support_terms = map { $_->class_SO_term } @{$support_vars};
+        $is_CNV_insertion = grep(/insertion|duplication|gain/i, @support_terms);
+      }
+
+      return (
+          duplication(@_) or
+          tandem_duplication(@_) or
+          ($bvf->class_SO_term(undef, 1) eq 'insertion') or
+          ($bvf->class_SO_term(undef, 1) =~ /insertion/i) or
+          ($bvf->class_SO_term(undef, 1) =~ /gain/i) or
+          ($bvf->class_SO_term(undef, 1) =~ /duplication/i) or
+          $is_CNV_insertion
+      );
     }
     
     else { return 0; }


### PR DESCRIPTION
[ENSVAR-5786](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5786)

For CNVs with supporting evidence (basically those that we import from multiple sources), calculate the consequences using the supporting variants.

- If the supporting variants have `class_SO_term` as `deletion` or `loss`, treat CNV as a deletion.
- If the supporting variants have `class_SO_term` as `insertion`, `duplication` or `gain`, treat CNV as an insertion.

## Testing

From my understanding, VEP does not support using CNVs with supporting variants as input, so there is no way to test them via VEP. I opened ticket [ENSVAR-5793](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5793) to support dbVar/DGVa identifiers, allowing to test this type of CNVs.

Check in my sandbox if consequences make sense for multiple CNVs with different supporting variants:
- CNV with deletions:
    - [nsv4517655](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:521700-621900;sv=nsv4517655;svf=127710255;vdb=variation)
    - [nsv5594649](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=13:100485511-101485511;sv=nsv5594649;svf=127234714;vdb=variation#)
- CNVs with duplications (considered as insertions):
    - [nsv4517661](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:683134-783334;sv=nsv4517661;svf=127710249;vdb=variation)
    - [nsv4033399](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:683134-783334;sv=nsv4033399;svf=127794743;vdb=variation)
    - [nsv6310981](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?db=core;r=1:862572-962772;sv=nsv6310981;svf=130331903;vdb=variation)
- CNVs with copy number loss (considered as deletions):
    - [esv1812726](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?r=1:196761405-196833442;sv=esv1812726;svf=1149079;vdb=variation)
    - [esv1815690](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?r=5:177729898-177771948;sv=esv1815690;svf=1108895;vdb=variation)
    - [esv1850194](http://wp-np2-11.ebi.ac.uk:6070/Homo_sapiens/StructuralVariation/Mappings?r=3:98168147-98201019;sv=esv1850194;svf=1154027;vdb=variation)
- CNVs with copy number gain (considered as insertions):
    - [nsv443016](http://wp-np2-11.ebi.ac.uk:6070/Sus_scrofa/StructuralVariation/Mappings?r=7:67148496-67211415;sv=nsv443016;svf=665;vdb=variation)