### PR TITLE
Generalise `tandem_duplication` as `tandem_repeat`

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/BaseVariationFeatureOverlapAllele.pm
@@ -422,15 +422,15 @@ sub _bvf_preds {
       my $support_vars  = $bvf->structural_variation->get_all_SupportingStructuralVariants;
       my @support_terms = map { $_->class_SO_term } @{$support_vars};
 
-      $is_CNV_deletion  = grep(/deletion|loss/i,              @support_terms);
-      $is_CNV_insertion = grep(/insertion|duplication|gain/i, @support_terms);
+      $is_CNV_deletion  = grep(/deletion|loss/i,                     @support_terms);
+      $is_CNV_insertion = grep(/insertion|duplication|gain|tandem/i, @support_terms);
     }
 
     if($class_SO_term =~ /deletion|loss/i || $is_CNV_deletion) {
       $self->_update_preds($bvf_preds, 'deletion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'decrease_length', 1, \$pred_digest);
     }
-    elsif($class_SO_term =~ /insertion|duplication|gain/i || $is_CNV_insertion) {
+    elsif($class_SO_term =~ /insertion|duplication|gain|tandem/i || $is_CNV_insertion) {
       $self->_update_preds($bvf_preds, 'insertion', 1, \$pred_digest);
       $self->_update_preds($bvf_preds, 'increase_length', 1, \$pred_digest);
     }

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -243,7 +243,7 @@ sub copy_number_gain {
 
     return (
         duplication(@_) or
-        tandem_duplication(@_) or
+        tandem_repeat(@_) or
         $bvf->class_SO_term(undef, 1) =~ /gain/i or
         grep(/gain/i, _supporting_cnv_terms($bvf))
     );
@@ -269,11 +269,11 @@ sub duplication {
             ($bvf->class_SO_term(undef, 1) =~ /duplication/i) or
             grep(/duplication/i, _supporting_cnv_terms($bvf))
         ) and
-        (not tandem_duplication(@_))
+        (not tandem_repeat(@_))
     );
 }
 
-sub tandem_duplication {
+sub tandem_repeat {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvf ||= $bvfoa->base_variation_feature;
     
@@ -295,8 +295,9 @@ sub tandem_duplication {
     if($bvf->isa('Bio::EnsEMBL::Variation::StructuralVariationFeature')) {
         return (
             ($bvf->class_SO_term(undef, 1) eq 'tandem_duplication') or
-            ($bvf->class_SO_term(undef, 1) =~ /tandem_duplication/i) or
-            grep(/tandem_duplication/i, _supporting_cnv_terms($bvf))
+            ($bvf->class_SO_term(undef, 1) eq 'tandem_repeat') or
+            ($bvf->class_SO_term(undef, 1) =~ /tandem/i) or
+            grep(/tandem/i, _supporting_cnv_terms($bvf))
         );
     }
 }


### PR DESCRIPTION
ENSVAR-5875: parse <CNV:TR> alleles (tandem repeats) from VCF

Required for https://github.com/Ensembl/ensembl-vep/pull/1561