### PR TITLE
Support chromosome synonyms in breakends

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
@@ -1274,7 +1274,7 @@ sub _parse_breakends {
   for my $alt_string (split "/", $alt) {
     my ($alt_allele, $alt_chr, $alt_pos, $alt_allele2) =
       $alt_string =~ '([A-Za-z]*)\s*[\[\]]\s*(\S+)\s*:\s*([0-9]+)\s*[\[\]]\s*([(A-Za-z)]*)';
-    $alt_allele = $alt_allele2 unless defined $alt_allele;
+    $alt_allele ||= $alt_allele2;
 
     unless (defined $alt_allele and defined $alt_chr and defined $alt_pos) {
       # Check if single breakend symbol, such as 'N.'

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationFeature.pm
@@ -1268,10 +1268,13 @@ sub _parse_breakends {
   my $ref;
 
   my $breakends = [];
-  # Support multiple breakends from ALT in the format C[2:321682[,]17:198982]G
+  # Support multiple breakends in the format T/C[2:321682[/]17:198982]G
+  # NB: the equivalent ALT format in VCF would be C[2:321682[,]17:198982]G
+  #     VEP converts the commas in ALT to slash and prepends the ref allele
   for my $alt_string (split "/", $alt) {
-    my ($alt_allele) = ($alt_string =~ '[\[\]]?([A-Za-z]+)[\[\]]?');
-    my ($alt_chr, $alt_pos) = ($alt_string =~ '([A-Za-z0-9]+) ?: ?([0-9]+)');
+    my ($alt_allele, $alt_chr, $alt_pos, $alt_allele2) =
+      $alt_string =~ '([A-Za-z]*)\s*[\[\]]\s*(\S+)\s*:\s*([0-9]+)\s*[\[\]]\s*([(A-Za-z)]*)';
+    $alt_allele = $alt_allele2 unless defined $alt_allele;
 
     unless (defined $alt_allele and defined $alt_chr and defined $alt_pos) {
       # Check if single breakend symbol, such as 'N.'

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
@@ -126,10 +126,10 @@ sub new_fast {
 }
 
 sub _close_to_feature {
-    my $self = shift;
+    my $vf = shift;
     my $feature = shift;
 
-    my $chr = $self->{seq_region_name} || $self->{chr};
+    my $chr = $vf->{seq_region_name} || $vf->{chr};
     return 0 unless (
       defined $chr and
       defined $feature and defined $feature->seq_region_name and
@@ -137,13 +137,9 @@ sub _close_to_feature {
     );
 
     # check if breakend is within/around feature
-    my $slice = $feature->{slice}->expand(
-        MAX_DISTANCE_FROM_TRANSCRIPT,
-        MAX_DISTANCE_FROM_TRANSCRIPT
-    );
-    return 0 unless
-        overlap($self->{start}, $self->{end}, $slice->start, $slice->end);
-
+    my $slice = $feature->feature_Slice;
+    $slice = $slice->expand(MAX_DISTANCE_FROM_TRANSCRIPT, MAX_DISTANCE_FROM_TRANSCRIPT);
+    return 0 unless overlap($vf->{start}, $vf->{end}, $slice->start, $slice->end);
     return 1;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -55,12 +55,13 @@ use warnings;
 
 use base qw(Exporter);
 
-our @EXPORT_OK = qw(overlap _intron_overlap _compare_seq_region_names within_feature within_cds MAX_DISTANCE_FROM_TRANSCRIPT within_intron stop_lost stop_retained start_lost frameshift $UPSTREAM_DISTANCE $DOWNSTREAM_DISTANCE);
+our @EXPORT_OK = qw(overlap _intron_overlap _compare_seq_region_names within_feature within_cds MAX_DISTANCE_FROM_TRANSCRIPT within_intron stop_lost stop_retained start_lost frameshift $UPSTREAM_DISTANCE $DOWNSTREAM_DISTANCE $CHROMOSOME_SYNONYMS);
 
 use constant MAX_DISTANCE_FROM_TRANSCRIPT => 5000;
 
 our $UPSTREAM_DISTANCE = MAX_DISTANCE_FROM_TRANSCRIPT;
 our $DOWNSTREAM_DISTANCE = MAX_DISTANCE_FROM_TRANSCRIPT;
+our $CHROMOSOME_SYNONYMS = {};
 
 #
 # Interface with some of the module function XS reimplementation
@@ -108,12 +109,17 @@ sub _intron_overlap {
 }
 
 sub _compare_seq_region_names {
-  my $region1 = shift;
-  my $region2 = shift;
-
-  $region1 =~ s/^chr//;
-  $region2 =~ s/^chr//;
-
+  my ($region1, $region2) = @_;
+  if ($CHROMOSOME_SYNONYMS) {
+    return 1 if
+      (
+        exists $CHROMOSOME_SYNONYMS->{$region1} &&
+        grep /^$region2$/, keys %{$CHROMOSOME_SYNONYMS->{$region1}}
+      ) || (
+        exists $CHROMOSOME_SYNONYMS->{$region2} &&
+        grep /^$region1$/, keys %{$CHROMOSOME_SYNONYMS->{$region2}}
+      );
+  }
   return lc $region1 eq lc $region2;
 }
 

--- a/modules/t/structuralVariationOverlap.t
+++ b/modules/t/structuralVariationOverlap.t
@@ -54,6 +54,7 @@ my $svf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new
    -end         => $outer_end,
    -outer_end   => $outer_end,
    -strand      => 1,
+   -slice       => $slice_adaptor->fetch_by_region('chromosome', $chr),
    -variation_name => $var_name,
    -is_somatic => $is_somatic,
    -length => $sv_length,
@@ -62,17 +63,13 @@ my $svf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new
 
 sub _create_feature {
   my $obj = shift;
-
+  my $chr = $obj->{chr} || $obj->seq_region_name;
   return Bio::EnsEMBL::Feature->new(
-    -seqname => $obj->{chr},
+    -seqname => $chr,
     -start   => $obj->{start} - 100,
     -end     => $obj->{end} + 100,
     -strand  => 0,
-    -slice   => Bio::EnsEMBL::Slice->new_fast({
-      seq_region_name => $obj->{chr},
-      start           => $obj->{start} - 100,
-      end             => $obj->{end} + 100,
-    })
+    -slice   => $slice_adaptor->fetch_by_region('chromosome', $chr),
   );
 }
 
@@ -97,11 +94,7 @@ $svf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new(
   -end             => 7803891,
   -outer_end       => 7803891,
   -seq_region_name => '8',
-  -slice           => Bio::EnsEMBL::Slice->new_fast({
-    seq_region_name => 8,
-    start           => 7803891,
-    end             => 7803891,
-  }),
+  -slice           => $slice_adaptor->fetch_by_region('chromosome', 8),
   -strand          => 1,
   -allele_string   => "A[4:66578[/T[7:3433[",
   -class_SO_term   => 'chromosome_breakpoint',
@@ -165,11 +158,7 @@ $svf = Bio::EnsEMBL::Variation::StructuralVariationFeature->new(
   -end             => 7803891,
   -outer_end       => 7803891,
   -seq_region_name => '8',
-  -slice           => Bio::EnsEMBL::Slice->new_fast({
-    seq_region_name => 8,
-    start           => 7803891,
-    end             => 7803891,
-  }),
+  -slice           => $slice_adaptor->fetch_by_region('chromosome', 8),
   -strand          => 1,
   -allele_string   => "TCG.",
   -class_SO_term   => 'chromosome_breakpoint',


### PR DESCRIPTION
[ENSVAR-5967](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5967)

- Support chromosome synonyms in breakends
    - Requires VEP setting up the new `$CHROMOSOME_SYNONYMS` global variable in Ensembl/ensembl-vep#1589
- Fix breakends getting more features than they should by using the correct feature slice
- Fix slices in unit tests