### PR TITLE
EVAImport: support relative filepaths

### DIFF
--- a/scripts/import/import_variant_synonyms
+++ b/scripts/import/import_variant_synonyms
@@ -39,6 +39,7 @@ use HTTP::Tiny;
 use Getopt::Long;
 use DBI qw(:sql_types);
 use Time::Piece;
+use File::Spec;
 
 use Bio::EnsEMBL::Registry;
 use Bio::EnsEMBL::Variation::Source;
@@ -73,6 +74,7 @@ $species ||= 'homo_sapiens';
 die("ERROR: source 'rat' can only be used for species rat\n") if($source_name eq 'rat' && $species !~ /rat/);
 
 my $reg = 'Bio::EnsEMBL::Registry';
+$registry_file = File::Spec->rel2abs($registry_file);
 $reg->load_all($registry_file);
 my $dba = $reg->get_DBAdaptor($species, 'variation');
 


### PR DESCRIPTION
Currently, the pipeline only works with absolute file paths. This PR allows to use relative file paths instead.

Requires https://github.com/Ensembl/ensembl-internal-variation/pull/143

Example script:

```bash
#!/bin/sh

release=113
species=ovis_aries_rambouillet
reg=$(realpath ensembl.registry)
host=$(v1-w details script)
current_ids=9940_GCA_016772045.1_current_ids.vcf.gz
merged_ids=9940_GCA_016772045.1_merged_ids.vcf.gz
dbname=ovis_aries_rambouillet_variation_113_2
old_dbname=ovis_aries_rambouillet_variation_112_2
chr_synonyms=chr_synonyms.txt
citations=rambouillet_citations_113.txt

sbatch -J EVAImport -o eva_import.out -e eva_import.err --mem 4GB --time 3-0 \
nextflow run -resume -profile slurm \
${ENSEMBL_ROOT_DIR}/ensembl-variation/nextflow/EVAImport \
  --species $species \
  --registry $reg \
  --release $release \
  --input_file ${current_ids} \
  --var_syn_file ${merged_ids} \
  --skipped_variants_file skipped_variants.txt \
  $host \
  --dbname $dbname \
  --old_dbname ${old_dbname} \
  --chr_synonyms $chr_synonyms \
  --citations_file $citations
```