### PR TITLE
Fix HGVSg for multiple alternative alleles

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1928,6 +1928,8 @@ sub hgvs_genomic {
 
   my @all_alleles = split(/\//,$tr_vf->allele_string());
   my $ref_allele = shift @all_alleles;  ## remove reference allele - not useful for HGVS
+  my $original_ref_allele = $ref_allele;
+  my $original_ref_start  = $ref_start;
 
   my $is_multi_allelic = scalar @all_alleles > 1;
   foreach my $original_allele ( @all_alleles ) {
@@ -1964,9 +1966,12 @@ sub hgvs_genomic {
 
     if ($is_multi_allelic) {
       # fix for multi-allelic variants
-      ($ref_allele, $allele, $chr_start, $chr_end, my $change) = @{trim_sequences($ref_allele, $allele, $chr_start)};
-      $ref_start += $change;
-      $allele ||= '-';      
+      my $old_chr_start = $chr_start;
+      ($ref_allele, $allele, $chr_start, $chr_end) = @{trim_sequences($original_ref_allele, $allele, $chr_start)};
+      $allele ||= '-';
+      $offset = $chr_start - $old_chr_start;
+      $ref_start = $original_ref_start + $offset;
+      $ref_allele ||= '-';
     }
     my $var_class  =  $self->var_allele_class($ref_allele . '/' . $allele);
     $var_class  =~ s/somatic_//;


### PR DESCRIPTION
Fixes Ensembl/ensembl-vep#1653

When using multiple alternative alleles with the `--hgvsg` option in VEP, the HGVSg is incorrect and different compared to running VEP on each alternative allele separately.

The bug occurs because we check the variation class SO term based on the complete allele string. In the case of an allele string with multiple alternative alleles (e.g., `GG/-/G`), we need to check the class SO term for each alternative allele separately.

## Testing

Run VEP on GRCh37 with `--hgvsg`. Example variants:

```
chr8 143694490 143694490 T/TT/TTT +
chr8 143694490 143694492 GGG/GG/G +
chr14 103576804 103576805 GG/-/G +
chr14 103576804 103576805 GG/- +
chr14 103576804 103576805 GG/G +
```

The HGVSg for each alternative allele should be:
- `GG/-`: `chr14:g.103576811_103576812del` 
- `GG/G`: `chr14:g.103576812del`