### PR TITLE
Update release dump data dir from noah

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/ReleaseDumps_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ReleaseDataDumps/ReleaseDumps_conf.pm
@@ -92,7 +92,7 @@ sub default_options {
         vf_per_slice => 2_000_000, # if number of vf exceeds this we split the slice and dump for each split slice
         max_split_slice_length => 5e6, # 1e7
 
-        data_dir => '/nfs/production/panda/ensembl/variation/data/',
+        data_dir => '/nfs/production/flicek/ensembl/variation/data/',
 
         ancestral_alleles_file_dir => {'homo_sapiens' => {
                                           'GRCh37' => $self->o('data_dir') . 'ancestral_alleles/GRCh37',


### PR DESCRIPTION
We have an update to use FASTA and ancestral allele in the release dump pipeline from this commit -
https://github.com/Ensembl/ensembl-variation/pull/491

- The FASTA is used to query sequence instead of using DB
- The ancestral allele file is used to correct AA for indels after changing them in VCF format.
They are not mandatory parameter as only supposed to be used with human. But AA seems to be necessary as we do need correcting of AA for indels.

The location of these files can be passed to the pipeline using `data_dir` parameter. Current default value is of a noah dir - this PR updates it to the equivalent codon dir.

To be able to use this we should update the data_dir with updated files. Check updated docs here -
https://www.ebi.ac.uk/seqdb/confluence/display/EV/Dump+GVF+and+VCF+for+a+new+e%21+and+EG+releases#DumpGVFandVCFforanewe!andEGreleases-Beforerunningthepipeline

### Test
rice - http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dumps_oryza_sativa_110&passwd=xxxxx
human - http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=snhossain_dumps_homo_sapiens_110&passwd=xxxxx 