### PR TITLE
Fix MaveDB plugin data creation

### DIFF
--- a/nextflow/MaveDB/bin/map_scores_to_variants.py
+++ b/nextflow/MaveDB/bin/map_scores_to_variants.py
@@ -102,10 +102,17 @@ def join_information (hgvs, mapped_info, row, extra):
   var = mapped_info['variation']
   ref = mapped_info['vrs_ref_allele_seq']
 
+  start = var["location"]["interval"]["start"]["value"]
+  end   = var["location"]["interval"]["end"]["value"]
+
+  # increment 1 to start (except when start == end, such as in insertions)
+  if start < end:
+    start = start + 1
+
   mapped = OrderedDict(
     [("chr",   get_chromosome(hgvs)),
-     ("start", var["location"]["interval"]["start"]["value"]),
-     ("end",   var["location"]["interval"]["end"]["value"]),
+     ("start", start),
+     ("end",   end),
      ("ref",   ref),
      ("alt",   var["state"]["sequence"]),
      ("hgvs",  hgvs)])

--- a/nextflow/MaveDB/bin/map_scores_to_variants.py
+++ b/nextflow/MaveDB/bin/map_scores_to_variants.py
@@ -228,7 +228,7 @@ def write_variant_mapping (f, map):
 
 # download MaveDB scores
 urn         = f"urn:mavedb:{args.urn}"
-url         = f"https://api.mavedb.org/api/v1/scoresets/{urn}/scores"
+url         = f"https://api.mavedb.org/api/v1/score-sets/{urn}/scores"
 scores_file = f"{args.urn}_scores.txt"
 if not os.path.isfile(scores_file):
   print("Downloading MaveDB scores...", flush=True)

--- a/nextflow/MaveDB/bin/map_scores_to_variants.py
+++ b/nextflow/MaveDB/bin/map_scores_to_variants.py
@@ -102,17 +102,10 @@ def join_information (hgvs, mapped_info, row, extra):
   var = mapped_info['variation']
   ref = mapped_info['vrs_ref_allele_seq']
 
-  start = var["location"]["interval"]["start"]["value"]
-  end   = var["location"]["interval"]["end"]["value"]
-
-  # increment 1 to start (except when start == end, such as in insertions)
-  if start < end:
-    start = start + 1
-
   mapped = OrderedDict(
     [("chr",   get_chromosome(hgvs)),
-     ("start", start),
-     ("end",   end),
+     ("start", var["location"]["interval"]["start"]["value"] + 1),
+     ("end",   var["location"]["interval"]["end"]["value"]),
      ("ref",   ref),
      ("alt",   var["state"]["sequence"]),
      ("hgvs",  hgvs)])

--- a/nextflow/MaveDB/nf_modules/fetch.nf
+++ b/nextflow/MaveDB/nf_modules/fetch.nf
@@ -12,7 +12,7 @@ process fetch_licence {
   import json
 
   urn = "urn:mavedb:${mappings.simpleName}"
-  url = f"https://api.mavedb.org/api/v1/scoresets/{urn}"
+  url = f"https://api.mavedb.org/api/v1/score-sets/{urn}"
   res = urllib.request.urlopen(url).read()
   res = json.loads(res)
 


### PR DESCRIPTION
ENSVAR-5960: Ensure MaveDB VEP plugin works with regulatory data

- Fix start position for all genomic HGVS variants (zero-index position is now one-index position to conform with protein HGVS)
- Update URL for MaveDB REST endpoint (previous one is now invalid)

Note: The path to the updated plugin data is mentioned in ENSVAR-5960 and can be tested with https://github.com/Ensembl/VEP_plugins/pull/628.