### PR TITLE
Add all supported SV types to region format

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -385,7 +385,7 @@ sub parse_line {
 }
 
 sub _valid_region_regex {
-  return qr/^([^:]+):(\d+)-(\d+)(:[-\+]?1)?[\/:]([a-z]{3,}|[ACGTN-]+)$/i;
+  return qr/^([^:]+):(\d+)-(\d+)(:[-\+]?1)?[\/:]([a-z0-9:]{3,}|[ACGTN-]+)$/i;
 }
 
 # sub-routine to check format of string


### PR DESCRIPTION
This PR allows the `region` format (used in REST) to support all SV types, such as:

```
INS:ME
INS:ME:ALU
DEL:ME:LINE1
```

Test this PR as part of https://github.com/Ensembl/ensembl-vep/pull/1618