### PR TITLE
Variation Consequence pipeline: Increase default time limit for SLURM runs

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -109,11 +109,11 @@ sub default_options {
         medmem_lsf_options  => '-qproduction -R"select[mem>10000] rusage[mem=10000]" -M10000',
         highmem_lsf_options => '-qproduction -R"select[mem>20000] rusage[mem=20000] span[hosts=1]" -M20000 -n4',
 
-        default_slurm_options      => '--partition=production --time=24:00:00 --mem=8G',
+        default_slurm_options      => '--partition=production --time=48:00:00 --mem=8G',
         default_long_slurm_options => '--partition=production --time=140:00:00 --mem=8G',
-        medmem_slurm_options       => '--partition=production --time=24:00:00 --mem=10G',
+        medmem_slurm_options       => '--partition=production --time=48:00:00 --mem=10G',
         medmem_long_slurm_options  => '--partition=production --time=140:00:00 --mem=10G',
-        highmem_slurm_options      => '--partition=production --time=24:00:00 --mem=20G',
+        highmem_slurm_options      => '--partition=production --time=48:00:00 --mem=20G',
         highmem_long_slurm_options => '--partition=production --time=140:00:00 --mem=20G',
 
         # options controlling the number of workers used for the parallelisable analyses


### PR DESCRIPTION
Last time this pipeline was run in SLURM, some jobs failed when hitting the 24h limit. The slowest job took 26h, so increasing the limit to 48h would allow to future-proof the pipeline.