### PR TITLE
Fix warning when there is no pre-seq

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -2115,7 +2115,7 @@ sub _clip_alleles {
   $hgvs_notation->{original_ref} = $hgvs_notation->{ref};
 
   ## store identical trimmed seq 
-  my $preseq;
+  my $preseq = "";
   print "can we clip :  $check_ref &  $check_alt\n" if $DEBUG ==1;
   ### strip same bases from start of string
   for (my $p =0; $p <length ($hgvs_notation->{ref}); $p++){


### PR DESCRIPTION
When there is no "prefixed sequence" between ref and alt alleles that matches a warning is produced by this line -

https://github.com/Ensembl/ensembl-variation/blob/2fc4a6a5b931f4dc80266b4867cef8fb8a4b6d2e/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L2187

The issue was introduced in this PR - https://github.com/Ensembl/ensembl-variation/pull/994
and result of using undefined `$preseq` - 

https://github.com/Ensembl/ensembl-variation/blob/2fc4a6a5b931f4dc80266b4867cef8fb8a4b6d2e/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm#L2118
