### PR TITLE
Increased default analysis_capacity for CAR pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpHGVS/DumpHGVS_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpHGVS/DumpHGVS_conf.pm
@@ -126,7 +126,7 @@ sub pipeline_analyses {
       },
       -rc_name           => 'medium_mem',
       -max_retry_count   => 0,
-      -analysis_capacity => 5,
+      -analysis_capacity => 500,
     },
     {
       -logic_name => 'finish_dump_hgvs',

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/GetCAR/GetCAR_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/GetCAR/GetCAR_conf.pm
@@ -122,7 +122,7 @@ sub pipeline_analyses {
       },
       -rc_name           => 'default_mem',
       -max_retry_count   => 0,
-      -analysis_capacity => 1,
+      -analysis_capacity => 30,
     },
     {
       -logic_name => 'finish_get_car',


### PR DESCRIPTION
DumpHGVS default analysis_capacity increased to 500
GetCAR default analysis_capacity increased to 30


