### PR TITLE
Prevent annotating `start_lost` if start codon is retained in case of indels

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -862,6 +862,7 @@ sub start_lost {
             my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
         
             return 0 unless $ref_pep;
+            return 0 unless $alt_pep && $alt_pep ne 'X';
             
             # allow for introducing additional bases that retain start codon e.g. atg -> aCGAtg
             $cache->{start_lost} = (
@@ -925,7 +926,7 @@ sub _inv_start_altered {
         substr($utr_and_translateable, $cdna_start - 1, ($cdna_end - $cdna_start) + 1) = $vf_feature_seq;
         my $new_sc = substr($utr_and_translateable, $atg_start, 3);
 
-        return $cache->{inv_start_altered} = 1 if substr($utr_and_translateable, $atg_start, 3) ne 'ATG';
+        return $cache->{inv_start_altered} = 1 if $new_sc ne 'ATG';
     }
 
     return $cache->{inv_start_altered};
@@ -1044,6 +1045,12 @@ sub _ins_del_start_altered {
 
         substr($utr_and_translateable, $cdna_start - 1, ($cdna_end - $cdna_start) + 1) = $vf_feature_seq;
 
+        # check if still retain start
+        my $atg_start = length($utr->seq);
+        my $new_sc = substr($utr_and_translateable, $atg_start, 3);
+        my $new_utr = substr($utr_and_translateable, 0, length($utr->seq));
+        return $cache->{inv_start_altered} if ($new_utr eq $utr->seq && $new_sc eq 'ATG');
+        
         # sequence shorter, we know it has been altered
         return $cache->{ins_del_start_altered} = 1 if length($utr_and_translateable) < length($translateable);
 

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -603,7 +603,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'GCA',
         start   => $cds_start+2,
         end     => $cds_start+1,
-        effects => [qw(inframe_insertion)],
+        effects => [qw(inframe_insertion start_retained_variant)],
     }, {
         alleles => '-',
         start   => $cds_start+3,
@@ -632,7 +632,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => 'CAT',
         start   => $cds_start-1,
         end     => $cds_start+2,
-        effects => [qw(5_prime_UTR_variant start_lost)],
+        effects => [qw(5_prime_UTR_variant start_retained_variant)],
         pep_alleles => '',
     }, {
         alleles => 'G',


### PR DESCRIPTION
[ENSVAR-5777](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5777)

### Test
Check ticket

### Update on unit test
1. `atg -> atGCAg` - we still retain the start codon, hence we should return `start_retained` beside `inframe_insertion`
2. `CATG -> CAT` - there is another G after the deleted G (see [here](https://grch37.ensembl.org/Homo_sapiens/Location/View?db=core;g=ENSG00000183918;r=X:123480490-123480496;t=ENST00000360027)) , so we should have `start_retained` beside `5_prime_UTR_variant `