### PR TITLE
Fix hgvs coding refseq mismatch

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -832,7 +832,7 @@ sub codon {
       my $refseq_ref = $edit_attrs[0]->value;
       $refseq_ref =~ s/\d+\s\d+\s//;
       if ($refseq_ref eq $seq) {
-        $self->{alleles_mismatch} = 1;
+        $self->{invalid_alleles} = 1;
       }
     }
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -77,8 +77,6 @@ use Bio::EnsEMBL::Variation::Utils::Sequence qw(hgvs_variant_notation format_hgv
 use Bio::EnsEMBL::Utils::Sequence qw(reverse_comp);
 use Bio::EnsEMBL::Variation::Utils::VariationEffect qw(overlap within_cds within_intron stop_lost start_lost frameshift stop_retained);
 
-use Data::Dumper;
-
 use base qw(Bio::EnsEMBL::Variation::VariationFeatureOverlapAllele Bio::EnsEMBL::Variation::BaseTranscriptVariationAllele);
 
 
@@ -1441,14 +1439,6 @@ sub hgvs_transcript {
 
   if(scalar @edit_attrs > 0) {
     my $ref = $tv->get_reference_TranscriptVariationAllele;
-
-    # print "Edit HGVSc alleles!!\n";
-
-    # print "-> (HGVSc) ref variation_feature_seq: ", $ref->variation_feature_seq, "\n";
-    # print "-> (HGVSc) self variation_feature_seq: ", $self->variation_feature_seq, "\n";
-    # print "-> (HGVSg) ref feature_seq: ", $ref->feature_seq, "\n";
-    # print "-> (HGVSg) self feature_seq: ", $self->feature_seq, "\n";
-
     $hgvs_notation->{ref} = $ref->variation_feature_seq;
     $hgvs_notation->{alt} = $self->variation_feature_seq;
   }
@@ -2593,7 +2583,7 @@ sub _hgvs_generic {
   my $self = shift;
   my $reference = pop;
   my $notation = shift;
-  
+
   #The rna and mitochondrial modes have not yet been implemented, so return undef in case we get a call to these
   return undef if ($reference =~ m/rna|mitochondrial/);
   

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1985,25 +1985,6 @@ sub hgvs_genomic {
     # Skip if e.g. allele is identical to the reference slice
     next if (!defined($hgvs_notation));
 
-    # Check if there are mismatches between refseq transcripts and the reference genome
-    # These mismatches are tracked in transcript attributes
-    # If there are mismatches then edit the HGVSg alleles
-    my $tv_test = $self->get_all_TranscriptVariations->[0];
-
-    if(defined $tv_test) {
-	    my @edit_attrs = grep {$_->code =~ /^_rna_edit/} @{$tv_test->transcript->get_all_Attributes()};
-
-      if(scalar(@edit_attrs) > 0) {
-        # print "Going to edit HGVSg alleles!!\n";
-        # Edit ref allele
-        my $tva_test = $tv_test->get_reference_TranscriptVariationAllele;
-        $hgvs_notation->{ref} = $tva_test->feature_seq;
-        # Edit alt allele
-        my $tva_alts_test = @{$tv_test->get_all_alternate_TranscriptVariationAlleles}[0];
-        $hgvs_notation->{alt} = $tva_alts_test->feature_seq;
-        }
-    }
-
     ## alleles may need trimming if the type is reported as a delins
     $hgvs_notation = _clip_alleles($hgvs_notation) if( $hgvs_notation->{type} eq 'delins');
 

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1985,6 +1985,25 @@ sub hgvs_genomic {
     # Skip if e.g. allele is identical to the reference slice
     next if (!defined($hgvs_notation));
 
+    # Check if there are mismatches between refseq transcripts and the reference genome
+    # These mismatches are tracked in transcript attributes
+    # If there are mismatches then edit the HGVSg alleles
+    my $tv_test = $self->get_all_TranscriptVariations->[0];
+
+    if(defined $tv_test) {
+	    my @edit_attrs = grep {$_->code =~ /^_rna_edit/} @{$tv_test->transcript->get_all_Attributes()};
+
+      if(scalar(@edit_attrs) > 0) {
+        # print "Going to edit HGVSg alleles!!\n";
+        # Edit ref allele
+        my $tva_test = $tv_test->get_reference_TranscriptVariationAllele;
+        $hgvs_notation->{ref} = $tva_test->feature_seq;
+        # Edit alt allele
+        my $tva_alts_test = @{$tv_test->get_all_alternate_TranscriptVariationAlleles}[0];
+        $hgvs_notation->{alt} = $tva_alts_test->feature_seq;
+        }
+    }
+
     ## alleles may need trimming if the type is reported as a delins
     $hgvs_notation = _clip_alleles($hgvs_notation) if( $hgvs_notation->{type} eq 'delins');
 

--- a/modules/t/transcriptVariationAdaptor.t
+++ b/modules/t/transcriptVariationAdaptor.t
@@ -425,7 +425,7 @@ $tv->cdna_start(1000);
 $tv->transcript->{cdna_coding_start} = 234;
 
 ## Coordinate within HGVS matches cds_start as these values take mismatch into account 
-ok($tv->hgvs_transcript->{A} eq 'NM_001270408.1:c.1234N>A', 'Refseq HGVS mismatch calculated');
+ok($tv->hgvs_transcript->{A} eq 'NM_001270408.1:c.1234G>A', 'Refseq HGVS mismatch calculated');
 
 ## Misalignment offset calculated from transcript edits recognises insertion of 4BP
 my @attribs = @{$tr->get_all_Attributes()};


### PR DESCRIPTION
Ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4493

This PR fixes the alleles for HGVS coding.
It adds `invalid_alleles` if ref == alt (to be used in ensembl-vep).
