### PR TITLE
Fix annotating dup as SNV

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -2165,16 +2165,21 @@ sub _clip_alleles {
   $hgvs_notation->{preseq} =   $preseq ;
 
   ### check if clipping suggests a type change 
-
+  
   ## no protein change - use transcript level annotation 
   if( $check_ref eq $check_alt) {
       $hgvs_notation->{type} = "=";
   }   
   
   ## re-set as > not delins
-  elsif( length ($check_ref) == 1 && length ($check_alt) == 1 && $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+  elsif( $check_ref ne "-" && 
+        length ($check_ref) == 1 && 
+        length ($check_alt) == 1 && 
+        $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+      
       $hgvs_notation->{type} = ">";
   }
+  
   
   ### re-set as ins/dup not delins 
   elsif(length ($check_ref) == 0 && length ($check_alt) >= 1){

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -2030,7 +2030,11 @@ sub _clip_alleles {
       $hgvs_notation->{type} = "=";
   }   
   
-  elsif( length ($hgvs_notation->{ref}) == 1 && length ($hgvs_notation->{alt}) == 1 && $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+  elsif( $hgvs_notation->{ref} ne "-" &&
+          length ($hgvs_notation->{ref}) == 1 && 
+          length ($hgvs_notation->{alt}) == 1 && 
+          $hgvs_notation->{alt} ne $hgvs_notation->{ref}) {
+      
       $hgvs_notation->{type} = ">";
   }
   


### PR DESCRIPTION
bugfix -
When we re-calculate hgvsg notation, and check if it is an SNV we also need to make sure the ref sequence is not an "-".