### PR TITLE
Patching test databases

### DIFF
--- a/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/meta.txt
@@ -1,5 +1,5 @@
 885	1	xref.timestamp	2010-12-02 16:01:38
-1	\N	schema_version	112
+1	\N	schema_version	113
 2	\N	patch	patch_52_53_a.sql|schema_version
 3	\N	patch	patch_52_53_b.sql|external_db_type_enum
 4	\N	patch	patch_52_53_c.sql|identity_xref_rename
@@ -255,3 +255,6 @@
 1055	\N	patch	patch_110_111_a.sql|schema_version
 1056	\N	patch	patch_111_112_a.sql|schema_version
 1057	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+1058	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64
+1059	\N	patch	patch_112_113_a.sql|schema_version
+1060	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null

--- a/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/core/table.sql
@@ -266,7 +266,7 @@ CREATE TABLE `exon` (
   PRIMARY KEY (`exon_id`),
   KEY `seq_region_idx` (`seq_region_id`,`seq_region_start`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM AUTO_INCREMENT=2725348 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=2725371 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `exon_transcript` (
   `exon_id` int(10) unsigned NOT NULL DEFAULT '0',
@@ -322,7 +322,7 @@ CREATE TABLE `gene` (
   KEY `analysis_idx` (`analysis_id`),
   KEY `stable_id_idx` (`stable_id`,`version`),
   KEY `canonical_transcript_id_idx` (`canonical_transcript_id`)
-) ENGINE=MyISAM AUTO_INCREMENT=267302 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=267304 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `gene_archive` (
   `gene_stable_id` varchar(128) NOT NULL DEFAULT '',
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) DEFAULT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=1058 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=1061 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL DEFAULT '',
@@ -851,7 +851,7 @@ CREATE TABLE `transcript` (
   KEY `xref_id_index` (`display_xref_id`),
   KEY `analysis_idx` (`analysis_id`),
   KEY `stable_id_idx` (`stable_id`,`version`)
-) ENGINE=MyISAM AUTO_INCREMENT=740730 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=740732 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `transcript_attrib` (
   `transcript_id` int(10) unsigned NOT NULL DEFAULT '0',

--- a/modules/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/funcgen/meta.txt
@@ -1,4 +1,4 @@
-534	\N	schema_version	112
+534	\N	schema_version	113
 80	\N	patch	patch_50_51_b.sql|multispecies
 83	\N	patch	patch_50_51_c.sql|associated_feature_type
 82	\N	patch	patch_50_51_a.sql|cell_type_description
@@ -337,3 +337,5 @@
 777	\N	patch	patch_111_112_a.sql|schema_version
 778	\N	patch	patch_111_112_b.sql|fix data_file_id length
 779	\N	patch	patch_111_112_c.sql|set data_file_id to not null auto increment
+780	\N	patch	patch_112_113_a.sql|schema_version
+781	\N	patch	patch_112_113_b.sql|fix_compatibility_issues

--- a/modules/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/funcgen/table.sql
@@ -256,7 +256,7 @@ CREATE TABLE `coord_system_bu` (
 ) ENGINE=MyISAM AUTO_INCREMENT=2473 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `data_file` (
-  `data_file_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `data_file_id` int(10) NOT NULL AUTO_INCREMENT,
   `table_id` int(10) unsigned NOT NULL,
   `table_name` varchar(32) NOT NULL,
   `path` varchar(255) NOT NULL,
@@ -461,12 +461,12 @@ CREATE TABLE `idr` (
 CREATE TABLE `meta` (
   `meta_id` int(10) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(46) NOT NULL,
+  `meta_key` varchar(64) NOT NULL,
   `meta_value` varchar(950) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`(50)),
   KEY `species_value_idx` (`species_id`,`meta_value`(50))
-) ENGINE=MyISAM AUTO_INCREMENT=780 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=782 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/homo_sapiens/otherfeatures/meta.txt
+++ b/modules/t/test-genome-DBs/homo_sapiens/otherfeatures/meta.txt
@@ -1,5 +1,5 @@
 1	\N	schema_type	core
-2	\N	schema_version	112
+2	\N	schema_version	113
 3	\N	patch	patch_73_74_a.sql|schema_version
 4	\N	patch	patch_73_74_b.sql|remove_dnac
 5	\N	patch	patch_73_74_c.sql|remove_unconventional_transcript_association
@@ -180,3 +180,6 @@
 890	\N	patch	patch_110_111_a.sql|schema_version
 891	\N	patch	patch_111_112_a.sql|schema_version
 892	\N	patch	patch_111_112_b.sql|Allow meta_value to be null
+893	\N	patch	patch_111_112_c.sql|Extend meta_key length to 64
+894	\N	patch	patch_112_113_a.sql|schema_version
+895	\N	patch	patch_112_113_b.sql|Ensure meta_value is not null

--- a/modules/t/test-genome-DBs/homo_sapiens/otherfeatures/table.sql
+++ b/modules/t/test-genome-DBs/homo_sapiens/otherfeatures/table.sql
@@ -485,12 +485,12 @@ CREATE TABLE `marker_synonym` (
 CREATE TABLE `meta` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `species_id` int(10) unsigned DEFAULT '1',
-  `meta_key` varchar(40) NOT NULL,
-  `meta_value` varchar(255) DEFAULT NULL,
+  `meta_key` varchar(64) NOT NULL,
+  `meta_value` varchar(255) NOT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `species_key_value_idx` (`species_id`,`meta_key`,`meta_value`),
   KEY `species_value_idx` (`species_id`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=893 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=896 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `meta_coord` (
   `table_name` varchar(40) NOT NULL,

--- a/modules/t/test-genome-DBs/multi/ontology/meta.txt
+++ b/modules/t/test-genome-DBs/multi/ontology/meta.txt
@@ -9,7 +9,7 @@
 10	patch	patch_72_73_b.sql|meta	\N
 12	patch	patch_73_74_a.sql|schema_version	\N
 14	patch	patch_74_75_a.sql|schema_version	\N
-15	schema_version	112	\N
+15	schema_version	113	\N
 16	patch	patch_75_76_a.sql|schema_version	\N
 17	patch	patch_76_77_a.sql|schema_version	\N
 18	patch	patch_77_78_a.sql|schema_version	\N
@@ -54,3 +54,7 @@
 57	patch	patch_109_110_a.sql|schema_version	\N
 58	patch	patch_110_111_a.sql|schema_version	\N
 59	patch	patch_111_112_a.sql|schema_version	\N
+60	patch	patch_111_112_b.sql|Allow meta_value to be null	\N
+61	patch	patch_111_112_c.sql|Extend meta_key length to 64	\N
+62	patch	patch_112_113_a.sql|schema_version	\N
+63	patch	patch_112_113_b.sql|Ensure meta_value is not null	\N

--- a/modules/t/test-genome-DBs/multi/ontology/table.sql
+++ b/modules/t/test-genome-DBs/multi/ontology/table.sql
@@ -135,11 +135,11 @@ CREATE TABLE `closure` (
 CREATE TABLE `meta` (
   `meta_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `meta_key` varchar(64) NOT NULL,
-  `meta_value` varchar(128) DEFAULT NULL,
+  `meta_value` varchar(255) NOT NULL,
   `species_id` int(1) unsigned DEFAULT NULL,
   PRIMARY KEY (`meta_id`),
   UNIQUE KEY `key_value_idx` (`meta_key`,`meta_value`)
-) ENGINE=MyISAM AUTO_INCREMENT=60 DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM AUTO_INCREMENT=64 DEFAULT CHARSET=latin1;
 
 CREATE TABLE `ontology` (
   `ontology_id` int(10) unsigned NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
This PR patches test databases for 113:
`homo_sapiens/core`
`homo_sapiens/funcgen`
`homo_sapiens/otherfeatures `
`multi/ontology`

The patch for `homo_sapiens/variation` is already done