### PR TITLE
updating for gencode primary

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVariationGeneName.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/DumpVariationGeneName.pm
@@ -44,8 +44,6 @@ use Digest::MD5 qw(md5_hex);
 
 use base qw(Bio::EnsEMBL::Variation::Pipeline::BaseVariationProcess);
 
-my $DEBUG   = 0;
-
 sub run {
   my $self = shift;
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptEffect.pm
@@ -106,6 +106,7 @@ sub run {
     my $ta = $core_dba->get_TranscriptAdaptor;
     my $transcript = $ta->fetch_by_stable_id($transcript_stable_id) 
       or die "failed to fetch transcript for stable id: $transcript_stable_id";
+
     $slice = $sa->fetch_by_transcript_stable_id(
       $transcript_stable_id, 
       $max_distance
@@ -114,7 +115,9 @@ sub run {
     $slice->seq();
     $transcript = $transcript->transfer($slice);
     push @transcripts, $transcript;
-  } else {
+  } 
+  
+  else {
     my $gene_stable_id =  $self->param('gene_stable_id');
     $stable_id = $gene_stable_id;
     my $ga = $core_dba->get_GeneAdaptor;
@@ -153,12 +156,16 @@ sub run {
   );
 
   for my $transcript (@transcripts) {
-    
+
     my $biotype = $transcript->biotype;
     my $is_mane = $transcript->is_mane(); # grch38
     my $is_canonical = $transcript->is_canonical(); # grch37
     my $stable_id = $transcript->stable_id;
     my @vf_ids;
+
+    #Skip transcript if running in gc primary mode and transcript isn't part of that set.
+    next if ($self->param('gencode_primary') and !$transcript->gencode_primary);
+
 
     for my $vf(@vfs) {
 

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptFactory.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/TranscriptFactory.pm
@@ -68,6 +68,7 @@ sub run {
   my @transcript_ids_fan = (); # e-hive speak: fan transcript_ids (run for each transcript_id in parallel) 
 
   for my $transcript (@{ $gene->get_all_Transcripts }) { 
+    next if ($self->param('gencode_primary') and !$transcript->gencode_primary);
     push @transcript_ids_fan, {
       transcript_stable_id => $transcript->stable_id,
       max_distance => $max_distance,

--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -154,6 +154,8 @@ sub default_options {
 
         # these flags control update running parts of pipeline
         update_diff             => undef,
+        gencode_primary         => 0,
+        debug_genes             => 0,
 
         # Human runs switch off run_var_class and set max_distance to 0 by default. To override
         # this behaviour, set this flag to 1
@@ -272,6 +274,7 @@ sub pipeline_analyses {
               include_lrg => $self->o('include_lrg'),
               limit_biotypes => $self->o('limit_biotypes'),
               update_diff => $self->o('update_diff'),
+              debug_genes => $self->o('debug_genes'),
               @common_params,
             },
             -rc_name   => 'default',
@@ -311,6 +314,7 @@ sub pipeline_analyses {
             -hive_capacity  => 50,
             -analysis_capacity  => 50,
             -parameters => {
+              gencode_primary => $self->o('gencode_primary'),
               @common_params,
             },
             -rc_name   => 'medmem',
@@ -330,6 +334,7 @@ sub pipeline_analyses {
               disambiguate_single_nucleotide_alleles => $self->o('disambiguate_single_nucleotide_alleles'),
               prevent_shifting => $self->o('prevent_shifting'),
               update_diff => $self->o('update_diff'),
+              gencode_primary => $self->o('gencode_primary'),
               @common_params,
             },
             -rc_name   => ($self->o('species') !~ /homo_sapiens|human/) ? 'default' : 'default_long',
@@ -346,6 +351,7 @@ sub pipeline_analyses {
               prevent_shifting => $self->o('prevent_shifting'),
               update_diff => $self->o('update_diff'),
               assembly => $self->o('assembly'),
+              gencode_primary => $self->o('gencode_primary'),
               @common_params,
             },
             -rc_name   => 'medmem',


### PR DESCRIPTION
Updating variation consequence pipeline to have an option to run on only gencode primary transcripts.

Also improved the debug method to make it more useful and switched on from config.

Full details on ticket: ENSVAR-6238