### PR TITLE
Detect input format using VEP code

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -92,8 +92,6 @@ use Bio::EnsEMBL::Variation::DBSQL::StructuralVariationFeatureAdaptor;
 use Bio::EnsEMBL::Variation::TranscriptStructuralVariation;
 use Bio::EnsEMBL::Variation::Source;
 
-use Bio::EnsEMBL::VEP::Parser qw(detect_line_format);
-
 # we need to manually include all these modules for caching to work
 use Bio::EnsEMBL::CoordSystem;
 use Bio::EnsEMBL::Transcript;
@@ -115,6 +113,8 @@ use vars qw(@ISA @EXPORT_OK);
 @ISA = qw(Exporter);
 
 @EXPORT_OK = qw(
+    &_valid_region_regex
+    &check_format
     &detect_format
     &parse_line
     &vf_to_consequences
@@ -384,9 +384,76 @@ sub parse_line {
     return $vfs;
 }
 
+sub _valid_region_regex {
+  return qr/^([^:]+):(\d+)-(\d+)(:[-\+]?1)?[\/:]([a-z]{3,}|[ACGTN-]+)$/i;
+}
+
+# sub-routine to check format of string
+sub check_format {
+    my @line = @_;
+    my $format;
+
+    # any changes here must be copied to the JavaScript file to run instant VEP:
+    # public-plugins/tools/htdocs/components/20_VEPForm.js
+
+    # region: chr21:10-10:1/A
+    if ( scalar @line == 1 && $line[0] =~ &_valid_region_regex() ) {
+        $format = 'region';
+    }
+
+    # SPDI: NC_000016.10:68684738:G:A
+    elsif ( scalar @line == 1 && $line[0] =~ /^(.*?\:){2}([^\:]+|)$/i ) {
+        $format = 'spdi';
+    }
+
+    # CAID: CA9985736
+    elsif ( scalar @line == 1 && $line[0] =~ /^CA\d{1,}$/i ) {
+        $format = 'caid';
+    }
+
+    # HGVS: ENST00000285667.3:c.1047_1048insC
+    elsif (
+        scalar @line == 1 &&
+        $line[0] =~ /^([^\:]+)\:.*?([cgmrp]?)\.?([\*\-0-9]+.*)$/i
+    ) {
+        $format = 'hgvs';
+    }
+
+    # variant identifier: rs123456
+    elsif ( scalar @line == 1 ) {
+        $format = 'id';
+    }
+
+    # VCF: 20  14370  rs6054257  G  A  29  0  NS=58;DP=258;AF=0.786;DB;H2  GT:GQ:DP:HQ
+    elsif (
+        $line[0] =~ /(chr)?\w+/ &&
+        $line[1] =~ /^\d+$/ &&
+        $line[3] && $line[3] =~ /^[ACGTN\-\.]+$/i &&
+        $line[4]
+    ) {
+        $format = 'vcf';
+    }
+
+    # ensembl: 20  14370  14370  A/G  +
+    elsif (
+        $line[0] =~ /\w+/ &&
+        $line[1] =~ /^\d+$/ &&
+        $line[2] && $line[2] =~ /^\d+$/ &&
+        $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
+    ) {
+        $format = 'ensembl';
+    }
+    return $format;
+}
+
 # sub-routine to detect format of input
 sub detect_format {
-    detect_line_format(@_);
+    my $line = shift;
+    my @data = split /\s+/, $line;
+
+    my $format = &check_format(@data);
+    die "ERROR: Could not detect input file format\n" unless $format;
+    return $format;
 }
 
 # parse a line of Ensembl format input into a variation feature object

--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -92,6 +92,8 @@ use Bio::EnsEMBL::Variation::DBSQL::StructuralVariationFeatureAdaptor;
 use Bio::EnsEMBL::Variation::TranscriptStructuralVariation;
 use Bio::EnsEMBL::Variation::Source;
 
+use Bio::EnsEMBL::VEP::Parser qw(detect_line_format);
+
 # we need to manually include all these modules for caching to work
 use Bio::EnsEMBL::CoordSystem;
 use Bio::EnsEMBL::Transcript;
@@ -384,55 +386,7 @@ sub parse_line {
 
 # sub-routine to detect format of input
 sub detect_format {
-    my $line = shift;
-    my @data = split /\s+/, $line;
-
-    # SPDI: NC_000016.10:68684738:G:A
-    if (
-      scalar @data == 1 &&
-      $data[0] =~ /^(.*?\:){2}([^\:]+|)$/i
-    ) {
-      return 'spdi';
-    }
-
-    # HGVS: ENST00000285667.3:c.1047_1048insC
-    elsif (
-        scalar @data == 1 &&
-        $data[0] =~ /^([^\:]+)\:.*?([cgmrp]?)\.?([\*\-0-9]+.*)$/i
-    ) {
-        return 'hgvs';
-    }
-
-    # variant identifier: rs123456
-    elsif (
-        scalar @data == 1
-    ) {
-        return 'id';
-    }
-
-    # VCF: 20  14370  rs6054257  G  A  29  0  NS=58;DP=258;AF=0.786;DB;H2  GT:GQ:DP:HQ
-    elsif (
-        $data[0] =~ /(chr)?\w+/ &&
-        $data[1] =~ /^\d+$/ &&
-        $data[3] =~ /^[ACGTN\-\.]+$/i &&
-        $data[4] && $data[4] =~ /^([\.ACGTN\-\*]+\,?)+$|^(\<[\w]+\>)$/i
-    ) {
-        return 'vcf';
-    }
-
-    # ensembl: 20  14370  14370  A/G  +
-    elsif (
-        $data[0] =~ /\w+/ &&
-        $data[1] =~ /^\d+$/ &&
-        $data[2] =~ /^\d+$/ &&
-        $data[3] =~ /(ins|dup|del)|([ACGTN-]+\/[ACGTN-]+)/i
-    ) {
-        return 'ensembl';
-    }
-
-    else {
-        die("ERROR: Could not detect input file format\n");
-    }
+    detect_line_format(@_);
 }
 
 # parse a line of Ensembl format input into a variation feature object


### PR DESCRIPTION
1. Update regex for input data detection based on VEP.
2. Create new exported function for input format detection to be used by VEP, avoiding code redundancy.
3. Accept CAID and Region input in web VEP.

## Ignore alternative allele when checking VCF format

The idea of this function is to check if this format is VCF: only these columns are needed to check that.

Basically, we should not check for the alternative allele here because:

- The valid characters for the alternative allele are constantly changing with new versions of the [VCF specification](https://samtools.github.io/hts-specs/VCFv4.4.pdf)
- It only checks the first line (other lines may have issues and are ignored)
- The regex may not be up-to-date (it already happened that we support a specific type of alternative allele but forgot to update the regex here)
- If the alternative allele is not supported, it should be the function [`create_VariationFeatures()` from `Parse::VCF`](https://github.com/Ensembl/ensembl-vep/blob/611114ef13d7bcbcfd330894711749c9a2030b04/modules/Bio/EnsEMBL/VEP/Parser/VCF.pm#L242) to return that issue with a warning (and not an error like `detect_format()`, because the format is still VCF).
- We get user-reported issues related with the strict regex here, even though the line is fully supported by VEP

## Related PRs

- https://github.com/Ensembl/ensembl-vep/pull/1477
- https://github.com/Ensembl/public-plugins/pull/717