### PR TITLE
Fix breakend consequences when using `chr` prefix

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -107,16 +107,25 @@ sub _intron_overlap {
   }
 }
 
+sub compare_seq_region_names {
+  my $region1 = shift;
+  my $region2 = shift;
+
+  $region1 =~ s/^chr//;
+  $region2 =~ s/^chr//;
+  return lc($region1) eq lc($region2);
+}
+
 sub within_feature {
-    my ($bvfoa, $feat, $bvfo, $bvf, $match_chromosome) = @_;
+    my ($bvfoa, $feat, $bvfo, $bvf, $match_seq_region_names) = @_;
     $bvf  ||= $bvfoa->base_variation_feature;
     $feat ||= $bvfoa->feature;
-    $match_chromosome ||= 0;
+    $match_seq_region_names ||= 0;
 
     my $cmp_chr = 1;
-    if ($match_chromosome) {
+    if ($match_seq_region_names) {
       my $chr  = $bvf->{chr} || $bvf->{slice}->{seq_region_name};
-      $cmp_chr = $chr eq $feat->{slice}->{seq_region_name};
+      $cmp_chr = compare_seq_region_names($chr, $feat->{slice}->{seq_region_name});
     }
 
     return $cmp_chr && overlap(


### PR DESCRIPTION
Fixes https://github.com/Ensembl/ensembl-vep/issues/1479

Simply ignore the `chr` prefix of breakend mates when checking if a mate is contained within an Ensembl feature.

In a future PR, we will also look into chromosome synonyms (ENSVAR-5967), such as `CM000664.2` and `NC_000002.12`.

### Testing

Run VEP with the following pairs of variants, the results should be the same whether they regions have a `chr` prefix or not:

```
#CHROM  POS     ID      REF     ALT     QUAL    FILTER  INFO    FORMAT
2       29225144        bnd     G       G]2:42267610]   .       .       SVTYPE=BND
2       42267610        bnd     A       A]2:29225144]   .       .       SVTYPE=BND
chr2    29225144        bnd     G       G]chr2:42267610]        .       .       SVTYPE=BND
chr2    42267610        bnd     A       A]chr2:29225144]        .       .       SVTYPE=BND
```