### PR TITLE
Fix lookup direction for dup when sequence is reversed

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2069,9 +2069,8 @@ sub _hgvs_from_components {
   # take alternate allele from genomic reference & coordinates if not supplied in HGVS string for a duplication
   if($description =~ /dup/){ 
     ## special case: handle as insertion for ensembl object purposes 
-    $start = $end ;
-    if($strand  == 1){ $start++; }
-    else{             $end--;   }
+    if($strand  == 1){ $start = $end + 1; }
+    else{ $end = $start - 1 }
 
     $ref_allele = "-" ;
     $alt_allele = $refseq_allele;

--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2069,7 +2069,9 @@ sub _hgvs_from_components {
   # take alternate allele from genomic reference & coordinates if not supplied in HGVS string for a duplication
   if($description =~ /dup/){ 
     ## special case: handle as insertion for ensembl object purposes 
-    $start = $end + 1; 
+    $start = $end ;
+    if($strand  == 1){ $start++; }
+    else{             $end--;   }
 
     $ref_allele = "-" ;
     $alt_allele = $refseq_allele;

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1378,15 +1378,7 @@ sub hgvs_transcript {
   ## this may be different to the input one for insertions/deletions
     print "vfs: $variation_feature_sequence &  $self->{_slice_start} -> $self->{_slice_end}\n" if $DEBUG ==1;
   if($variation_feature_sequence && $vf->strand != $refseq_strand) {
-    if($vf->strand == 1){
-      reverse_comp(\$variation_feature_sequence);
-    }
-    else{
-      # if variation feature is in + strand and transcript in - strand only complementing is 
-      # enough as variation feature sequence will be from reverse strand but in 3'-5' direction
-      $variation_feature_sequence =~
-        tr/acgtrymkswhbvdnxACGTRYMKSWHBVDNX/tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX/;
-    }
+    reverse_comp(\$variation_feature_sequence);
   };
   ## delete consequences if we have an offset. This is only in here for when we want HGVS to shift but not consequences.
   ## TODO add no_shift flag test
@@ -1395,8 +1387,6 @@ sub hgvs_transcript {
   
   return undef if (($self->{_slice}->end - $self->{_slice}->start + 1) < ($self->{_slice_end} + $offset_to_add));
   #return undef if (length($self->{_slice}->seq()) < ($self->{_slice_end} + $offset_to_add));
-  
-  my $dup_lookup_direction = ($refseq_strand == -1 && !$offset_to_add) ? 1 : -1;
   $hgvs_notation = hgvs_variant_notation(
     $variation_feature_sequence,    ### alt_allele,
     $self->{_slice}->seq(),                             ### using this to extract ref allele
@@ -1404,8 +1394,7 @@ sub hgvs_transcript {
     $self->{_slice_end} + $offset_to_add,
     "",
     "",
-    $var_name,
-    $dup_lookup_direction
+    $var_name
   );
   
   ### This should not happen

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1377,13 +1377,16 @@ sub hgvs_transcript {
   }
   ## this may be different to the input one for insertions/deletions
     print "vfs: $variation_feature_sequence &  $self->{_slice_start} -> $self->{_slice_end}\n" if $DEBUG ==1;
-  
-    
-  my $dup_lookup_direction = ($refseq_strand == -1 && !$offset_to_add) ? 1 : -1;
-    
   if($variation_feature_sequence && $vf->strand != $refseq_strand) {
+    if($vf->strand == 1){
       reverse_comp(\$variation_feature_sequence);
-      $dup_lookup_direction *= -1; 
+    }
+    else{
+      # if variation feature is in + strand and transcript in - strand only complementing is 
+      # enough as variation feature sequence will be from reverse strand but in 3'-5' direction
+      $variation_feature_sequence =~
+        tr/acgtrymkswhbvdnxACGTRYMKSWHBVDNX/tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX/;
+    }
   };
   ## delete consequences if we have an offset. This is only in here for when we want HGVS to shift but not consequences.
   ## TODO add no_shift flag test
@@ -1393,6 +1396,7 @@ sub hgvs_transcript {
   return undef if (($self->{_slice}->end - $self->{_slice}->start + 1) < ($self->{_slice_end} + $offset_to_add));
   #return undef if (length($self->{_slice}->seq()) < ($self->{_slice_end} + $offset_to_add));
   
+  my $dup_lookup_direction = ($refseq_strand == -1 && !$offset_to_add) ? 1 : -1;
   $hgvs_notation = hgvs_variant_notation(
     $variation_feature_sequence,    ### alt_allele,
     $self->{_slice}->seq(),                             ### using this to extract ref allele

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -244,6 +244,10 @@ sub _return_3prime {
   
   my $shift_length;
   my $strand = $tr->strand;
+
+  # vf can be on different strand than transcript
+  my $vf_strand = $self->variation_feature->strand;
+  reverse_comp(\$seq_to_check) if $vf_strand != $strand;
   
   ## Actually performs the shift, and provides raw data in order to create shifting hash
   ($shift_length, $seq_to_check, $hgvs_output_string, $start, $end) = $self->perform_shift($seq_to_check, $post_seq, $pre_seq, $start, $end, $hgvs_output_string, (-1 * ($strand -1))/2, $strand); 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1377,16 +1377,13 @@ sub hgvs_transcript {
   }
   ## this may be different to the input one for insertions/deletions
     print "vfs: $variation_feature_sequence &  $self->{_slice_start} -> $self->{_slice_end}\n" if $DEBUG ==1;
+  
+    
+  my $dup_lookup_direction = ($refseq_strand == -1 && !$offset_to_add) ? 1 : -1;
+    
   if($variation_feature_sequence && $vf->strand != $refseq_strand) {
-    if($vf->strand == 1){
       reverse_comp(\$variation_feature_sequence);
-    }
-    else{
-      # if variation feature is in + strand and transcript in - strand only complementing is 
-      # enough as variation feature sequence will be from reverse strand but in 3'-5' direction
-      $variation_feature_sequence =~
-        tr/acgtrymkswhbvdnxACGTRYMKSWHBVDNX/tgcayrkmswdvbhnxTGCAYRKMSWDVBHNX/;
-    }
+      $dup_lookup_direction *= -1; 
   };
   ## delete consequences if we have an offset. This is only in here for when we want HGVS to shift but not consequences.
   ## TODO add no_shift flag test
@@ -1396,7 +1393,6 @@ sub hgvs_transcript {
   return undef if (($self->{_slice}->end - $self->{_slice}->start + 1) < ($self->{_slice_end} + $offset_to_add));
   #return undef if (length($self->{_slice}->seq()) < ($self->{_slice_end} + $offset_to_add));
   
-  my $dup_lookup_direction = ($refseq_strand == -1 && !$offset_to_add) ? 1 : -1;
   $hgvs_notation = hgvs_variant_notation(
     $variation_feature_sequence,    ### alt_allele,
     $self->{_slice}->seq(),                             ### using this to extract ref allele

--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -498,14 +498,10 @@ sub hgvs_variant_notation {
   my $display_start = shift;
   my $display_end = shift;
   my $var_name  = shift;
-  my $dup_lookup_direction = shift;
 
   # If display_start and display_end were not specified, use ref_start and ref_end
   $display_start ||= $ref_start;
   $display_end ||= $ref_end;
-  
-  # the direction to look for ref seq match with alt allele to see if it is dup type
-  $dup_lookup_direction ||= -1;
   
   #Throw an exception if the lengths of the display interval and reference interval are different
   throw("The coordinate interval for display is of different length than for the reference allele") if (($display_end - $display_start) != ($ref_end - $ref_start));
@@ -570,19 +566,12 @@ sub hgvs_variant_notation {
   if (!$ref_length) {
   
     # Get the same number of nucleotides preceding the insertion as the length of the insertion
-    my $prev_str = $dup_lookup_direction == -1 ? 
-      substr($ref_sequence,($ref_end-$alt_length),$alt_length) :
-      substr($ref_sequence,$ref_end,$alt_length);
+    my $prev_str = substr($ref_sequence,($ref_end-$alt_length),$alt_length);
 
     # If they match, this is a duplication
     if ($prev_str eq $alt_allele) {
       
-      if ($dup_lookup_direction == -1){
-        $notation{'start'} = ($display_end - $alt_length + 1);
-      }
-      else{
-        $notation{'end'} = $display_start + $alt_length - 1;
-      }
+      $notation{'start'} = ($display_end - $alt_length + 1);
       $notation{'type'} = 'dup';
       # Return the notation
       return \%notation;


### PR DESCRIPTION
Related issue - https://github.com/Ensembl/ensembl-vep/issues/1485

The bug is introduced in - https://github.com/Ensembl/ensembl-variation/pull/994
When variation and transcript strand is opposite we should reverse complement the sequence irrespectively. But needs to update the lookup direction if that happens.

More testing needed. Related JIRA ticket for testing - https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5765