### PR TITLE
Remapping pipeline: add CHECKSUMS to Rapid Release FTP

### DIFF
--- a/nextflow/Remapping/modules/copy.nf
+++ b/nextflow/Remapping/modules/copy.nf
@@ -25,7 +25,6 @@ process copy_to_rapid_release_ftp {
 
   # Add or update checksums
   become ensrapid rm -f ${outdir}/md5sum* ${outdir}/CHECKSUMS
-  become ensrapid \
-    bash -c 'assembly=${assembly} && cd ${outdir} && md5sum * > CHECKSUMS'
+  become ensrapid bash -c "cd ${outdir} && md5sum * > CHECKSUMS"
   """
 }

--- a/nextflow/Remapping/modules/copy.nf
+++ b/nextflow/Remapping/modules/copy.nf
@@ -3,8 +3,9 @@
 process copy_to_rapid_release_ftp {
   memory '1GB'
   time '10m'
-  
+
   errorStrategy 'terminate'
+  cache false
 
   input:
     tuple val(id), path(vcf)
@@ -15,10 +16,16 @@ process copy_to_rapid_release_ftp {
 
   script:
     def assembly = !params.keep_id && lookup[id] ? lookup[id] : id
+    def outdir = params.rr_root + "/" + params.rr_path
   """
   assembly=${assembly}
   for file in ${vcf}; do
-    become ensrapid rsync -av `realpath \${file}` ${params.rr_root}/${params.rr_path}
+    become ensrapid rsync -av `realpath \${file}` ${outdir}
   done
+
+  # Add or update checksums
+  become ensrapid rm -f ${outdir}/md5sum* ${outdir}/CHECKSUMS
+  become ensrapid \
+    bash -c 'assembly=${assembly} && cd ${outdir} && md5sum * > CHECKSUMS'
   """
 }

--- a/nextflow/Remapping/modules/copy.nf
+++ b/nextflow/Remapping/modules/copy.nf
@@ -2,7 +2,7 @@
 
 process copy_to_rapid_release_ftp {
   memory '1GB'
-  time '10m'
+  time '1h'
 
   errorStrategy 'terminate'
   cache false

--- a/nextflow/Remapping/modules/crossmap.nf
+++ b/nextflow/Remapping/modules/crossmap.nf
@@ -45,7 +45,7 @@ process tabix {
   """
   for file in $vcf $unmap; do
     final=\${file/$id/$assembly}
-    sort -k1,1d -k2,2n \${file} -o \${final}
+    (grep "^#" \${file} && grep -v "^#" \${file} | sort -k1,1d -k2,2n) > \${final}
     bgzip \${final}
     tabix -p vcf \${final}.gz
   done

--- a/nextflow/Remapping/modules/crossmap.nf
+++ b/nextflow/Remapping/modules/crossmap.nf
@@ -9,18 +9,19 @@ process crossmap {
   input:
     path vcf
     each id
-    path chain_dir
-    path fasta_dir
+    path chain_dir, stageAs: 'chain'
+    path fasta_dir, stageAs: 'fasta'
 
   output:
     tuple val(id), path("*.vcf"), path("*.unmap"), emit: vcf
     path("*_report.txt"), emit: report
 
   script:
-    def chain = "${chain_dir}/*${id}*"
-    def fasta = "${fasta_dir}/*${id}*.bgz"
+    def chain = "${chain_dir}/*${id}*.chain{,.gz,.bgz}"
+    def fasta = "${fasta_dir}/*${id}*.{fa,fasta}{,.gz,.bgz}"
     def out   = "${vcf.simpleName}_${id}.vcf"
   """
+  shopt -s nullglob # do not expand glob on non-matching files
   CrossMap vcf ${chain} ${vcf} ${fasta} ${out} 2> ${id}_report.txt
   """
 }


### PR DESCRIPTION
- Always run process to confirm the files were copied (avoids caching)
- Add/update CHECKSUMS
- Update time limit