### PR TITLE
Update remapping pipeline

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/FinishVariationFeatureQC.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/FinishVariationFeatureQC.pm
@@ -276,7 +276,7 @@ sub flip_population_genotypes {
     my $rev_comp_genotype_string = reverse_comp_allele_string($genotype_string);
     if (contained_in_allele_string($allele_string, $rev_comp_genotype_string)) {
       my $genotype_code_id = $sgta->_genotype_code([split('/', $rev_comp_genotype_string)]);
-      print $fh_out "UPDATE population_genotype SET genotype_code_id = $genotype_code_id WHERE population_genotype_id = $population_genotype_id;\n ";
+      print $fh_out "UPDATE population_genotype SET genotype_code_id = $genotype_code_id WHERE population_genotype_id = $population_genotype_id;\n";
     }
   }
   $fh->close();

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingVariationFeature_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/Remapping/RemappingVariationFeature_conf.pm
@@ -180,7 +180,7 @@ sub pipeline_analyses {
       -logic_name => 'finish_variant_qc',
       -module     => 'Bio::EnsEMBL::Variation::Pipeline::Remapping::FinishVariationFeatureQC',
       -max_retry_count => 0,
-      -rc_name    => 'default_mem',
+      -rc_name    => 'high_mem',
        -flow_into => {
         1 => ['compare_prev_assembly'],
       },

--- a/scripts/import/compress_genotypes_by_var.pl
+++ b/scripts/import/compress_genotypes_by_var.pl
@@ -71,8 +71,8 @@ $no_sort ||= 0;
 
 warn("Make sure you have an updated ensembl.registry file!\n");
 
-usage('-TMP_DIR argument is required') if(!$TMP_DIR);
-usage('-TMP_FILE argument is required') if(!$TMP_FILE);
+usage('-tmpdir argument is required') if(!$TMP_DIR);
+usage('-tmpfile argument is required') if(!$TMP_FILE);
 usage('-species argument is required') if(!$species);
 
 $registry_file ||= $Bin . "/ensembl.registry";
@@ -85,6 +85,8 @@ my $vdba = $reg->get_DBAdaptor($species,'variation');
 my $dbCore = $reg->get_DBAdaptor($species,'core');
 
 my $dbVar = $vdba->dbc->db_handle;
+debug("Truncating compressed_genotype_var table");
+$dbVar->do(qq{ TRUNCATE compressed_genotype_var }); 
 
 $ImportUtils::TMP_DIR = $TMP_DIR;
 $ImportUtils::TMP_FILE = $TMP_FILE;

--- a/scripts/import/post_process_variation_feature_variation_set.pl
+++ b/scripts/import/post_process_variation_feature_variation_set.pl
@@ -88,7 +88,7 @@ our $VAR_SET_TABLE = 'variation_set_'.$sv_prefix.'variation';
 die ("Required argument '-species' was not specified") unless (defined($species));
 die ("Registry file $registry_file not found") unless -e $registry_file;
 
-# Allow relative paths to ensembl.registry
+# Support relative paths to registry file
 $registry_file = File::Spec->rel2abs($registry_file);
 
 # Load the registry from the supplied file
@@ -159,7 +159,7 @@ sub post_process {
     };
     my $ins_expl_sth = $dbVar->dbc->prepare($stmt);
     
-    #ÊAdd the implicit parent sets to the list of variation_sets
+    #ï¿½Add the implicit parent sets to the list of variation_sets
     $stmt = qq{
         UPDATE
             $tmp_table t,
@@ -185,7 +185,7 @@ sub post_process {
     ####
     ## Post-process
     
-    #ÊFirst, create the temporary table (drop it if it already exists)
+    #ï¿½First, create the temporary table (drop it if it already exists)
     $stmt = qq{
         DROP TABLE IF EXISTS
             $tmp_table

--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -64,7 +64,7 @@ my $reg = 'Bio::EnsEMBL::Registry';
 
 if (defined($registry)) {
   # Support relative paths to registry file
-  $registry_file = File::Spec->rel2abs($registry_file);
+  $registry = File::Spec->rel2abs($registry);
   $reg->load_all($registry);
 } else {
   if(defined($host) && $host =~ /staging|variation|livemirror/) {

--- a/scripts/misc/generate_vep_examples.pl
+++ b/scripts/misc/generate_vep_examples.pl
@@ -35,6 +35,7 @@ use Bio::EnsEMBL::Variation::VariationFeature;
 
 use Getopt::Long;
 use FileHandle;
+use File::Spec;
 
 # Print instructions if run without parameters
 usage() unless (scalar(@ARGV));
@@ -62,6 +63,8 @@ die "Error: provide the Ensembl version with option '-v'\n" if !$version;
 my $reg = 'Bio::EnsEMBL::Registry';
 
 if (defined($registry)) {
+  # Support relative paths to registry file
+  $registry_file = File::Spec->rel2abs($registry_file);
   $reg->load_all($registry);
 } else {
   if(defined($host) && $host =~ /staging|variation|livemirror/) {

--- a/scripts/misc/update_seq_region_coord.pl
+++ b/scripts/misc/update_seq_region_coord.pl
@@ -27,8 +27,8 @@ my $script_opts = [{args => ['host', 'dbhost', 'h'], type => '=s'},
         {args => ['pass', 'dbpass', 'p'], type => ':s'},
         {args => ['dbname',  'D'],         type => ':s'},
         {args => ['version'],    type => ':i'},
-        {args => ['dry_run'], type=>'!'}, ],
-        {args => ['truncate'], type=>'!'}, ],;
+        {args => ['dry_run'], type=>'!'},
+        {args => ['truncate'], type=>'!'}, ];
 
 if (scalar(@ARGV) == 0) {
   usage();
@@ -61,12 +61,8 @@ foreach my $variation_dbname (keys %$variation_dbas) {
   
   # Coord system need to be truncated?
   if ($opts->{truncate}) {
-    my $sql_truncate = qq{
-      TRUNCATE table coord_system
-    };
-    my $trunc = $vdba->dbc()->sql_helper()->execute(
-                                         -SQL => $sql_truncate);
-    print "Total of $trunc rows in coord_system set\n";
+    my $sql_truncate = qq{ TRUNCATE table coord_system };
+    $vdba->dbc()->sql_helper()->execute(-SQL => $sql_truncate);
   }
 
   # Are there foreign key failures between seq_region and coord_system?
@@ -163,8 +159,10 @@ USAGE:
   $0 \$(XserverX details script_db) --dbname XdbnameX --dry_run
   $0 \$(XserverX details script_db) --version Xrelease-versionX
   $0 --help
+
+  --truncate    Truncate coord_system table
   --dry_run     Print update statements
-  --help        Displays this help text.
+  --help        Displays this help text
 
 This script will update 
 - the variation seq_region.coord_system_id with core seq_region.coord_system_id


### PR DESCRIPTION
* [Update memory for variation_feature remap jobs](https://github.com/Ensembl/ensembl-variation/pull/1015/commits/bce75650ca658c6c45c63dd6f825187d0d1746c6)
* [Fix empty last line in `update_flip_features.txt`](https://github.com/Ensembl/ensembl-variation/pull/1015/commits/072fd2322a250255ffef99a7f1f3d8d5218b76ca) (`finish_variant_qc` step errors out when trying to run SQL command with empty line)
* Updates to remapping scripts:
    * **update_seq_region_coord.pl:** [Fix script error related with truncate option](https://github.com/Ensembl/ensembl-variation/commit/9886a662a5f3d0138253bffce29208fb0fb7b42a)
    * **compress_genotypes_by_var.pl:** [Truncate compressed_genotype_var when starting the run](https://github.com/Ensembl/ensembl-variation/commit/59ae9e7d9b579f34043effa97d88ef6199c38d95)
    * **post_process_variation_feature_variation_set.pl**: [Allow relative paths to ensembl.registry](https://github.com/Ensembl/ensembl-variation/pull/1015/commits/cda005aa3f34d59453cf91579a6a8126241a5c37)
    * **generate_vep_examples.pl**: [Support relative paths to registry file](https://github.com/Ensembl/ensembl-variation/pull/1015/commits/fed48516b29b8d219750eb8b23266afc97a2b21c) (+ [fix](https://github.com/Ensembl/ensembl-variation/pull/1015/commits/0bfe02a330a703993493e68790409984c012a895))