### PR TITLE
Add new cadd version to allowed versions

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/ProteinFunction/ProteinFunction_conf.pm
@@ -68,7 +68,7 @@ sub default_options {
         hive_root_dir           => $ENV{'HOME'} . '/src/ensembl-hive',
         
         pipeline_name           => 'protein_function',
-        pipeline_dir            => '/hps/nobackup/production/ensembl/'.$ENV{USER}.'/'.$self->o('pipeline_name'),
+        pipeline_dir            => '/hps/nobackup/flicek/ensembl/variation/'.$ENV{USER}.'/'.$self->o('pipeline_name'),
         species_dir             => $self->o('pipeline_dir').'/'.$self->o('species'),
         # directory used for the hive's own output files
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/CADDProteinFunctionAnnotation.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/CADDProteinFunctionAnnotation.pm
@@ -70,7 +70,7 @@ sub new {
 
   my $self = $class->SUPER::new(@_);
 
-  if (! grep {$_ eq $self->annotation_file_version} ('v1.3', 'v1.4', 'v1.5', 'v1.6')) {
+  if (! grep {$_ eq $self->annotation_file_version} ('v1.3', 'v1.4', 'v1.5', 'v1.6', 'v1.7')) {
     die "CADD version " . $self->annotation_file_version . " is not supported.";
   }
 


### PR DESCRIPTION
- [x] Updated default pipeline_dir path as current one looks outdated. Does not affect the pipeline run if pipeline_dir is mentioned in the registry file. 
- [x] Add CADD version v1.7 to allowed versions

[Link](http://guihive.ebi.ac.uk:8080/versions/96/?driver=mysql&username=ensadmin&host=mysql-ens-var-prod-4&port=4694&dbname=likhithas_ehive_protein_function_dbsnfp_113_38_homo_sapiens&passwd=xxxxx) to successful ehive pipeline