### PR TITLE
Update pipeline to support new MaveDB mapping format

### DIFF
--- a/nextflow/MaveDB/bin/liftover.py
+++ b/nextflow/MaveDB/bin/liftover.py
@@ -18,8 +18,6 @@ mapped    = args.mapped_variants
 mappings  = args.mappings
 
 res = json.load(open(mappings))
-if len(res['target']['reference_maps']) > 1:
-  raise Exception("Multiple reference maps are not currently supported")
 
 def liftover_variants (mapped, genome, reference):
   # write file information with lifted-over coordinates to new file
@@ -49,7 +47,11 @@ def liftover_variants (mapped, genome, reference):
       out.write('\t'.join(l))
   out.close()
 
-genome = res['target']['reference_maps'][0]['genome']['short_name']
+if 'reference' in res['metadata']['extraMetadata']:
+  genome = res['metadata']['extraMetadata']['reference']
+else:
+  genome = 'hg38'
+
 if genome == reference:
   # just rename file if variants are already mapped to reference genome
   os.rename(mapped, f"liftover_{mapped}")

--- a/nextflow/MaveDB/bin/map_scores_to_variants.py
+++ b/nextflow/MaveDB/bin/map_scores_to_variants.py
@@ -77,8 +77,6 @@ def load_scores (f):
   with open(scores_file) as csvfile:
     reader = csv.DictReader(csvfile)
     for row in reader:
-      # get index to sort data (required to match scores with MaveDB mappings)
-      row['index'] = int(row['accession'].split("#")[1])
       scores.append(row)
   return scores
 
@@ -187,7 +185,7 @@ def map_scores_to_variants (scores, mappings, map_ids, matches=None):
     if row['accession'] in map_ids:
       mapping = mappings['mapped_scores'][ map_ids.index(row['accession']) ]
     else:
-      warnings.warn(row['accession'] + "not in mappings file")
+      warnings.warn(row['accession'] + " not in mappings file")
       continue
 
     if row['accession'] == mapping['mavedb_id']:
@@ -244,6 +242,6 @@ map = map_scores_to_variants(scores, mappings, mavedb_ids, hgvsp2vars)
 write_variant_mapping(args.output, map)
 
 # clean up
-#os.remove(scores_file)
+os.remove(scores_file)
 
 print("Done: MaveDB score mapped to variants!", flush=True)

--- a/nextflow/MaveDB/main.nf
+++ b/nextflow/MaveDB/main.nf
@@ -11,6 +11,7 @@ params.help     = false
 params.mappings = null
 params.ensembl  = "${ENSEMBL_ROOT_DIR}"
 params.output   = "output/MaveDB_variants.tsv.gz"
+params.registry = null
 
 params.licences = "CC0" // Open-access only
 params.round    = 4
@@ -33,6 +34,7 @@ if (params.help) {
     --output    Path to output file (default: 'output/MaveDB_variants.tsv.gz')
     --licences  Comma-separated list of accepted licences (default: 'CC0')
     --round     Decimal places to round floats in MaveDB data (default: 4)
+    --registry  Path to Ensembl registry
 
   Note: the mappings must be named with the MaveDB accession, such as
         '00000001-a-1.json'.

--- a/nextflow/MaveDB/nextflow.config
+++ b/nextflow/MaveDB/nextflow.config
@@ -29,8 +29,6 @@ singularity {
 }
 
 process {
-  queue  = 'production'
-  withLabel: bigmem { queue = 'bigmem' }
 
   memory = { ["1 GB", "4 GB", "8 GB", "40 GB"][task.attempt - 1] }
   time   = '2d'

--- a/nextflow/MaveDB/nextflow.config
+++ b/nextflow/MaveDB/nextflow.config
@@ -9,7 +9,13 @@ profiles {
     }
   }
 
-  slurm { process.executor = 'slurm' }
+  slurm {
+    executor {
+      name            = 'slurm'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
+    }
+  }
 }
 
 notification {
@@ -24,7 +30,10 @@ singularity {
 
 process {
   queue  = 'production'
+  withLabel: bigmem { queue = 'bigmem' }
+
   memory = { ["1 GB", "4 GB", "8 GB", "40 GB"][task.attempt - 1] }
+  time   = '2d'
 
   // Exit status codes:
   // - 130: job exceeded LSF allocated memory

--- a/nextflow/MaveDB/nf_modules/liftover.nf
+++ b/nextflow/MaveDB/nf_modules/liftover.nf
@@ -18,6 +18,7 @@ process download_chain_files {
 process liftover_to_hg38 {
   // Identify genome of reference used to map variants and lift-over to hg38
   container 'quay.io/biocontainers/pyliftover:0.4--py_0'
+  tag "${mappings.simpleName}"
 
   input: 
     tuple path(mappings), path(mapped_variants)

--- a/nextflow/MaveDB/nf_modules/mapping.nf
+++ b/nextflow/MaveDB/nf_modules/mapping.nf
@@ -5,6 +5,8 @@ process map_scores_to_HGVSp_variants {
   input:  tuple path(mappings), path(vr)
   output: tuple path(mappings), path('map_*.tsv')
 
+  memory { mappings.size() * 4.B + 1.GB }
+
   script:
   def urn   = mappings.simpleName
   def round = params.round ? "--round ${params.round}" : ""
@@ -23,6 +25,8 @@ process map_scores_to_HGVSg_variants {
   tag "${mappings.simpleName}"
   input:  path(mappings)
   output: tuple path(mappings), path('map_*.tsv')
+
+  memory { mappings.size() * 2.B + 1.GB }
 
   script:
   def urn   = mappings.simpleName

--- a/nextflow/MaveDB/nf_modules/output.nf
+++ b/nextflow/MaveDB/nf_modules/output.nf
@@ -63,7 +63,7 @@ process tabix {
   grep -v "^#" ${out} | grep -v "^LRG" | grep -v "^CHR_" > tmp.tsv
 
   # sort file by position
-  (head -n1 ${out}; sort -k1,1 -k2,2n -k3,3n tmp.tsv) > ${name}
+  (head -n1 ${out}; sort -k1,1 -k2,2n -k3,3n tmp.tsv | uniq) > ${name}
 
   bgzip ${name}
   tabix -s1 -b2 -e3 ${gzip}

--- a/nextflow/MaveDB/nf_modules/output.nf
+++ b/nextflow/MaveDB/nf_modules/output.nf
@@ -4,6 +4,8 @@ process concatenate_files {
   input:  path(mapped_variants)
   output: path("combined.tsv")
 
+  memory '4GB'
+
   """
   #!/usr/bin/env python3
   import glob, pandas

--- a/nextflow/MaveDB/nf_modules/variant_recoder.nf
+++ b/nextflow/MaveDB/nf_modules/variant_recoder.nf
@@ -13,7 +13,8 @@ process run_variant_recoder {
 
   script:
   def bin = "${params.ensembl}/ensembl-vep"
+  def reg = params.registry ? "--registry ${params.registry}" : ""
   """
-  perl ${bin}/variant_recoder -i $hgvs --vcf_string > vr.json
+  perl ${bin}/variant_recoder -i $hgvs --vcf_string $reg > vr.json
   """
 }

--- a/nextflow/MaveDB/nf_modules/variant_recoder.nf
+++ b/nextflow/MaveDB/nf_modules/variant_recoder.nf
@@ -1,14 +1,15 @@
 process run_variant_recoder {
   // Run Variant Recoder on a file with HGVS identifiers
-
-  tag "${mappings.simpleName}"
-  memory { hgvs.size() * 0.4.MB + 1.GB }
-
-  errorStrategy 'ignore'
-  maxRetries 1
+  label 'bigmem'
 
   input:  tuple path(mappings), path(hgvs)
   output: tuple path(mappings), path('vr.json')
+
+  tag "${mappings.simpleName}"
+  memory { file(hgvs.target).countLines() * 100.MB + 4.GB }
+
+  errorStrategy 'ignore'
+  maxRetries 1
 
   script:
   def bin = "${params.ensembl}/ensembl-vep"


### PR DESCRIPTION
Other changes:
- Optimise configuration for SLURM (including improved memory config)
- Allow to input a registry file to lookup custom databases
- Remove duplicate lines

# Testing

```
./main.nf -profile slurm -resume --mappings [folder_with_MaveDB_mappings] --registry [registry]
```

You can grab some MaveDB mappings from the URL mentioned in the JIRA ticket description: [ENSVAR-5485](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-5485)