### PR TITLE
EVAImport pipeline: fix EVA source version, url and data types

### DIFF
--- a/nextflow/EVAImport/main.nf
+++ b/nextflow/EVAImport/main.nf
@@ -24,7 +24,7 @@ params.input_file      = ""
 input_file_tbi         = "${params.input_file}.tbi"
 params.source          = "EVA"
 params.description     = "Short variant data imported from EVA"
-params.version         = 4
+params.version         = null
 params.remove_prefix   = false
 params.chr_synonyms    = ""
 params.merge_all_types = true
@@ -130,6 +130,10 @@ if(!params.host || !params.dbname || !params.port || !params.user || !params.pas
 // Check input params
 if(!params.species) {
   exit 1, "ERROR: species name (--species) must be provided when running EVA import"
+}
+
+if(!params.version) {
+  exit 1, "ERROR: EVA version (--version) must be provided when running EVA import"
 }
 
 if(params.input_file == "" || !file(params.input_file).exists() || !file(input_file_tbi).exists()) {

--- a/nextflow/EVAImport/main.nf
+++ b/nextflow/EVAImport/main.nf
@@ -25,6 +25,9 @@ input_file_tbi         = "${params.input_file}.tbi"
 params.source          = "EVA"
 params.description     = "Short variant data imported from EVA"
 params.version         = null
+params.url             = 'https://www.ebi.ac.uk/eva/'
+params.data_types      = 'variation'
+
 params.remove_prefix   = false
 params.chr_synonyms    = ""
 params.merge_all_types = true
@@ -161,12 +164,22 @@ registry = file(params.registry)
 input_file = file(params.input_file)
 input_file_tbi = file(input_file_tbi)
 
-command_to_run = " -i ${input_file} --source ${params.source} --source_description '${params.description}' --version ${params.version} --registry ${registry} --species ${params.species} --skip_tables '${params.skip_tables}'"
+command_to_run = [
+  " -i ${input_file}",
+  params.source      ? "--source ${params.source}"                    : null,
+  params.description ? "--source_description '${params.description}'" : null,
+  params.version     ? "--version ${params.version}"                  : null,
+  params.url         ? "--url ${params.url}"                          : null,
+  params.data_types  ? "--data_types ${params.data_types}"            : null,
+  params.registry    ? "--registry ${params.registry}"                : null,
+  params.species     ? "--species ${params.species}"                  : null,
+  params.skip_tables ? "--skip_tables '${params.skip_tables}'"        : null
+].findAll { it != null }
 
-log.info """
-  Importing EVA data with the following parameters: \
-  ${command_to_run}
-"""
+log.info "\n  Importing EVA data with the following parameters:"
+log.info command_to_run.join("\n").indent(4)
+
+command_to_run = command_to_run.join(" ")
 
 process run_eva {
   cpus "${params.fork}"
@@ -203,6 +216,7 @@ process run_variant_synonyms {
   val wait
   path var_syn_script
   val source_name
+  val source_version
   val species
   path input_file
   path registry
@@ -213,22 +227,40 @@ process run_variant_synonyms {
   output: val 'ok'
   
   script:
-  
+  source_version_cmd = source_version ? "--source_version ${source_version}" : ""
+  cmd = """
+    perl ${var_syn_script} \\
+      --species ${species} \\
+      --data_file ${input_file} \\
+      --registry ${registry} \\
+      --source_name ${source_name} \\
+      ${source_version_cmd}
+  """
+
   if(species == "sus_scrofa")
-      """
-        perl ${var_syn_script} --source_name ${source_name} --species ${species} --data_file ${input_file} --registry ${registry}
-        perl ${var_syn_script} --source_name "pig_chip" --species ${species} --registry ${registry}
-      """
-  
+    """
+    ${cmd}
+    perl ${var_syn_script} \\
+      --source_name "pig_chip" \\
+      --species ${species} \\
+      --registry ${registry}
+    """
   else if(species == "rattus_norvegicus")
-      """
-        perl ${var_syn_script} --source_name ${source_name} --species ${species} --data_file ${input_file} --registry ${registry}
-        perl ${var_syn_script} --source_name "rat" --species ${species} --registry ${registry} --host ${host} --port ${port} --user 'ensro' --db_name $dbname
-      """
-  else 
-      """
-        perl ${var_syn_script} --source_name ${source_name} --species ${species} --data_file ${input_file} --registry ${registry}
-      """
+    """
+    ${cmd}
+    perl ${var_syn_script} \\
+      --source_name "rat" \\
+      --species ${species} \\
+      --registry ${registry} \\
+      --host ${host} \\
+      --port ${port} \\
+      --user 'ensro' \\
+      --db_name $dbname
+    """
+  else
+    """
+    ${cmd}
+    """
 }
 
 process run_variation_set {
@@ -309,7 +341,7 @@ workflow {
 
   run_eva(prepare_tables.out, file(eva_script), command_to_run, input_file, input_file_tbi, params.merge_all_types, params.fork, params.sort_vf, file(params.chr_synonyms), params.remove_prefix, params.skipped_variants_file)
 
-  run_variant_synonyms(run_eva.out, file(var_syn_script), params.source, params.species, file(params.var_syn_file), registry, params.old_host, params.old_port, params.old_dbname)
+  run_variant_synonyms(run_eva.out, file(var_syn_script), params.source, params.version, params.species, file(params.var_syn_file), registry, params.old_host, params.old_port, params.old_dbname)
 
   // check if the species starts with any of the keys in set_names, such as 'ovis_aries_rambouillet' matching 'ovis_aries'
   set_names_key = set_names.keySet().find{ params.species =~ /^${it}/ }

--- a/scripts/import/import_set_from_file.pl
+++ b/scripts/import/import_set_from_file.pl
@@ -6,6 +6,7 @@ use warnings;
 use DBI;
 use Getopt::Long;
 use Bio::EnsEMBL::Registry;
+use File::Spec;
 
 =head1 import_set_from_file.pl 
 
@@ -40,6 +41,7 @@ die "\n Usage: import_set_from_file.pl -load_file [rs list] -variation_set [shor
 my $done = load_done($done_file) if $done_file;
 
 my $registry = 'Bio::EnsEMBL::Registry';
+$registry_file = File::Spec->rel2abs($registry_file);
 $registry->load_all($registry_file);
 
 my $dba  = $registry->get_DBAdaptor($species, 'variation');

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -160,6 +160,8 @@ sub configure {
     'skip_tables=s',
     'add_tables=s',
     'version=i',
+    'url=s',
+    'data_types=s',
 
     'only_existing',
     'no_merge',
@@ -1645,11 +1647,13 @@ sub get_seq_region_ids{
 
 # gets source_id - retrieves if name already exists, otherwise inserts
 sub get_source_id{
-  my $config = shift;
-  my $dbVar  = $config->{dbVar};
-  my $source = $config->{source};
-  my $desc   = $config->{source_description};
+  my $config  = shift;
+  my $dbVar   = $config->{dbVar};
+  my $source  = $config->{source};
+  my $desc    = $config->{source_description};
   my $version = $config->{version};
+  my $url     = $config->{url};
+  my $types   = $config->{data_types};
 
   my $source_id;
 
@@ -1665,8 +1669,8 @@ sub get_source_id{
       debug($config, "(TEST) Writing source name $source to source table");
     }
     else {
-      $sth = $dbVar->prepare(qq{insert into source(name, version, description) values(?,?,?)});
-      $sth->execute($source, $version, $desc);
+      $sth = $dbVar->prepare(qq{insert into source(name, version, description, url, data_types) values(?,?,?,?,?)});
+      $sth->execute($source, $version, $desc, $url, $types);
       $sth->finish();
       $source_id = $dbVar->last_insert_id(undef, undef, qw(source source_id));
     }

--- a/scripts/import/import_vcf.pl
+++ b/scripts/import/import_vcf.pl
@@ -43,6 +43,7 @@ use Bio::EnsEMBL::Variation::SampleGenotype;
 # use this for remapping
 use Bio::EnsEMBL::SimpleFeature;
 
+use File::Spec;
 use Getopt::Long;
 use FileHandle;
 use Socket;
@@ -1311,6 +1312,7 @@ sub connect_to_dbs {
       $reg->load_registry_from_db(-host => $config->{host}, -port => $config->{port}, -user => $config->{user}, -pass => $config->{password});
     }
     else {
+      $config->{registry} = File::Spec->rel2abs( $config->{registry} );
       if(-e $config->{registry}) {
         $reg->load_all($config->{registry});
       }
@@ -1321,7 +1323,7 @@ sub connect_to_dbs {
 
     # connect to DB
     my $vdba = $reg->get_DBAdaptor($config->{species},'variation')
-      || usage( "Cannot find variation db for ".$config->{species}." in ".$config->{registry_file} );
+      || usage( "Cannot find variation db for ".$config->{species}." in ".$config->{registry} );
     $config->{dbVar} = $vdba->dbc->db_handle;
 
     debug($config, "Connected to database ", $vdba->dbc->dbname, " on ", $vdba->dbc->host, " as user ", $vdba->dbc->username);


### PR DESCRIPTION
## Changelog

* Fix version, url and data types when importing EVA data
	- Add new parameters `--url` and `--data_types`
	- Require `--version` as a mandatory, non-null parameter
* Avoid duplicate code
* Print command in a more readable format
* Fix wrong registry file used for `import_set_from_file.pl` and `import_vcf.pl`:
    - Support relative registry file paths

## Testing

Run the pipeline with new options `--version`, `--url` and `--data_types` and check if the EVA information in the `source` table seems okay.

Please ask me for data to test the pipeline with.