### PR TITLE
Fix SV import script

### DIFF
--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -274,7 +274,7 @@ foreach my $in_file (@files) {
 # Post processing for mouse annotation (delete duplicated entries in structural_variation_sample)
 post_processing_annotation() if ($species =~ /mouse|mus/i);
 post_processing_feature();
-post_processing_sample();
+post_processing_sample() if ($source_name eq 'DGVa');
 post_processing_phenotype();
 post_processing_clinical_significance();
 post_processing_failed_variants();

--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -161,7 +161,7 @@ my $int_dba = Bio::EnsEMBL::Registry->get_DBAdaptor('multi', 'intvar');
 
 # count number of rows before import
 my @count_tables = qw(structural_variation structural_variation_feature structural_variation_sample structural_variation_association);
-report_counts($dba, "before", \@count_tables);
+report_counts($vdb, "before", \@count_tables);
 
 # set the target assembly
 $target_assembly ||= $default_cs->version;
@@ -286,7 +286,7 @@ verifications(); # URLs
 cleanup() if (!defined($debug));
 
 # count number of rows after import
-report_counts($dba, "after", \@count_tables);
+report_counts($vdb, "after", \@count_tables);
 
 debug(localtime()." All done!");
 


### PR DESCRIPTION
- there were undefined variable in use - `$dba`; it should variation database adaptor - `$vda`
- In `post_processing_sample` we only have logic for `DGVa` study. While running the script other study generates warnings in this function. It is best to put a condition to run this function only when we are importing `DGVa`. 