### PR TITLE
Bugfix - wrong HGVSp when `--shift_hgvs` is enabled

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1732,6 +1732,7 @@ sub hgvs_protein {
   $convert_to_three_letter = 1 unless defined $convert_to_three_letter;
   ##### Convert ref & alt peptides taking into account HGVS rules
   $hgvs_notation = $self->_get_hgvs_peptides($hgvs_notation, $convert_to_three_letter);
+
   unless($hgvs_notation) {
     $self->{hgvs_protein} = undef;
     return undef;
@@ -2119,9 +2120,10 @@ sub _clip_alleles {
     my $check_next_ref = substr( $check_ref, 0, 1);
     my $check_next_alt = substr( $check_alt, 0, 1);
     
-    if( defined $hgvs_notation->{'numbering'} && $hgvs_notation->{'numbering'} eq 'p' && 
+    ### stop re-created by variant - no protein change
+    if( defined $hgvs_notation->{'numbering'} &&
+        $hgvs_notation->{'numbering'} eq 'p' &&
         $check_next_ref eq  "*" && $check_next_alt eq "*"){
-      ### stop re-created by variant - no protein change
       $hgvs_notation->{type} = "=";
 
       return($hgvs_notation);
@@ -2182,11 +2184,13 @@ sub _clip_alleles {
   
   ### re-set as ins/dup not delins 
   elsif(length ($check_ref) == 0 && length ($check_alt) >= 1){
-      ### re-set as dup not delins
+      ### re-set as dup not delins (ignore for protein as it is checked later on)
       my $prev_str = substr($preseq, length($preseq) - length($check_alt));
-      if($check_alt eq $prev_str) {
-        $hgvs_notation->{type} = "dup";
-        $hgvs_notation->{start} -= length($check_alt);
+      if( defined $hgvs_notation->{'numbering'} &&
+          $hgvs_notation->{'numbering'} ne 'p' &&
+          $check_alt eq $prev_str) {
+            $hgvs_notation->{type} = "dup";
+            $hgvs_notation->{start} -= length($check_alt);
       }
     
       ### re-set as ins not delins

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -2164,7 +2164,9 @@ sub _clip_alleles {
   ### check if clipping suggests a type change 
   
   ## no protein change - use transcript level annotation 
-  if( $check_ref eq $check_alt) {
+  if( defined $hgvs_notation->{'numbering'} &&
+        $hgvs_notation->{'numbering'} eq 'p'&&
+        $check_ref eq $check_alt) {
       $hgvs_notation->{type} = "=";
   }   
   


### PR DESCRIPTION
[ENSVAR-6131](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6131)

In https://github.com/Ensembl/ensembl-variation/pull/994 we added a update that will convert a `delins` to `dup`. An example can be found in the issue reported in https://github.com/Ensembl/ensembl-vep/issues/500 with example (`chr1  20978294  .  TTTTATTTATTTA  TTTTATTTATTTATTTA`). The code change was in `_clip_allele` function which is used to check after clipping alleles the type of HGVS notation changes. We introduced checking whether type changes to `dup` before checking for `ins`.

The `_clip_allele` function is used by both HGVSc and HGVSp. For HGVSp this change caused a problem as the `dup` calculation in done after `_clip_allele` - in `_check_for_peptide_duplication` function, whereas, for HGVSc it is done before. 

So in these code changes I have added condition to not revert `delins` to `dup` for HGVSp under `_clip_allele`.

- also revert back checking `=` type for only HGVSp (updated in the above mentioned PR without any issue being reported)
- update some comments and refactoring of codes

### Test
HGVSp position -
```
#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	H_NJ-HCC1395-HCC1395
6	41754573	.	C	CCTT	.	.	.	GT:DP:DP4:BQ:SS:AD:DP2:TAR:TIR:TOR:DP50:FDP50:SUBDP50:FT	0/1:76:13,9,28,26:36:2:12:78:12,12:55,55:12,12:80.52:1.92:0:PASS
```

HGVSc/HGVSp `dup` gets corrected still -
```
chr1 20978294 . TTTTATTTATTTA TTTTATTTATTTATTTA
chr1 20978964 . GGTAGGC GGTAGGCGTAGGC
```
