### PR TITLE
VEP handling Y PAR variants

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -1992,8 +1992,8 @@ sub _get_gene_transcripts {
   my ($self, $transcript_adaptor, $reference, $multiple_ok) = @_;
 
   my $gene_adaptor = $transcript_adaptor->db->get_GeneAdaptor();
-  my ($gene) = grep {($_->external_name || '') eq $reference} @{$gene_adaptor->fetch_all_by_external_name($reference)};
-  
+  my ($gene) = grep {($_->external_name || '') eq $reference && $_->is_reference} @{$gene_adaptor->fetch_all_by_external_name($reference)};
+
   my @transcripts;
 
   if($gene) {


### PR DESCRIPTION
[ENSVAR-5478](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5478)

When we input an hgvs with the gene name, VEP returns output for chrY but it should be chrX.

Input
`PLCXD1:c.57_61del`
