### PR TITLE
Nextflow: print instructions if JVM memory is low

### DIFF
--- a/nextflow/EVAImport/main.nf
+++ b/nextflow/EVAImport/main.nf
@@ -164,6 +164,10 @@ log.info """
   ${command_to_run}
 """
 
+include { check_JVM_mem; print_summary } from '../utils/utils.nf'
+check_JVM_mem(min=0.4)
+print_summary()
+
 process run_eva {
   cpus "${params.fork}"
 
@@ -319,20 +323,4 @@ workflow {
   if(params.citations_file) {
     run_citations(run_variant_synonyms.out, file(citations_script), params.species, registry, file(params.citations_file))
   }
-}
-
-workflow.onComplete {
-  println ( workflow.success ? """
-    Workflow summary
-    ----------------
-    Completed at: ${workflow.complete}
-    Duration    : ${workflow.duration}
-    Success     : ${workflow.success}
-    workDir     : ${workflow.workDir}
-    exit status : ${workflow.exitStatus}
-    """ : """
-    Failed: ${workflow.errorReport}
-    exit status : ${workflow.exitStatus}
-    """
-  )
 }

--- a/nextflow/MaveDB/main.nf
+++ b/nextflow/MaveDB/main.nf
@@ -53,17 +53,10 @@ include { download_chain_files;
 include { concatenate_files;
           tabix } from './nf_modules/output.nf'
 
-log.info """
-  Create MaveDB plugin data for VEP
-  ---------------------------------
-  urn      : ${params.urn}
-  output   : ${params.output}
-  ensembl  : ${params.ensembl}
-  registry : ${params.registry}
-
-  licences : ${params.licences}
-  round    : ${params.round}
-  """
+include { check_JVM_mem; print_params; print_summary } from '../utils/utils.nf'
+print_params('Create MaveDB plugin data for VEP', nullable=['registry'])
+check_JVM_mem(min=50.4)
+print_summary()
 
 workflow {
   // filter MaveDB URNs based on file-specific licence
@@ -98,21 +91,4 @@ workflow {
                    collect { it.last() }
   concatenate_files( output_files )
   tabix( concatenate_files.out )
-}
-
-// Print summary
-workflow.onComplete {
-  println ( workflow.success ? """
-        Workflow summary
-        ----------------
-        Completed at: ${workflow.complete}
-        Duration    : ${workflow.duration}
-        Success     : ${workflow.success}
-        workDir     : ${workflow.workDir}
-        exit status : ${workflow.exitStatus}
-        """ : """
-        Failed: ${workflow.errorReport}
-        exit status : ${workflow.exitStatus}
-        """
-  )
 }

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -88,6 +88,10 @@ include { store_translation_mapping } from './nf_modules/database_utils.nf'
 include { run_sift_pipeline }         from './nf_modules/sift.nf'
 include { run_pph2_pipeline }         from './nf_modules/polyphen2.nf'
 
+include { check_JVM_mem; print_summary } from '../utils/utils.nf'
+check_JVM_mem(min=4)
+print_summary()
+
 // Check input data
 if (!params.translated) {
   if (!params.fasta && !params.gtf) {
@@ -184,21 +188,4 @@ workflow {
   // Run protein function prediction
   if ( params.sift_run_type != "NONE" ) run_sift_pipeline( translated )
   if ( params.pph_run_type  != "NONE" ) run_pph2_pipeline( translated )
-}
-
-// Print summary
-workflow.onComplete {
-    println ( workflow.success ? """
-        Workflow summary
-        ----------------
-        Completed at: ${workflow.complete}
-        Duration    : ${workflow.duration}
-        Success     : ${workflow.success}
-        workDir     : ${workflow.workDir}
-        exit status : ${workflow.exitStatus}
-        """ : """
-        Failed: ${workflow.errorReport}
-        exit status : ${workflow.exitStatus}
-        """
-    )
 }

--- a/nextflow/Remapping/main.nf
+++ b/nextflow/Remapping/main.nf
@@ -151,10 +151,11 @@ if (params.help) {
 
 include { crossmap; tabix; report } from './modules/crossmap.nf'
 include { copy_to_rapid_release_ftp } from './modules/copy.nf'
-include { print_params; print_summary } from '../utils/utils.nf'
 
-print_params(description=description, separator=separator,
+include { check_JVM_mem; print_params; print_summary } from '../utils/utils.nf'
+print_params(description,
              nullable=['rr_root', 'rr_path'])
+check_JVM_mem(min=0.4)
 print_summary()
 
 workflow {

--- a/nextflow/pangenomes/main.nf
+++ b/nextflow/pangenomes/main.nf
@@ -13,16 +13,6 @@ params.user    = null
 params.host    = null
 params.port    = null
 
-log.info "\nCreate GO and Phenotype annotations for pangenomes"
-log.info "=================================================="
-for (a in params) {
-  // print param
-  log.info "  ${a.getKey().padRight(8)} : ${a.getValue()}"
-  // raise error if param is null
-  if (!a.getValue()) exit 1, "ERROR: parameter --${a.getKey()} not defined"  
-}
-log.info ""
-
 include { fetch_gene_symbol_lookup;
           list_assemblies; 
           download_pangenomes_data } from './modules/download.nf'
@@ -32,6 +22,11 @@ include { create_latest_annotation;
           create_pangenomes_annotation } from './modules/annotation.nf'
 include { tabix_gtf; decompress_fasta } from './modules/utils.nf'
 include { test_annotation } from './modules/test.nf'
+
+include { check_JVM_mem; print_params; print_summary } from '../utils/utils.nf'
+print_params('Create GO and Phenotype annotations for pangenomes')
+check_JVM_mem(min=0.4)
+print_summary()
 
 workflow create_go_annotations {
   take:

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -1,20 +1,20 @@
 #!/usr/bin/env nextflow
 
-def print_params(description, separator="-"*description.length(), nullable=true,
-                 indent=4, params=params, sort=false, skip=['help']) {
+def print_params(description, nullable=[], sort=false, skip=['help'], 
+                 params=params, separator="-"*description.length(), indent=4) {
   /*
     Print script parameters
 
     @param description Short pipeline description
+    @param nullable    List of params allowed to be null; raises an error for
+                       null params that are not in this list (default: [])
+    @param sort        Boolean to sort params alphabetically (default: false)
+    @param skip        List of params not to print; if null, all params are
+                       printed (default: ['help'])
+    @param params      Map of params (default: script params)
     @param separator   Separator used between description and params
                        (default: '-' based on description length)
     @param indent      Number of spaces used to indent the message (default: 4)
-    @param params      Map of params (default: script params)
-    @param sort        Boolean to sort params alphabetically (default: false)
-    @param nullable    List of params allowed to be null; raises an error for
-                       null params that are not in this list (default: [])
-    @param skip        List of params not to print; if null, all params are
-                       printed (default: ['help'])
   */
   indent = " " * indent
   log.info "\n${indent}${description}\n${indent}${separator}"
@@ -58,5 +58,27 @@ def print_summary() {
     Exit status : ${workflow.exitStatus}
     """
     )
+  }
+}
+
+def check_JVM_mem (min=0.4) {
+  /*
+    Check memory available to the Java Virtual Machine (JVM) instance running
+    the Nextflow head node
+
+    Throws error if memory is lower than parameter min
+
+    @param min Min memory in GiB (default: 0.4)
+  */
+
+  mem = Runtime.getRuntime().maxMemory() / (1024 ** 3) // in GiB
+  if (mem < min) {
+    log.error """
+    ERROR: The memory of the Nextflow head node (${mem.round(2)} GiB) is below the recommended (${min} GiB); please try the following actions:
+      - Increase the JVM's max RAM percentage: export NXF_JVM_ARGS="-XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=75"
+      - Increase the JVM heap size memory: export NXF_OPTS="-Xms50m -Xmx${min}g"
+      - Increase the memory of the job used to run the Nextflow pipeline: salloc --time 6:00:00 --mem ${min * 4}GB
+    """.stripIndent()
+    exit 1
   }
 }

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -76,8 +76,8 @@ def check_JVM_mem (min=0.4) {
     log.error """
     ERROR: The memory of the Nextflow head node (${mem.round(2)} GiB) is below the recommended (${min} GiB); please try the following actions:
       - Increase the JVM's max RAM percentage: export NXF_JVM_ARGS="-XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=75"
-      - Increase the JVM heap size memory: export NXF_OPTS="-Xms50m -Xmx${min}g"
-      - Increase the memory of the job used to run the Nextflow pipeline: salloc --time 6:00:00 --mem ${min * 4}GB
+      - Increase the JVM heap size memory: export NXF_OPTS="-Xms50m -Xmx${min.round(0)}g"
+      - Increase the memory of the job used to run the Nextflow pipeline: salloc --time 6:00:00 --mem ${(min * 4).round(0)}GB
     """.stripIndent()
     exit 1
   }


### PR DESCRIPTION
* Throw error if memory used for Nextflow head node is lower than a minimum value
    - JVM memory is 1/4 of the SLURM job memory by default
    - The default minimum value of 0.4 GiB is a bit lower than 1/4 of a 2 GiB SLURM job
    - The error instructions show easy solutions for the issue
* Uniformise all pipelines to use common functions