### PR TITLE
Add VCF remapping pipeline using CrossMap

### DIFF
--- a/nextflow/Remapping/main.nf
+++ b/nextflow/Remapping/main.nf
@@ -142,7 +142,7 @@ if (params.help) {
 include { crossmap; rename_and_tabix; report } from './modules/crossmap.nf'
 include { print_params; print_summary } from '../utils/utils.nf'
 
-print_params(description, separator)
+print_params(description=description, separator=separator, nullable=['rr_root'])
 print_summary()
 
 workflow {

--- a/nextflow/Remapping/main.nf
+++ b/nextflow/Remapping/main.nf
@@ -20,8 +20,10 @@ params.keep_id   = false
 params.out_dir = 'output'
 params.report  = 'crossmap_report.txt'
 
+// Rapid Release FTP dir (and example of --rr_path below)
 params.rr_root = null
-params.rr_path = 'species/Homo_sapiens/$assembly/ensembl/variation/2022_10/vcf/2024_07/'
+params.rr_path = null
+// params.rr_path = 'species/Homo_sapiens/$assembly/ensembl/variation/2022_10/vcf/`date +%Y_%m`/'
 
 lookup = [
   "HG02257.1"    : "GCA_018466835.1",
@@ -151,7 +153,8 @@ include { crossmap; tabix; report } from './modules/crossmap.nf'
 include { copy_to_rapid_release_ftp } from './modules/copy.nf'
 include { print_params; print_summary } from '../utils/utils.nf'
 
-print_params(description=description, separator=separator, nullable=['rr_root'])
+print_params(description=description, separator=separator,
+             nullable=['rr_root', 'rr_path'])
 print_summary()
 
 workflow {
@@ -166,6 +169,9 @@ workflow {
   report(crossmap.out.report.collect(), lookup)
 
   if (params.rr_root) {
+    if (!params.rr_path) {
+      error "ERROR: --rr_path is required to provide the full path of the Rapid Release FTP directory"
+    }
     copy_to_rapid_release_ftp(tabix.out, lookup)
   }
 }

--- a/nextflow/Remapping/main.nf
+++ b/nextflow/Remapping/main.nf
@@ -15,9 +15,102 @@ params.vcf    = null
 
 params.chain_dir = null
 params.fasta_dir = null
+params.keep_id   = false
 
 params.out_dir = 'output'
 params.report = 'crossmap_report.txt'
+
+lookup = [
+  "HG02257.1"    : "GCA_018466835.1",
+  "HG02257.2"    : "GCA_018466845.1",
+  "HG02559.1"    : "GCA_018466855.1",
+  "HG02559.2"    : "GCA_018466985.1",
+  "HG02486.1"    : "GCA_018467005.1",
+  "HG02486.2"    : "GCA_018467015.1",
+  "HG01891.2"    : "GCA_018467155.1",
+  "HG01891.1"    : "GCA_018467165.1",
+  "HG01258.2"    : "GCA_018469405.1",
+  "HG03516.1"    : "GCA_018469415.1",
+  "HG03516.2"    : "GCA_018469425.1",
+  "HG01123.2"    : "GCA_018469665.1",
+  "HG01258.1"    : "GCA_018469675.1",
+  "HG01361.2"    : "GCA_018469685.1",
+  "HG01123.1"    : "GCA_018469695.1",
+  "HG01361.1"    : "GCA_018469705.1",
+  "HG01358.2"    : "GCA_018469865.1",
+  "HG02622.2"    : "GCA_018469875.1",
+  "HG02622.1"    : "GCA_018469925.1",
+  "HG02717.2"    : "GCA_018469935.1",
+  "HG02630.1"    : "GCA_018469945.1",
+  "HG02630.2"    : "GCA_018469955.1",
+  "HG01358.1"    : "GCA_018469965.1",
+  "HG02717.1"    : "GCA_018470425.1",
+  "HG02572.1"    : "GCA_018470435.1",
+  "HG02572.2"    : "GCA_018470445.1",
+  "HG02886.2"    : "GCA_018470455.1",
+  "HG02886.1"    : "GCA_018470465.1",
+  "HG01175.1"    : "GCA_018471065.1",
+  "HG01106.1"    : "GCA_018471075.1",
+  "HG01175.2"    : "GCA_018471085.1",
+  "HG00741.2"    : "GCA_018471095.1",
+  "HG00741.1"    : "GCA_018471105.1",
+  "HG01106.2"    : "GCA_018471345.1",
+  "HG00438.2"    : "GCA_018471515.1",
+  "HG02148.1"    : "GCA_018471525.1",
+  "HG02148.2"    : "GCA_018471535.1",
+  "HG01952.2"    : "GCA_018471545.1",
+  "HG01952.1"    : "GCA_018471555.1",
+  "HG00673.2"    : "GCA_018472565.1",
+  "HG00621.1"    : "GCA_018472575.1",
+  "HG00673.1"    : "GCA_018472585.1",
+  "HG00438.1"    : "GCA_018472595.1",
+  "HG00621.2"    : "GCA_018472605.1",
+  "HG01071.2"    : "GCA_018472685.1",
+  "HG01928.2"    : "GCA_018472695.1",
+  "HG01928.1"    : "GCA_018472705.1",
+  "HG00735.1"    : "GCA_018472715.1",
+  "HG01071.1"    : "GCA_018472725.1",
+  "HG00735.2"    : "GCA_018472765.1",
+  "HG03579.2"    : "GCA_018472825.1",
+  "HG03579.1"    : "GCA_018472835.1",
+  "HG01978.1"    : "GCA_018472845.1",
+  "HG03453.2"    : "GCA_018472855.1",
+  "HG01978.2"    : "GCA_018472865.1",
+  "HG03540.2"    : "GCA_018473295.1",
+  "HG03453.1"    : "GCA_018473305.1",
+  "HG03540.1"    : "GCA_018473315.1",
+  "HG03486.1"    : "GCA_018503245.1",
+  "NA18906.2"    : "GCA_018503255.1",
+  "NA18906.1"    : "GCA_018503285.1",
+  "HG03486.2"    : "GCA_018503525.1",
+  "HG02818.1"    : "GCA_018503575.1",
+  "HG02818.2"    : "GCA_018503585.1",
+  "HG01243.1"    : "GCA_018504045.1",
+  "HG02080.1"    : "GCA_018504055.1",
+  "HG02723.2"    : "GCA_018504065.1",
+  "HG02723.1"    : "GCA_018504075.1",
+  "HG02080.2"    : "GCA_018504085.1",
+  "HG01109.2"    : "GCA_018504365.1",
+  "HG01243.2"    : "GCA_018504375.1",
+  "NA20129.1"    : "GCA_018504625.1",
+  "NA20129.2"    : "GCA_018504635.1",
+  "HG01109.1"    : "GCA_018504645.1",
+  "NA21309.2"    : "GCA_018504655.1",
+  "NA21309.1"    : "GCA_018504665.1",
+  "HG02109.2"    : "GCA_018505825.1",
+  "HG03492.1"    : "GCA_018505835.1",
+  "HG03492.2"    : "GCA_018505845.1",
+  "HG02055.1"    : "GCA_018505855.1",
+  "HG02109.1"    : "GCA_018505865.1",
+  "HG02055.2"    : "GCA_018506125.1",
+  "HG03098.1"    : "GCA_018506155.1",
+  "HG03098.2"    : "GCA_018506165.1",
+  "HG00733.1"    : "GCA_018506955.1",
+  "HG00733.2"    : "GCA_018506975.1",
+  "HG02145.2"    : "GCA_018852585.1",
+  "HG02145.1"    : "GCA_018852595.1",
+  "T2T_CHM13_v2" : "GCA_009914755.4"
+]
 
 // Print usage
 if (params.help) {
@@ -41,11 +134,12 @@ if (params.help) {
   Optional arguments:
     --out_dir    Path to output directory (default: 'output')
     --report     Filename with remapping statistics (default: 'crossmap_report.txt')
+    --keep_id    Boolean: rename filename based on hard-coded lookup table (default) or keep original ID?
   """
   exit 1
 }
 
-include { crossmap; tabix; report } from './modules/crossmap.nf'
+include { crossmap; rename_and_tabix; report } from './modules/crossmap.nf'
 include { print_params; print_summary } from '../utils/utils.nf'
 
 print_params(description, separator)
@@ -59,6 +153,6 @@ workflow {
   fasta_dir = Channel.fromPath(params.fasta_dir, checkIfExists: true)
 
   crossmap(vcf, ids, chain_dir, fasta_dir)
-  tabix(crossmap.out.vcf)
-  report(crossmap.out.report.collect())
+  rename_and_tabix(crossmap.out.vcf, lookup)
+  report(crossmap.out.report.collect(), lookup)
 }

--- a/nextflow/Remapping/main.nf
+++ b/nextflow/Remapping/main.nf
@@ -1,0 +1,64 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Nextflow pipeline to remap VCF files
+ */
+
+nextflow.enable.dsl=2
+description = "Pipeline to remap VCF files"
+separator   = "-" * description.length()
+
+// Default params
+params.help   = false
+params.ids    = null
+params.vcf    = null
+
+params.chain_dir = null
+params.fasta_dir = null
+
+params.out_dir = 'output'
+params.report = 'crossmap_report.txt'
+
+// Print usage
+if (params.help) {
+  log.info """
+  ${description}
+  ${separator}
+
+  Usage:
+    nextflow run -profile slurm -resume main.nf \\
+      --ids ids.txt \\
+      --vcf sample.vcf.gz \\
+      --chain_dir /path/to/chain/dir \\
+      --fasta_dir /path/to/fasta/dir
+
+  Mandatory arguments:
+    --vcf        VCF file to remap
+    --ids        File containing IDs of genomes
+    --chain_dir  Path to chain directory (filenames must have the ID given in --ids)
+    --fasta_dir  Path to fasta directory (filenames must have the ID given in --ids)
+
+  Optional arguments:
+    --out_dir    Path to output directory (default: 'output')
+    --report     Filename with remapping statistics (default: 'crossmap_report.txt')
+  """
+  exit 1
+}
+
+include { crossmap; tabix; report } from './modules/crossmap.nf'
+include { print_params; print_summary } from '../utils/utils.nf'
+
+print_params(description, separator)
+print_summary()
+
+workflow {
+  ids = Channel.fromPath(params.ids, checkIfExists: true).splitText { it.trim() }
+
+  vcf       = Channel.fromPath(params.vcf, checkIfExists: true)
+  chain_dir = Channel.fromPath(params.chain_dir, checkIfExists: true)
+  fasta_dir = Channel.fromPath(params.fasta_dir, checkIfExists: true)
+
+  crossmap(vcf, ids, chain_dir, fasta_dir)
+  tabix(crossmap.out.vcf)
+  report(crossmap.out.report.collect())
+}

--- a/nextflow/Remapping/modules/copy.nf
+++ b/nextflow/Remapping/modules/copy.nf
@@ -1,0 +1,24 @@
+#!/usr/bin/env nextflow
+
+process copy_to_rapid_release_ftp {
+  memory '1GB'
+  time '10m'
+  
+  errorStrategy 'terminate'
+
+  input:
+    tuple val(id), path(vcf)
+    val lookup
+
+  output:
+    stdout
+
+  script:
+    def assembly = !params.keep_id && lookup[id] ? lookup[id] : id
+  """
+  assembly=${assembly}
+  for file in ${vcf}; do
+    become ensrapid rsync -av `realpath \${file}` ${params.rr_root}/${params.rr_path}
+  done
+  """
+}

--- a/nextflow/Remapping/modules/crossmap.nf
+++ b/nextflow/Remapping/modules/crossmap.nf
@@ -25,22 +25,22 @@ process crossmap {
   """
 }
 
-process rename_and_tabix {
+process tabix {
   tag "$id"
   memory '4GB'
   time '1h'
 
-  publishDir "${params.out_dir}", mode: 'move'
+  publishDir "${params.out_dir}", mode: 'copy'
 
   input:
     tuple val(id), path(vcf), path(unmap)
     val lookup
 
   output:
-    path("*.vcf.gz*")
+    tuple val(id), path("*.vcf.gz*")
 
   script:
-    def assembly = !params.keep_id && lookup[id] ?: id
+    def assembly = !params.keep_id && lookup[id] ? lookup[id] : id
   """
   for file in $vcf $unmap; do
     final=\${file/$id/$assembly}
@@ -55,7 +55,7 @@ process report {
   memory '1GB'
   time '1h'
 
-  publishDir "${params.out_dir}", mode: 'move'
+  publishDir "${params.out_dir}", mode: 'copy'
 
   input:
     path report

--- a/nextflow/Remapping/modules/crossmap.nf
+++ b/nextflow/Remapping/modules/crossmap.nf
@@ -1,0 +1,69 @@
+#!/usr/bin/env nextflow
+
+process crossmap {
+  tag "$id"
+  container 'quay.io/biocontainers/crossmap:0.7.0--pyhdfd78af_0'
+  memory '4GB'
+  time '1h'
+
+  input:
+    path vcf
+    each id
+    path chain_dir
+    path fasta_dir
+
+  output:
+    tuple val(id), path("*.vcf"), path("*.unmap"), emit: vcf
+    path("*_report.txt"), emit: report
+
+  script:
+    def chain = "${chain_dir}/*${id}*"
+    def fasta = "${fasta_dir}/*${id}*.bgz"
+    def out   = "${vcf.simpleName}_${id}.vcf"
+  """
+  CrossMap vcf ${chain} ${vcf} ${fasta} ${out} 2> ${id}_report.txt
+  """
+}
+
+process tabix {
+  tag "$id"
+  memory '4GB'
+  time '1h'
+
+  publishDir "${params.out_dir}", mode: 'move'
+
+  input:
+    tuple val(id), path(vcf), path(unmap)
+  output:
+    path("*.vcf.gz*")
+
+  """
+  for file in $vcf $unmap; do
+    sort -k1,1d -k2,2n \${file} -o \${file}
+    bgzip \${file}
+    tabix -p vcf \${file}.gz
+  done
+  """
+}
+
+process report {
+  memory '1GB'
+  time '1h'
+
+  publishDir "${params.out_dir}", mode: 'move'
+
+  input:
+    path report
+  output:
+    path "${params.report}"
+
+  """
+  echo "#ID\tFailed\tTotal\tPercentage" > ${params.report}
+  for i in `echo ${report} | tr " " "\n" | sort`; do
+    total=`grep -Eo "Total entries: .*" \$i | grep -Eo "[0-9]+"`
+    failed=`grep -Eo "Failed to map: .*" \$i | grep -Eo "[0-9]+"`
+    percentage=`bc <<< "scale=2; \$failed * 100 / \$total"`
+    echo "\${i/_report.txt/}\t\$failed\t\$total\t\$percentage" >> ${params.report}
+  done
+  """
+}

--- a/nextflow/Remapping/nextflow.config
+++ b/nextflow/Remapping/nextflow.config
@@ -1,0 +1,67 @@
+profiles {
+  standard { process.executor = 'local' }
+
+  lsf {
+    executor {
+      name            = 'lsf'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
+    }
+  }
+
+  slurm {
+    executor {
+      name            = 'slurm'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
+    }
+  }
+}
+
+notification {
+  enabled = true
+  to = "${USER}@ebi.ac.uk"
+}
+
+singularity {
+  enabled    = true
+  autoMounts = true
+}
+
+process {
+
+  memory = { ["1 GB", "4 GB", "8 GB", "40 GB"][task.attempt - 1] }
+  time   = '2d'
+
+  // Exit status codes:
+  // - 130: job exceeded LSF allocated memory
+  // - 140: job exceeded SLURM allocated resources (memory, CPU, time)
+  errorStrategy = { task.exitStatus in [130, 140] ? 'retry' : 'ignore' }
+
+  maxRetries = 3
+}
+
+trace {
+    enabled = true
+    overwrite = true
+    file = "reports/trace.txt"
+    //fields = 'task_id,name,status,exit,realtime,%cpu,rss'
+}
+
+dag {
+    enabled = true
+    overwrite = true
+    file = "reports/flowchart.mmd"
+}
+
+timeline {
+    enabled = true
+    overwrite = true
+    file = "reports/timeline.html"
+}
+
+report {
+    enabled = true
+    overwrite = true
+    file = "reports/report.html"
+}

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -32,7 +32,7 @@ def print_params(description, separator="-"*description.length(), indent=4,
     // print parameter
     log.info "${indent}${i.key.padRight(max)} : ${i.value}"
 
-    if (nullable && !i.value) {
+    if (nullable && i.value == null) {
       // raise error if param is null
       exit 1, "ERROR: parameter --${i.key} not defined"
     }

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
-def print_params(description, separator="-"*description.length(), indent=4,
-                 params=params, sort=false, nullable=true, skip=['help']) {
+def print_params(description, separator="-"*description.length(), nullable=true,
+                 indent=4, params=params, sort=false, skip=['help']) {
   /*
     Print script parameters
 
@@ -11,8 +11,8 @@ def print_params(description, separator="-"*description.length(), indent=4,
     @param indent      Number of spaces used to indent the message (default: 4)
     @param params      Map of params (default: script params)
     @param sort        Boolean to sort params alphabetically (default: false)
-    @param nullable    Boolean to allow null params; if false, raises an error
-                       if any param is null (default: true)
+    @param nullable    List of params allowed to be null; raises an error for
+                       null params that are not in this list (default: [])
     @param skip        List of params not to print; if null, all params are
                        printed (default: ['help'])
   */
@@ -32,7 +32,7 @@ def print_params(description, separator="-"*description.length(), indent=4,
     // print parameter
     log.info "${indent}${i.key.padRight(max)} : ${i.value}"
 
-    if (nullable && i.value == null) {
+    if (i.key !in nullable && i.value == null) {
       // raise error if param is null
       exit 1, "ERROR: parameter --${i.key} not defined"
     }

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -1,0 +1,62 @@
+#!/usr/bin/env nextflow
+
+def print_params(description, separator="-"*description.length(), indent=4,
+                 params=params, sort=false, nullable=true, skip=['help']) {
+  /*
+    Print script parameters
+
+    @param description Short pipeline description
+    @param separator   Separator used between description and params
+                       (default: '-' based on description length)
+    @param indent      Number of spaces used to indent the message (default: 4)
+    @param params      Map of params (default: script params)
+    @param sort        Boolean to sort params alphabetically (default: false)
+    @param nullable    Boolean to allow null params; if false, raises an error
+                       if any param is null (default: true)
+    @param skip        List of params not to print; if null, all params are
+                       printed (default: ['help'])
+  */
+  indent = " " * indent
+  log.info "\n${indent}${description}\n${indent}${separator}"
+
+  // ignore specific parameters
+  p = params.findAll { it.key !in skip }
+
+  // sort parameters (by default, they are ordered as defined in the script)
+  if (sort) { p = p.sort() }
+
+  // get max length of keys
+  max = p.collect { it.key.length() }.max()
+  
+  for (i in p) {
+    // print parameter
+    log.info "${indent}${i.key.padRight(max)} : ${i.value}"
+
+    if (nullable && !i.value) {
+      // raise error if param is null
+      exit 1, "ERROR: parameter --${i.key} not defined"
+    }
+  }
+  log.info ""
+}
+
+def print_summary() {
+  /*
+    Print workflow summary when it finishes
+  */
+  workflow.onComplete {
+    println ( workflow.success ? """
+    Workflow summary
+    ----------------
+    Completed at: ${workflow.complete}
+    Duration    : ${workflow.duration}
+    Success     : ${workflow.success}
+    workDir     : ${workflow.workDir}
+    Exit status : ${workflow.exitStatus}
+    """ : """
+    Failed      : ${workflow.errorReport}
+    Exit status : ${workflow.exitStatus}
+    """
+    )
+  }
+}


### PR DESCRIPTION
ENSVAR-6267: new pipeline to remap VCF files using CrossMap

* Output filenames are named with assembly from lookup table
    * If ID is not in lookup table, keeps the original ID
* Copies files to Rapid Release FTP if `--rr_root` is defined

## Testing

```bash
#!/bin/sh

#SBATCH -J 'remap-clinvar-pangenomes'
#SBATCH --time '1:00:00'
#SBATCH --mem '1G'

nextflow run -profile slurm -resume \
${ENSEMBL_ROOT_DIR}/ensembl-variation/nextflow/Remapping \
  --ids input/ids.txt \
  --vcf input/clinvar_20240624.vcf.gz \
  --chain_dir input/chain \
  --fasta_dir input/fasta
```