### PR TITLE
Update citations import - remove die

### DIFF
--- a/scripts/import/import_EPMC.pl
+++ b/scripts/import/import_EPMC.pl
@@ -1246,10 +1246,18 @@ sub remove_outdated_citations {
     my $attrib_id = $c->[2];
 
     my $variation = $var_ad->fetch_by_dbID($variation_id);
-    die "No variation found for '$variation_id'!\n" unless defined $variation;
+    # if there is a dbSNP import then some variants in the phenotype tables could be missing from the variation table
+    # print which ones are not in variation anymore - to delete post-inspection
+    if(!$variation) {
+      print $wrt "WARNING: No variation found for variation_id = $variation_id\n";
+      next;
+    }
 
     my $publication = $pub_ad->fetch_by_dbID($publication_id);
-    die "No publication found for '$publication_id'!\n" unless defined $publication;
+    if(!$publication) {
+      print $wrt "WARNING: No publication found for publication_id = $publication_id\n";
+      next;
+    }
 
     my $variation_rsid = $variation->name();
     my $publication_pmid = $publication->pmid();


### PR DESCRIPTION
In release 111, the import died: `"No variation found for '$variation_id'!\n"`
There were new dbSNP + citation tables that were copied from the previous release.
Some variants were not included in 111 anymore so the script was killed when the variant was not found. For this specific case, it was expected some variants not be there anymore.
This PR replaces the die statement with a print.
We should let the script finish and investigate why/if some variants/publications were not found.
