### PR TITLE
Import SV script fix - header label corruption

### DIFF
--- a/scripts/import/import_all_sv_data.pl
+++ b/scripts/import/import_all_sv_data.pl
@@ -428,7 +428,7 @@ sub study_table{
     $study_ftp = "https://www.ncbi.nlm.nih.gov/dbvar/studies/$study_ftp";
   }
 
-  my $assembly_desc = " [remapped from build $assembly]" if ($mapping and $assembly ne $target_assembly);
+  my $assembly_desc = $mapping and ($assembly ne $target_assembly) ? " [remapped from build $assembly]" : "";
 
   $stmt = qq{ SELECT st.study_id, st.description, st.external_reference FROM study st, source s
               WHERE s.source_id=st.source_id AND s.name='$source_name' and st.name='$study'};
@@ -1246,7 +1246,7 @@ sub get_header_info {
     ($label, $info) = split(' ', $line);
   } 
   elsif ($line =~ /\:/) {
-    $line =~ /^(.+)\:\s+(.+)$/;
+    $line =~ /^(.+?)\:\s+(.+)$/;
     $label = $1;
     $info  = $2;
   }


### PR DESCRIPTION
The header parser function `get_header_info` was doing greedy regex match until `:` found for getting label. It results in corrupted label if the header line includes a second (or third ...) `:`. For example in `nstd207` study the $study_desc is coming from - 

```
# Study_description: Long-read and strand-specific sequencing technologies together facilitate the de novo assembly of high-quality haplotype-resolved human genomes without parent-child trio data. We present 64 assembled haplotypes from 32 diverse human genomes. These highly contiguous haplotype assemblies (average contig N50: 26 Mbp) ...
```

We should do a lazy match instead.