### PR TITLE
Update VEP plugin documentation script

### DIFF
--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -378,23 +378,26 @@ sub read_plugin_file {
              
             # Add code block -- three types of code blocks:
             #   1. to show a code script
-            #        start: line starts with ##### or contains # BEGIN
-            #        end:   line contains # END 
+            #        start: line contains # BEGIN or starts with ``` or #####
+            #        end:   line contains # END   or starts with ```
             #   2. to show arbitrary code lines
             #        line starts with > or --plugin or bash commands (see $cmds)
             #   3. to illustrate variant location:
             #        start: line contains v (variant) after 3 or more spaces
             #        end:   line only contains I (intron) or ES/EE (exon start/end)
-            if ($line =~ /#{5,}/ || $line =~ /# BEGIN/) {
-              # start block of code script
-              $line = '<pre class="code sh_sh">' . $line unless $code_script;
-              $code_script = 1;
-            } elsif ($code_script) {
-              # continue code script until getting to a line containing # END
-              if ($line =~ /# END/) {
+            if ($code_script) {
+              # continue code script until getting to a line containing # END or ```
+              $line =~ s/^\s*>?\s?//;
+              if ($line =~ /# END/ || $line =~ /^\s*```\s*$/) {
+                $line = '' if $line =~ /^\s*```\s*$/;
                 $line .= '</pre>';
                 $code_script = 0;
               }
+            } elsif ($line =~ /#{5,}/ || $line =~ /# BEGIN/ || $line =~ /^\s*```\s*$/) {
+              # start block of code script
+              $line = '' if $line =~ /^\s*```\s*$/;
+              $line = '<pre class="code sh_sh">' . $line unless $code_script;
+              $code_script = 1;
             } elsif ($line =~ /^\s{3,}v/) {
               # start code block to illustrate variant position
               $line = '<pre class="code sh_sh">' . $line unless $code_block;

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -313,6 +313,7 @@ sub read_plugin_file {
         }
         else {
           if ($desc ne '' || $line !~ /^\s+$/) {
+            # Create unordered list when starting line with certain characters
             if ($line =~ /^\s+[-*+] (.*)/) {
               $line = ($ulist ? '</li>' : '<ul>') . '<li>' . $1;
               $ulist = 1;
@@ -328,6 +329,7 @@ sub read_plugin_file {
               }
             }
 
+            # Create table for plugin arguments
             if ($line =~ 'key=value') {
               $line = '</td></tr></tbody></table>' . "\n" . $line if $table;
               $table = 1;
@@ -401,6 +403,7 @@ sub read_plugin_file {
               }
             }
 
+            # Create ordered list from numbers at line start
             if ($line =~ /^\s+\(?([0-9]+)[\)\.] (.*)/) {
               $line = ($olist ? '</li>' : '<ol>') . '<li value="' . $1 . '">' . $2;
               $olist = 1;

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -142,11 +142,11 @@ warn join("\n  - ", "The following plugins were NOT documented:", @skipped), "\n
 open OUT, "> $output_file" or die $!;
 
 my $table_content .= qq{   
-  <table class="ss">
+  <table class="ss" style="table-layout: fixed;">
     <thead>
       <tr>
         <th>Plugin</th>
-        <th style="max-width:50%">Description</th>
+        <th style="width:50%">Description</th>
         <th>Category</th>
         <th>External libraries</th>
         <th>Developer</th>
@@ -173,7 +173,7 @@ foreach my $file (@sorted_files) {
     '<tr class="%s plugin_row" data-category="%s">'.
     '<td><div style="font-weight:bold"><a rel="external" href="%s">%s</a></div>%s</td>'.
     '<td>%s</td>'.
-    '<td><div class="vdoc_dtype_count" style="float:left;padding:2px 6px;cursor:default;background-color:%s">%s</div></td>'.
+    '<td><div class="vdoc_dtype_count" style="white-space:normal;float:left;padding:2px 6px;cursor:default;background-color:%s">%s</div></td>'.
     '<td>%s</td>'.
     '<td>%s</td>'.
     '</tr>',
@@ -452,7 +452,7 @@ sub read_plugin_file {
     my $lc_name = lc($name);
        $lc_name =~ s/ /_/g;
     my $desc_link = qq{ <a class="button" href="#$lc_name" style="padding:3px 8px 0px 8px !important;height:18px" onclick="show_hide('$lc_name');" id="a_$lc_name">more</a>};
-    $desc =~ s/<\/p><p>/$desc_link<\/p><div id="div_$lc_name" style="display:none;"><p>/;
+    $desc =~ s/<\/p><p>/$desc_link<\/p><div id="div_$lc_name" style="display:none;word-wrap:break-word;"><p>/;
     $desc .= '</div>';
   }
 

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -141,8 +141,8 @@ warn join("\n  - ", "The following plugins were NOT documented:", @skipped), "\n
 # Print output HTML
 open OUT, "> $output_file" or die $!;
 
-my $table_content .= qq{   
-  <table class="ss" style="table-layout: fixed;">
+my $table_content .= qq{
+  <table class="ss" style="table-layout: fixed; word-break: break-word;">
     <thead>
       <tr>
         <th>Plugin</th>

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -170,13 +170,14 @@ foreach my $file (@sorted_files) {
   $plugin_class_list{$plugin_class} = $plugin_id;
 
   $table_content .= sprintf(
-    '<tr class="%s plugin_row" data-category="%s">'.
+    '<tr id="%s" class="%s plugin_row" data-category="%s">'.
     '<td><div style="font-weight:bold"><a rel="external" href="%s">%s</a></div>%s</td>'.
     '<td>%s</td>'.
     '<td><div class="vdoc_dtype_count" style="white-space:normal;float:left;padding:2px 6px;cursor:default;background-color:%s">%s</div></td>'.
     '<td>%s</td>'.
     '<td>%s</td>'.
     '</tr>',
+    $plugin_name,
     $tr_class,
     $plugin_id,
     "$vep_plugin_url_version/$file",

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -366,7 +366,7 @@ sub read_plugin_file {
   close(F);
 
   # Make URLs clickable
-  $desc =~ s|((http\|ftp)s?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9():]{0,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*[^\)\.,;:\s]))|<a href="$1">$1</a>|g;
+  $desc =~ s|((http\|ftp)s?:\/\/(www\.)?[-a-zA-Z0-9\@:%._\+~#=]{1,256}\.[a-zA-Z0-9():]{0,6}\b([-a-zA-Z0-9()\@:%_\+.~#?&//=]*[^\)\.,;:\s]))|<a href="$1">$1</a>|g;
   
   # Postprocess the description content (reformatting)
   $desc = "<p>$desc</p>";

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -337,7 +337,7 @@ sub read_plugin_file {
               $ulist_newline = 0;
             } elsif ($ulist) {
               if ($ulist_newline) {
-                $line = '</li></ul>' . $line;
+                $line = '</li></ul><p>' . $line;
                 $ulist = 0;
               } elsif ($line =~ '^\s+$') {
                 $ulist_newline = 1;
@@ -348,7 +348,7 @@ sub read_plugin_file {
 
             # Create table for plugin arguments
             if ($line =~ 'key=value') {
-              $line = '</td></tr></tbody></table>' . "\n" . $line if $table;
+              $line = '</td></tr></tbody></table><p>' . $line if $table;
               $table = 1;
               $table_newline = 0;
               chomp($line);
@@ -368,7 +368,7 @@ sub read_plugin_file {
                   '<td>' . $description . ' ');
                 $table_newline = 0;
               } elsif ($table_newline) {
-                $line = '</td></tr></tbody></table>' . "\n" . $line;
+                $line = '</td></tr></tbody></table><p>' . $line;
                 $table = 0;
                 $table_newline = 0;
               } elsif ($line =~ '^\s+$') {
@@ -418,7 +418,7 @@ sub read_plugin_file {
                 $line = "" if $line =~ /^\s+$/;
 
                 # end code block (terminal commands)
-                $line = '</pre><p>' . $line . '</p>';
+                $line = '</pre><p>' . $line;
                 $code_block = 0;
               }
             }
@@ -430,7 +430,7 @@ sub read_plugin_file {
               $olist_newline = 0;
             } elsif ($olist) {
               if ($olist_newline) {
-                $line = '</li></ol>' . $line;
+                $line = '</li></ol><p>' . $line;
                 $olist = 0;
               } elsif ($line =~ '^\s+$') {
                 $olist_newline = 1;
@@ -440,14 +440,17 @@ sub read_plugin_file {
             }
 
             $desc .= $line;
-            $line = '</pre><p>' . $line . '</p>' if $code_block;
+            $line = '</pre><p>' . $line if $code_block;
           }
         }
         chomp($line);
       }
-      $desc .= '</td></tr></tbody></table>' if $table_newline;
+      $desc .= '</ul><p>' if $ulist_newline;
+      $desc .= '</ol><p>' if $olist_newline;
+      $desc .= '</td></tr></tbody></table><p>' if $table_newline;
+      $desc .= '</pre><p>' if $code_block;
     }
-    
+
     # Get the non Ensembl Perl module dependencies
     if ($line =~ /^use\s+(.+);/) {
       my $lib = $1;

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -325,13 +325,17 @@ sub read_plugin_file {
       while ($desc_flag != 0) {
         $line = <F>;
         
+        # Escape non-HTML tags, such as <test>
+        $line =~ s|<|&lt|g;
+        $line =~ s|>|&gt|g;
+
         if ($line =~ /^\s*=head1/ || $line =~ /^\s*=cut/) {
           $desc_flag = 0;
         }
         else {
           if ($desc ne '' || $line !~ /^\s+$/) {
             # Create unordered list when starting line with certain characters
-            if ($line =~ /^\s+[-*+] (.*)/) {
+            if ($line =~ /^\s*[-*+] (.*)/) {
               $line = ($ulist ? '</li>' : '<ul>') . '<li>' . $1;
               $ulist = 1;
               $ulist_newline = 0;
@@ -406,13 +410,12 @@ sub read_plugin_file {
               # end code block to illustrate variant position
               $line .= '</pre>';
               $code_block = 0;
-            } elsif ($line =~ /^\s*>\s?/ || $line =~ /^\s*($cmds)\s/ || $line =~ /^\s*--plugin/) {
+            } elsif ($line =~ /^\s*\&gt\s?/ || $line =~ /^\s*($cmds)\s/ || $line =~ /^\s*--plugin/) {
               # start code block (terminal commands)
-              $line =~ s/^\s*>?\s?//;
+              $line =~ s/^\s*(\&gt)?\s?//;
               $line = '<pre class="code sh_sh">' . $line unless $code_block;
               $code_block = 1;
             } else {
-#              $line =~ s/^\s+// if $line =~ /\S+/;
               if ($code_block) {
                 # remove blank lines after code block (looks nicer)
                 $line = "" if $line =~ /^\s+$/;
@@ -424,7 +427,7 @@ sub read_plugin_file {
             }
 
             # Create ordered list from numbers at line start
-            if ($line =~ /^\s+\(?([0-9]+)[\)\.] (.*)/) {
+            if ($line =~ /^\s*\(?([0-9]+)[\)\.] (.*)/) {
               $line = ($olist ? '</li>' : '<ol>') . '<li value="' . $1 . '">' . $2;
               $olist = 1;
               $olist_newline = 0;

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -471,6 +471,9 @@ sub read_plugin_file {
   # Make URLs clickable
   $desc =~ s|((http\|ftp)s?:\/\/(www\.)?[-a-zA-Z0-9\@:%._\+~#=]{1,256}\.[a-zA-Z0-9():]{0,6}\b([-a-zA-Z0-9()\@:%_\+.~#?&//=]*[^\)\.,;:\s\<]))|<a href="$1">$1</a>|g;
 
+  # Convert DOI to URL
+  $desc =~ s|(doi:([^\s]+[A-Za-z0-9]))|<a rel="external" href="https://doi.org/$2">$1</a>|g;
+
   # Convert pair of single quotes to code
   $desc =~ s|[\'\`]([\w:\-?\/_\.\|\&\,\;\=\]\[]*)[\'\`]|<kbd>$1</kbd>|g;
 

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -289,9 +289,10 @@ sub read_plugin_file {
       my $desc_flag = 1;
       my $code_block = 0;
       my $code_script = 0;
-      my $cmds = join "|", qw( zcat zgrep cat wget rm gzip gunzip awk head
-                               sort sed bgzip unzip cd perl make tabix mysql
-                               echo tar ./filter_vep ./vep );
+      my $cmds = join "|", qw( ./vep ./filter_vep awk bgzip cat cd chmod cp curl
+                               echo exit grep gunzip gzip head ls less make mkdir
+                               mysql mv perl rm sed sort paste pwd sudo tabix
+                               tail tar touch unzip wget zcat zgrep zip );
       $cmds =~ s#(\.|/)#\\$1#g;
 
       while ($desc_flag != 0) {

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -471,6 +471,9 @@ sub read_plugin_file {
   # Make URLs clickable
   $desc =~ s|((http\|ftp)s?:\/\/(www\.)?[-a-zA-Z0-9\@:%._\+~#=]{1,256}\.[a-zA-Z0-9():]{0,6}\b([-a-zA-Z0-9()\@:%_\+.~#?&//=]*[^\)\.,;:\s\<]))|<a href="$1">$1</a>|g;
 
+  # Convert pair of single quotes to code
+  $desc =~ s|[\'\`]([\w:\-?\/_\.\|\&\,\;\=\]\[]*)[\'\`]|<kbd>$1</kbd>|g;
+
   # Add usage examples
   $desc .= '<p>' . $usage . '</p>';
 


### PR DESCRIPTION
Requires Ensembl/VEP_plugins#674

## Changelog

- a83766f: Format bullet and numbered lists 
    - Bullet lists are created for line starting with characters like `- ` and `* `
    - Numbered lists are created for numbered patterns like `2. ` and `4) `
    - Nested lists are not currently supported
- 23c5c38: Display plugin arguments in a table
    - Arguments need to be in format `argument_name : description`
    - The table only starts after a sentence that contains the keyword `key=value`
- 222828517: Add usage examples from `SYNOPSIS`
- 6d2712ec0: Add code block when using ` ``` ` (like in Markdown)
- 6e65ae3d0: Format text surrounded with `` ` `` or `'` as keyboard input (`<kbd>`)
- 2537dd582: Convert DOI (pattern like `doi:10.235/343`) to an URL
- 97d2793: Increase list of UNIX commands automatically recognised for code blocks
- 1cb91a2e6: Add anchor links to each plugin row

### Bug fixes

- 3522e55b6: Fix table layout
    - Code blocks are now scrollable instead of increasing table width
- 0412c44: Avoid warning: `Possible unintended interpolation of @: in string` 
- 8c4fde2c5: Fix `<p>` tags
- 3bc3609f9: Other minor bug fixes

## Testing

Check the following features in my [sandbox](http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html) compared to the [live website](https://ensembl.org/info/docs/tools/vep/script/vep_plugins.html):

| Feature | Sandbox example |
|--------|--------|
| Numbered list | [Carol][] <br> [Condel][] |
| Bullet list | [AlphaMissense][] <br> [dbNSFP][] |
| Table of plugin arguments | [AlphaMissense][] <br> [satMutMPRA][] |
| Usage examples | [AlphaMissense][] <br> [Carol][] <br> [Condel][] |
| Code block with ` ``` ` | [TranscriptAnnotator][] <br> [neXtProt][] |
| Format text as `<kbd>` when surrounded with `` ` `` or `'` | [AncestralAlle][] <br> [Condel][] |
| DOI to URL | [Condel][] |

Please check as many plugin docs as you can! Thank you.

[AlphaMissense]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#AlphaMissense
[AncestralAlle]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#AncestralAllele
[Carol]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#Carol
[dbNSFP]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#dbNSFP
[Condel]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#Condel
[neXtProt]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#neXtProt
[TranscriptAnnotator]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#TranscriptAnnotator
[satMutMPRA]: http://wp-np2-11.ebi.ac.uk:6070/info/docs/tools/vep/script/vep_plugins.html#satMutMPRA