### PR TITLE
Add start_retained for non-ATG transcript

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1051,7 +1051,7 @@ sub synonymous_variant {
     
     return 0 unless $ref_pep;
 
-    return ( ($alt_pep eq $ref_pep) and (not stop_retained(@_) and ($alt_pep !~ /X/) and ($ref_pep !~ /X/)) );
+    return ( ($alt_pep eq $ref_pep) and (not stop_retained(@_) and not start_retained_variant(@_) and ($alt_pep !~ /X/) and ($ref_pep !~ /X/)) );
 }
 
 sub missense_variant {

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -1442,7 +1442,7 @@ $transcript_tests->{$sc_se_t->stable_id}->{tests} = [
     }, 
 ];
 
-# a transcript with a misc amino acid edit
+# a transcript with a misc amino acid edit altered to start codon
 my $aa_se_t = $ta->fetch_by_stable_id('ENST00000295641');
 
 $transcript_tests->{$aa_se_t->stable_id}->{transcript} = $aa_se_t;
@@ -1453,7 +1453,7 @@ $transcript_tests->{$aa_se_t->stable_id}->{tests} = [
         alleles => 'T',
         start   => 220462640,
         end     => 220462640,
-        effects => [qw(synonymous_variant)],
+        effects => [qw(start_retained_variant)],
     }, 
 ];
 
@@ -1489,7 +1489,7 @@ my $tv = Bio::EnsEMBL::Variation::TranscriptVariation->new(
 my $tva = $tv->get_all_alternate_BaseVariationFeatureOverlapAlleles();
 
 my $start_retained = Bio::EnsEMBL::Variation::Utils::VariationEffect::start_retained_variant($tva->[0]);
-is($start_retained, undef, 'start_retained works with no $bvfo & $bvf');
+is($start_retained, 0, 'start_retained works with no $bvfo & $bvf');
 
 my $stop_retained = Bio::EnsEMBL::Variation::Utils::VariationEffect::stop_retained($tva->[0]);
 is($stop_retained, undef, 'stop_retained works with no $bvfo & $bvf');

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -1453,7 +1453,7 @@ $transcript_tests->{$aa_se_t->stable_id}->{tests} = [
         alleles => 'T',
         start   => 220462640,
         end     => 220462640,
-        effects => [qw(synonymous_variant start_retained_variant)],
+        effects => [qw(start_retained_variant)],
     }, 
 ];
 

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -1442,7 +1442,7 @@ $transcript_tests->{$sc_se_t->stable_id}->{tests} = [
     }, 
 ];
 
-# a transcript with a misc amino acid edit altered to start codon
+# a transcript with a misc amino acid edit altered to start
 my $aa_se_t = $ta->fetch_by_stable_id('ENST00000295641');
 
 $transcript_tests->{$aa_se_t->stable_id}->{transcript} = $aa_se_t;
@@ -1453,7 +1453,7 @@ $transcript_tests->{$aa_se_t->stable_id}->{tests} = [
         alleles => 'T',
         start   => 220462640,
         end     => 220462640,
-        effects => [qw(start_retained_variant)],
+        effects => [qw(synonymous_variant start_retained_variant)],
     }, 
 ];
 


### PR DESCRIPTION
JIRA Ticket - [ENSVAR-3154](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-3154)
Also see - https://www.ebi.ac.uk/seqdb/confluence/display/EV/VEP+-+non-standard+translation

### Problem
There are some transcript that have non-ATG start, for example - gene WT1, transcript ENST00000332351. It has already been fixed to report `synonymous_variant` if the start codon is altered to an ATG (which is the normal start codon). But we should report `start_retained_variant` instead of `synonymous_variant` as it is more accurate/appropriate.

### Solution
Added another function that checks the amino acid that replaces the start codon and see if is an 'ATG'.

### Test
Example command -
```
vep -i input_data --force --database

#input_data
11	32435360	rsfake	G	T
```