### PR TITLE
Automate downloading MaveDB mappings

### DIFF
--- a/nextflow/MaveDB/README.md
+++ b/nextflow/MaveDB/README.md
@@ -59,19 +59,19 @@ nextflow run [path_to]/ensembl-variation/nextflow/MaveDB/main.nf \
 
 1. For each MaveDB URN, download respective metadata and check if it is using open-access licence (CC0 by default)
 2. Split MaveDB mapping files by HGVS type: either **HGVSg** or **HGVSp**
-3. If HGVSg:
-	1. Map MaveDB scores to genomic variants using MaveDB mappings file
-      - Scores file is automatically downloaded using MaveDB API
-	3. LiftOver genomic coordinates to GRCh38/hg38 (if needed) with [pyliftover][]
-4. If HGVSp:
-	1. Get all unique HGVSp from MaveDB mappings file
-	2. Run [Variant Recoder][] (VR) to get possible genomic coordinates for HGVSp
-	    - Can take up to 6 hours + 70 GB of RAM for a single run with many HGVSp
-	    - Given that it uses the online Ensembl database, it may fail due to too many connections
-	4. Map MaveDB scores to genomic variants using VR output and MaveDB mappings file
-	    - Scores file is automatically downloaded using MaveDB API
-5. Concatenate all output files into a single file
-6. Sort, bgzip and tabix
+3. Download scores and mappings files using MaveDB API
+4. For each pair of scores and mappings files:
+    - If genomic variants (HGVSg):
+        - Map MaveDB scores to genomic variants using MaveDB mappings file
+        - LiftOver genomic coordinates to GRCh38/hg38 (if needed) with [pyliftover][]
+    - If protein variants (HGVSp):
+        - Get all unique HGVSp from MaveDB mappings file
+        - Run [Variant Recoder][] (VR) to get possible genomic coordinates for HGVSp
+ 		    - Can take up to 6 hours + 70 GB of RAM for a single run with many HGVSp
+   		    - Given that it uses the online Ensembl database, it may fail due to too many connections
+     	- Map MaveDB scores to genomic variants using VR output and MaveDB mappings file
+6. Concatenate all output files into a single file
+7. Sort, bgzip and tabix
 
 Notes:
 - The MaveDB API may return `502: Proxy error` when under stress, resulting in failed jobs.

--- a/nextflow/MaveDB/README.md
+++ b/nextflow/MaveDB/README.md
@@ -80,40 +80,60 @@ Notes:
 ## Pipeline diagram
 
 ```mermaid
+%%{
+  init: {
+    'theme': 'base',
+    'themeVariables': {
+      'primaryColor': '#2BA75D',
+      'primaryTextColor': '#fff',
+      'primaryBorderColor': '#2BA75D',
+      'lineColor': '#2BA75D',
+      'secondaryColor': '#2BA75D',
+      'secondaryBorderColor': '#2BA75D',
+      'secondaryTextColor': '#2BA75D',
+      'tertiaryColor': '#E9F6EE',
+      'tertiaryBorderColor': '#2BA75D',
+      'tertiaryTextColor': '#2BA75D'
+    }
+  }
+}%%
+
 flowchart TD
     start(( ))
-    metadata(download metadata)
-    licence(filter by licence)
-    download(download MaveDB scores and mapping)
-    warn([warn about files with\nnon-matching licences])
-    p7([branch files])
-    p11[map scores to\ngenomic variants]
-    chain[download chain files]
-    liftover[LiftOver to\nGRCh38/hg38]
-    p14[get HGVSp identifiers]
-    discard([discard if no\nHGVSp identifiers])
-    vr[run Variant Recoder\nto map protein variants]
-    p19[map scores to\ngenomic variants]
-    concat[concatenate files]
-    tabix[tabix]
+    metadata(fa:fa-download download metadata)
+    licence(fa:fa-filter filter by licence)
+    download(fa:fa-download download MaveDB\nscores and mapping)
+    warn([fa:fa-warning warn about files with\nnon-matching licences])
+    split([fa:fa-right-left split by mapping type])
+    parse1[fa:fa-diagram-predecessor parse scores per\ngenetic variant]
+    chain[fa:fa-download download\nchain files]
+    liftover[fa:fa-diamond-turn-right LiftOver to\nGRCh38/hg38]
+    unique[fa:fa-fingerprint get unique HGVSp identifiers]
+    discard([fa:fa-trash discard if no\nHGVSp identifiers])
+    vr[fa:fa-map-location-dot run Variant Recoder\nto map protein variants]
+    parse2[fa:fa-diagram-predecessor parse scores per\ngenetic variant]
+    concat[fa:fa-layer-group concatenate files]
+    tabix[fa:fa-compass-drafting tabix]
 
     start --> |urn| metadata
     metadata --> licence
     licence --> download
     licence --> warn
-    download --> p7
-    p7 --> p14
-    p7 --> p11
+    download --> for
+    subgraph for["For each pair of MaveDB score and mapping files"]
+    split --> unique
+    split --> parse1
     subgraph hgvsg ["HGVSg: genomic variants"]
-    p11 --> liftover
+    parse1 --> liftover
     chain --> liftover
     end
-    liftover --> concat
     subgraph hgvsp ["HGVSp: protein variants"]
-    p14 --> discard
-    discard --> vr
-    vr --> p19
+    unique --> discard
+    unique --> vr
+    vr --> parse2
     end
-    p19 --> concat
+    end
+    liftover --> concat
+    parse2 --> concat
     concat --> tabix
 ```

--- a/nextflow/MaveDB/main.nf
+++ b/nextflow/MaveDB/main.nf
@@ -8,7 +8,7 @@ nextflow.enable.dsl=2
 
 // Default params
 params.help     = false
-params.mappings = null
+params.urn      = null
 params.ensembl  = "${ENSEMBL_ROOT_DIR}"
 params.output   = "output/MaveDB_variants.tsv.gz"
 params.registry = null
@@ -27,23 +27,22 @@ if (params.help) {
               --mappings [MaveDB_mappings_folder]
 
   Mandatory arguments:
-    --mappings  Path to directory containing MaveDB mapping files in JSON format
+    --urn       File with MaveDB URNs, such as 'urn:mavedb:00000001-a-1'
 
   Optional arguments:
     --ensembl   Path to Ensembl root directory (default: ${ENSEMBL_ROOT_DIR})
-    --output    Path to output file (default: 'output/MaveDB_variants.tsv.gz')
-    --licences  Comma-separated list of accepted licences (default: 'CC0')
-    --round     Decimal places to round floats in MaveDB data (default: 4)
+    --output    Path to output file (default: output/MaveDB_variants.tsv.gz)
     --registry  Path to Ensembl registry
 
-  Note: the mappings must be named with the MaveDB accession, such as
-        '00000001-a-1.json'.
+    --licences  Comma-separated list of accepted licences (default: 'CC0')
+    --round     Decimal places to round floats in MaveDB data (default: 4)
   """
   exit 1
 }
 
 // Module imports
 include { filter_by_licence } from './subworkflows/filter.nf'
+include { download_MaveDB_data } from './nf_modules/fetch.nf'
 include { split_by_mapping_type } from './subworkflows/split.nf'
 include { run_variant_recoder } from './nf_modules/variant_recoder.nf'
 include { get_hgvsp } from './nf_modules/utils.nf'
@@ -57,29 +56,38 @@ include { concatenate_files;
 log.info """
   Create MaveDB plugin data for VEP
   ---------------------------------
-  mappings : ${params.mappings}
+  urn      : ${params.urn}
   output   : ${params.output}
   ensembl  : ${params.ensembl}
+  registry : ${params.registry}
 
   licences : ${params.licences}
   round    : ${params.round}
   """
 
 workflow {
-  // prepare data based on licence
-  files = Channel.fromPath( params.mappings + "/*.json", checkIfExists: true )
+  // filter MaveDB URNs based on file-specific licence
+  urn = Channel
+          .fromPath( params.urn, checkIfExists: true )
+          .splitText()
+          .map { it.trim() }
   licences = params.licences.tokenize(",")
-  filtered = filter_by_licence(files, licences)
-  mapping_files = split_by_mapping_type( filtered )
+  urn = filter_by_licence(urn, licences)
+
+  // download mappings and scores from MaveDB
+  download_MaveDB_data(urn)
+  files = download_MaveDB_data.out
+            .map { [urn: it[0], mappings: it[1], scores: it[2], metadata: it[3]] }
+  files = split_by_mapping_type( files )
 
   // use MaveDB-prepared HGVSg mappings
-  map_scores_to_HGVSg_variants( mapping_files.hgvs_nt )
+  map_scores_to_HGVSg_variants( files.hgvs_nt )
   download_chain_files()
   liftover_to_hg38( map_scores_to_HGVSg_variants.out,
                     download_chain_files.out )
 
   // prepare HGVSp mappings
-  get_hgvsp( mapping_files.hgvs_pro )
+  get_hgvsp( files.hgvs_pro )
   hgvsp = get_hgvsp.out.filter { it.last().size() > 0 }
   run_variant_recoder( hgvsp )
   map_scores_to_HGVSp_variants( run_variant_recoder.out )

--- a/nextflow/MaveDB/nf_modules/fetch.nf
+++ b/nextflow/MaveDB/nf_modules/fetch.nf
@@ -1,23 +1,36 @@
-process fetch_licence {
-  // Check if files are open access (error out if not)
-
+process download_MaveDB_metadata {
+  // Download MaveDB metadata
   errorStrategy 'ignore'
 
-  input:  path mappings
-  output: tuple path(mappings), path('LICENCE.txt')
+  input:  val urn
+  output: tuple val(urn), path('metadata.json'), path('LICENCE.txt')
 
   """
   #!/usr/bin/env python3
   import urllib.request
   import json
 
-  urn = "urn:mavedb:${mappings.simpleName}"
-  url = f"https://api.mavedb.org/api/v1/score-sets/{urn}"
+  url = "https://api.mavedb.org/api/v1/score-sets/${urn}"
   res = urllib.request.urlopen(url).read()
   res = json.loads(res)
+  
+  with open('metadata.json', 'w') as f:
+    json.dump(res, f)
 
-  f = open("LICENCE.txt", "w")
-  f.write(res['license']['shortName'])
-  f.close()
+  with open("LICENCE.txt", "w") as f:
+    f.write(res['license']['shortName'])
+  """
+}
+
+process download_MaveDB_data {
+  // Download MaveDB data
+  input: tuple val(urn), path(metadata), path(licence)
+  output: tuple val(urn), path('mappings.json'), path('scores.csv'), path(metadata)
+
+  script:
+    url = "https://api.mavedb.org/api/v1/score-sets/${urn}"
+  """
+  wget ${url}/mapped-variants -O mappings.json
+  wget ${url}/scores -O scores.csv
   """
 }

--- a/nextflow/MaveDB/nf_modules/liftover.nf
+++ b/nextflow/MaveDB/nf_modules/liftover.nf
@@ -18,16 +18,16 @@ process download_chain_files {
 process liftover_to_hg38 {
   // Identify genome of reference used to map variants and lift-over to hg38
   container 'quay.io/biocontainers/pyliftover:0.4--py_0'
-  tag "${mappings.simpleName}"
+  tag "${urn}"
 
   input: 
-    tuple path(mappings), path(mapped_variants)
+    tuple val(urn), path(metadata), path(mapped_variants)
     path(chain_files)
   output:
-    tuple path(mappings), path("liftover_*.tsv")
+    tuple val(urn), path("liftover_*.tsv")
 
   """
-  liftover.py --mappings ${mappings} \
+  liftover.py --metadata ${metadata} \
               --mapped_variants ${mapped_variants} \
               --reference hg38
   """

--- a/nextflow/MaveDB/nf_modules/mapping.nf
+++ b/nextflow/MaveDB/nf_modules/mapping.nf
@@ -1,20 +1,21 @@
 process map_scores_to_HGVSp_variants {
   // Download MaveDB scores and map associated variants by HGVSp
 
-  tag "${mappings.simpleName}"
-  input:  tuple path(mappings), path(vr)
-  output: tuple path(mappings), path('map_*.tsv')
+  tag "${urn}"
+  input:  tuple val(urn), path(mappings), path(scores), path(metadata), path(vr)
+  output: tuple val(urn), path('map_*.tsv')
 
   memory { mappings.size() * 4.B + 1.GB }
 
   script:
-  def urn   = mappings.simpleName
   def round = params.round ? "--round ${params.round}" : ""
   """
-  map_scores_to_variants.py --urn ${urn} \
-                            --mappings ${mappings} \
-                            --vr $vr \
-                            ${round} \
+  map_scores_to_variants.py --urn ${urn} \\
+                            --scores ${scores} \\
+                            --mappings ${mappings} \\
+                            --metadata ${metadata} \\
+                            --vr $vr \\
+                            ${round} \\
                             --output map_${urn}.tsv
   """
 }
@@ -22,19 +23,20 @@ process map_scores_to_HGVSp_variants {
 process map_scores_to_HGVSg_variants {
   // Download MaveDB scores and map associated variants from HGVSg
 
-  tag "${mappings.simpleName}"
-  input:  path(mappings)
-  output: tuple path(mappings), path('map_*.tsv')
+  tag "${urn}"
+  input:  tuple val(urn), path(mappings), path(scores), path(metadata), val(hgvs)
+  output: tuple val(urn), path(metadata), path('map_*.tsv')
 
   memory { mappings.size() * 2.B + 1.GB }
 
   script:
-  def urn   = mappings.simpleName
   def round = params.round ? "--round ${params.round}" : ""
   """
-  map_scores_to_variants.py --urn ${urn} \
-                            --mappings ${mappings} \
-                            ${round} \
+  map_scores_to_variants.py --urn ${urn} \\
+                            --scores ${scores} \\
+                            --mappings ${mappings} \\
+                            --metadata ${metadata} \\
+                            ${round} \\
                             --output map_${urn}.tsv
   """
 }

--- a/nextflow/MaveDB/nf_modules/utils.nf
+++ b/nextflow/MaveDB/nf_modules/utils.nf
@@ -1,16 +1,15 @@
 process get_hgvsp {
   // Get and sort all HGVSp identifiers from mappings file
 
-  tag "${mappings.simpleName}"
+  tag "${urn}"
   errorStrategy 'ignore'
-  input:  path mappings
-  output: tuple path(mappings), path('hgvsp.txt')
+  input:  tuple val(urn), path(mappings), path(scores), path(metadata), val(hgvs)
+  output: tuple val(urn), path(mappings), path(scores), path(metadata), path('hgvsp.txt')
 
   """
-  grep -Eo '".*:p..*"' $mappings |\
-    sed 's/"//g' |\
-    sed 's/value: //g' |\
-    sort -t":" -V -k2.6 |\
+  sed 's/"/\\n/g' $mappings |\\
+    grep -Eo '.*:p\\..*' |\\
+    sort -t":" -V -k2.6 |\\
     uniq > hgvsp.txt
   """
 }

--- a/nextflow/MaveDB/nf_modules/variant_recoder.nf
+++ b/nextflow/MaveDB/nf_modules/variant_recoder.nf
@@ -2,10 +2,10 @@ process run_variant_recoder {
   // Run Variant Recoder on a file with HGVS identifiers
   label 'bigmem'
 
-  input:  tuple path(mappings), path(hgvs)
-  output: tuple path(mappings), path('vr.json')
+  input:  tuple val(urn), path(mappings), path(scores), path(metadata), path(hgvs)
+  output: tuple val(urn), path(mappings), path(scores), path(metadata), path('vr.json')
 
-  tag "${mappings.simpleName}"
+  tag "${urn}"
   memory { file(hgvs.target).countLines() * 100.MB + 4.GB }
 
   errorStrategy 'ignore'

--- a/nextflow/MaveDB/subworkflows/filter.nf
+++ b/nextflow/MaveDB/subworkflows/filter.nf
@@ -1,21 +1,23 @@
-include { fetch_licence } from '../nf_modules/fetch.nf'
+include { download_MaveDB_metadata } from '../nf_modules/fetch.nf'
 
 workflow filter_by_licence {
   take:
-    files
+    urn
     licences
   main:
-    fetch_licence( files )
+    download_MaveDB_metadata( urn )
     // Warn about discarded files
-    fetch_licence.out.
-      filter{ !licences.contains(it.last().text) }.
-      subscribe{
-        println "NOTE: Discarded ${it.first().simpleName} based on licence ${it.last().text}"
+    data = download_MaveDB_metadata.out
+             .map { [ urn: it[0], metadata: it[1], licence: it[2] ] }
+
+    data.
+      filter { !licences.contains(it.licence.text) }.
+      subscribe {
+        println "NOTE: Discarded ${it.urn} based on licence ${it.licence.text}"
       }
+
     // Return files with matching licences
-    filtered = fetch_licence.out.
-      filter{ licences.contains(it.last().text) }.
-      map{ it.first() }
+    filtered = data.filter { licences.contains(it.licence.text) }
   emit:
     filtered
 }

--- a/nextflow/MaveDB/subworkflows/split.nf
+++ b/nextflow/MaveDB/subworkflows/split.nf
@@ -1,7 +1,7 @@
 def split_by_mapping_type (files) {
   // split mapping files based on HGVS type (HGVSp or HGVSg files)
   type = files.map {
-    it.withReader {
+    it.mappings.withReader {
       while( line = it.readLine() ) {
         if (line.contains("hgvs.")) {
           // get first line describing HGVS type
@@ -16,15 +16,10 @@ def split_by_mapping_type (files) {
         }
       }
     }
-    [file: it, hgvs: hgvs]
+    it + [hgvs: hgvs]
   }.branch{
     hgvs_pro: it.hgvs == "hgvs.p"
     hgvs_nt:  it.hgvs == "hgvs.g"
   }
-
-  // clean up: only return the files in each branch
-  files = [hgvs_pro: null, hgvs_nt: null]
-  files.hgvs_pro = type.hgvs_pro.map { it.file }
-  files.hgvs_nt  = type.hgvs_nt.map { it.file }
-  return files
+  return type
 }


### PR DESCRIPTION
## Changelog

- Accept a file containing a list of URNs (`--urn`) instead of multiple mappings files (`--mappings`)
    - Automate downloading MaveDB mappings
    - Correctly parse mappings from MaveDB API
- Download MaveDB metadata (before, it was included in the MaveDB mappings file)
- Download MaveDB scores in obvious processes (instead of in the middle of scripts)
- Update README instructions + diagram

## Testing

Run pipeline using a file with some MaveDB URNs, such as:

```
urn:mavedb:00000001-a-1
urn:mavedb:00000001-b-1
urn:mavedb:00000001-b-2
urn:mavedb:00000002-a-1
urn:mavedb:00000003-a-1
urn:mavedb:00000003-b-1
```