### PR TITLE
Fix allele numbers for breakends

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
@@ -74,14 +74,16 @@ sub new {
         my $feature = $self->feature;
         my $num = 0;
         for ($vf, @$breakends) {
-            next unless _close_to_feature($_, $feature);
-            $self->add_StructuralVariationOverlapAllele(
-                Bio::EnsEMBL::Variation::StructuralVariationOverlapAllele->new(
-                    -structural_variation_overlap => $self,
-                    -symbolic_allele              => $_->{string},
-                    -breakend                     => $_,
-                )
-            );
+            if ($_->_close_to_feature($feature)) {
+                $self->add_StructuralVariationOverlapAllele(
+                    Bio::EnsEMBL::Variation::StructuralVariationOverlapAllele->new(
+                        -structural_variation_overlap => $self,
+                        -symbolic_allele              => $_->{string},
+                        -breakend                     => $_,
+                        -allele_number                => $num,
+                    )
+                );
+            }
             $num++;
         }
     }

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlap.pm
@@ -74,7 +74,7 @@ sub new {
         my $feature = $self->feature;
         my $num = 0;
         for ($vf, @$breakends) {
-            if ($_->_close_to_feature($feature)) {
+            if (_close_to_feature($_, $feature)) {
                 $self->add_StructuralVariationOverlapAllele(
                     Bio::EnsEMBL::Variation::StructuralVariationOverlapAllele->new(
                         -structural_variation_overlap => $self,

--- a/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlapAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/StructuralVariationOverlapAllele.pm
@@ -49,13 +49,18 @@ use base qw(Bio::EnsEMBL::Variation::BaseVariationFeatureOverlapAllele);
     The symbolic allele string
 
   Arg [-BREAKEND] :
-    Breakend information 
+    Breakend information
+
+  Arg [-ALLELE_NUMBER] :
+    The order in which this allele appears in the BaseVariationFeature's
+    allele string
 
   Example : 
     my $vfoa = Bio::EnsEMBL::Variation::StructuralVariationOverlapAllele->new(
         -structural_variation_overlap   => $svfo,
         -symbolic_allele                => 'N[8:56445865[',
-        -breakend                       => $breakend
+        -breakend                       => $breakend,
+        -allele_number                  => 1,
     );
 
   Description: Constructs a new StructuralVariationOverlapAllele instance given a 
@@ -96,23 +101,28 @@ sub new {
     (
       $symbolic_allele,
       $breakend,
+      $allele_number,
     ) = (
       $args{-symbolic_allele},
       $args{-breakend},
+      $args{-allele_number},
     );
   }
   else {
     (
       $symbolic_allele,
       $breakend,
+      $allele_number
     ) = rearrange([qw(
       SYMBOLIC_ALLELE
       BREAKEND
+      ALLELE_NUMBER
     )], %args);
   }
 
   $self->{symbolic_allele} = $symbolic_allele;
   $self->{breakend} = $breakend if defined $breakend;
+  $self->{allele_number} = $allele_number;
 
   return $self;
 }


### PR DESCRIPTION
Related with https://github.com/Ensembl/ensembl-vep/issues/1698

The allele number is currently undefined for breakends. This PR fixes that issue.

The reference breakend is given the allele number of 0, whereas all other breakends are given an allele number of 1 or higher.

## Testing

Run breakpoint variants with VEP using `--allele_number`:

```
vep --id "chr22 29767384 . G [1:109650635[GG,[2:9650635[TT . . ." --database --force --db_version 112 --allele_number
```