### PR TITLE
Allow developer other than Ensembl as plugin author

### DIFF
--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -253,7 +253,7 @@ sub read_plugin_file {
     }
     
     # Contact/developper information
-    if ($line =~ /=head1 CONTACT/ && scalar(@developer) == 0) {
+    if ($line =~ /=head1 CONTACT/) {
       my $contact_flag = 1;
       while ($contact_flag != 0) {
         $line = <F>;
@@ -263,7 +263,10 @@ sub read_plugin_file {
         }
         else {
           $line =~ s/^\s+//;
-          push(@developer, $1) if ($line =~ /(.+)\s+</);
+          if ($line =~ /(.+)\s+</) {
+            # some plugin had old-style Ensembl contact info with lots of text
+            push @developer, $1 if $1 ne "developers list at"; 
+          }
         }
       }
     }

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -265,7 +265,7 @@ sub read_plugin_file {
           $line =~ s/^\s+//;
           if ($line =~ /(.+)\s+</) {
             # some plugin had old-style Ensembl contact info with lots of text
-            push @developer, $1 if $1 ne "developers list at"; 
+            push @developer, $1 unless (grep /^$1$/, @developer || $1 eq "developers list at");
           }
         }
       }

--- a/scripts/docs/update_web_vep_plugins_documentation.pl
+++ b/scripts/docs/update_web_vep_plugins_documentation.pl
@@ -265,7 +265,7 @@ sub read_plugin_file {
           $line =~ s/^\s+//;
           if ($line =~ /(.+)\s+</) {
             # some plugin had old-style Ensembl contact info with lots of text
-            push @developer, $1 unless (grep /^$1$/, @developer || $1 eq "developers list at");
+            push @developer, $1 unless (grep(/^$1$/, @developer) || $1 eq "developers list at");
           }
         }
       }


### PR DESCRIPTION
UTRannotator have Ensembl copyright but also external developer as author. (See - https://github.com/Ensembl/VEP_plugins/pull/657)

Current plugin doc creation script does not allow that. This PR removes that restriction.