### PR TITLE
EVAImport: Fix undefined set_names for valid species

### DIFF
--- a/nextflow/EVAImport/main.nf
+++ b/nextflow/EVAImport/main.nf
@@ -307,8 +307,10 @@ workflow {
 
   run_variant_synonyms(run_eva.out, file(var_syn_script), params.source, params.species, file(params.var_syn_file), registry, params.old_host, params.old_port, params.old_dbname)
 
-  if(set_names[params.species]) {
-    my_species_set = Channel.fromList(set_names.get(params.species))
+  # check if the species starts with any of the keys in set_names, such as 'ovis_aries_rambouillet' matching 'ovis_aries'
+  set_names_key = set_names.keySet().find{ params.species =~ /^${it}/ }
+  if(set_names_key) {
+    my_species_set = Channel.fromList(set_names.get(set_names_key))
     run_variation_set(run_variant_synonyms.out, my_species_set, var_set_script, files_path, filenames, params.species, registry)
 
     run_variation_set_2(run_variation_set.out.collect(), var_set_script_2, params.species, registry)

--- a/nextflow/EVAImport/main.nf
+++ b/nextflow/EVAImport/main.nf
@@ -307,7 +307,7 @@ workflow {
 
   run_variant_synonyms(run_eva.out, file(var_syn_script), params.source, params.species, file(params.var_syn_file), registry, params.old_host, params.old_port, params.old_dbname)
 
-  # check if the species starts with any of the keys in set_names, such as 'ovis_aries_rambouillet' matching 'ovis_aries'
+  // check if the species starts with any of the keys in set_names, such as 'ovis_aries_rambouillet' matching 'ovis_aries'
   set_names_key = set_names.keySet().find{ params.species =~ /^${it}/ }
   if(set_names_key) {
     my_species_set = Channel.fromList(set_names.get(set_names_key))


### PR DESCRIPTION
Allow to match a subspecies with any available species, for instance `ovis_aries_rambouillet` with `ovis_aries`, when trying to run `run_variation_set`.