### PR TITLE
Fix format checking for variant at start of a seq region

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VEP.pm
@@ -428,8 +428,8 @@ sub check_format {
     elsif (
         $line[0] =~ /(chr)?\w+/ &&
         $line[1] =~ /^\d+$/ &&
-        $line[3] && $line[3] =~ /^[ACGTN\-\.]+$/i &&
-        $line[4]
+        exists $line[3] && $line[3] =~ /^[ACGTN\-\.]+$/i &&
+        exists $line[4]
     ) {
         $format = 'vcf';
     }
@@ -438,8 +438,8 @@ sub check_format {
     elsif (
         $line[0] =~ /\w+/ &&
         $line[1] =~ /^\d+$/ &&
-        $line[2] && $line[2] =~ /^\d+$/ &&
-        $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
+        exists $line[2] && $line[2] =~ /^\d+$/ &&
+        exists $line[3] && $line[3] =~ /([a-z]{2,})|([ACGTN-]+\/[ACGTN-]+)/i
     ) {
         $format = 'ensembl';
     }


### PR DESCRIPTION
If we have a variant described at the start of a sequence it will fail for default VEP input format. For example, for a variant -

```
HSCHR15_4_CTG8	1	0	-/TC	+	var
```

The line `$line[2] && $line[2] =~ /^\d+$/ &&` will fail because the end position is `0` which is interpreted as False. We should use `exists` function instead to check if we have a field present.
