### PR TITLE
Update phenotype pipeline - G2P replace MIM by external_id

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportG2P.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/PhenotypeAnnotation/ImportG2P.pm
@@ -254,7 +254,7 @@ sub parse_input_file {
         push @phenotypes, {
           'id' => $gene->stable_id,
           'description' => $phen,
-          'MIM' => $id,
+          'external_id' => $id,
           'seq_region_id' => $gene->slice->get_seq_region_id,
           'seq_region_start' => $gene->seq_region_start,
           'seq_region_end' => $gene->seq_region_end,


### PR DESCRIPTION
`external_id` is used by BioMart.
When we updated to `MIM` BioMart lost G2P data.
[ENSVAR-6060](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6060)