### PR TITLE
Fix some population url for public docs

### DIFF
--- a/scripts/docs/generate_population_table.pl
+++ b/scripts/docs/generate_population_table.pl
@@ -96,7 +96,7 @@ my %project_urls = (
   'Gambian Genome Variation Project' => 'https://www.internationalgenome.org/data-portal/data-collection/ggvp-grch38',
   'NCBI ALFA'       => 'https://www.ncbi.nlm.nih.gov/snp/docs/gsr/alfa/',
   'GEM-J'           => 'https://grch38.togovar.org/doc/datasets/gem_j_wga/',
-  'NHLBI Exome Sequencing Project' => 'https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000403.v3.p3/',
+  'NHLBI Exome Sequencing Project' => 'https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000403.v3.p3',
   'ISGC'            => 'http://www.sheephapmap.org/'
 );
 

--- a/scripts/docs/generate_population_table.pl
+++ b/scripts/docs/generate_population_table.pl
@@ -95,8 +95,8 @@ my %project_urls = (
   'EVA'             => 'https://www.ebi.ac.uk/eva/?eva-study=###ID###',
   'Gambian Genome Variation Project' => 'https://www.internationalgenome.org/data-portal/data-collection/ggvp-grch38',
   'NCBI ALFA'       => 'https://www.ncbi.nlm.nih.gov/snp/docs/gsr/alfa/',
-  'GEM-J'           => 'https://togovar.biosciencedbc.jp/doc/datasets/gem_j_wga',
-  'NHLBI Exome Sequencing Project' => 'https://evs.gs.washington.edu/EVS/',
+  'GEM-J'           => 'https://grch38.togovar.org/doc/datasets/gem_j_wga/',
+  'NHLBI Exome Sequencing Project' => 'https://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000403.v3.p3/',
   'ISGC'            => 'http://www.sheephapmap.org/'
 );
 


### PR DESCRIPTION
Updating broken population url with working ones. They are used on the public documentations.