### PR TITLE
Fix using breakend with regulatory/motif features

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -351,15 +351,17 @@ sub feature_truncation {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
     $bvf  ||= $bvfoa->base_variation_feature;
     $feat ||= $bvfoa->base_variation_feature_overlap->feature;
-    
+
     return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele');
     
     if(chromosome_breakpoint(@_)) {
         return 1 if within_feature($bvfoa, $feat, $bvfo, $bvfoa->breakend, 1);
     }
 
+    # require transcripts (but not other feature types) to be within cDNA
+    return 0 if $feat->isa('Bio::EnsEMBL::Transcript') and not within_cdna(@_);
+
     return (
-        within_cdna(@_) and
         (
             partial_overlap_feature($bvfoa, $feat, $bvfo, $bvf) or
             complete_within_feature($bvfoa, $feat, $bvfo, $bvf)


### PR DESCRIPTION
ENSVAR-6388: fixes https://github.com/Ensembl/ensembl-vep/issues/1694

When checking for feature truncation, avoid checking if Regulatory/Motif features are within cDNA (this will simply error out because cDNA coordinates are only available for transcript features).

## Testing

Run VEP with breakends and the `--regulatory` flag:

```
./vep -i bnd.vcf --database --regulatory
```

Example breakends:
```
chr21   46184504        MantaBND:524924:1:2:0:0:0:0     A       ]chr21:46184710]TACTCAGGA       159     PASS    SVTYPE=BND;SVINSSEQ=TACTCAGG;SVINSLEN=8;BND_DEPTH=356;OriginalId=chr21&46184504&A&]chr21:46184710]TACTCAGGA&665;MATE_BND_DEPTH=341;MATEID=MantaBND:524924:1:2:0:0:0:1;SVOAI=0   GT:FT:GQ:PL:PR:SR:DQ:DN 0/1:PASS:139:189,0,811:15,0:57,13:0:.   0/1:PASS:20:70,0,999:27,0:79,16:.:.     0/0:HomRef:224:0,174,999:18,0:101,14:.:.
chr21   46184710        MantaBND:524924:1:2:0:0:0:1     G       GTACTCAGG[chr21:46184504[       159     PASS    SVTYPE=BND;SVINSSEQ=TACTCAGG;SVINSLEN=8;BND_DEPTH=341;OriginalId=chr21&46184710&G&GTACTCAGG[chr21:46184504[&666;MATE_BND_DEPTH=356;MATEID=MantaBND:524924:1:2:0:0:0:0;SVOAI=0   GT:FT:GQ:PL:PR:SR:DQ:DN 0/1:PASS:139:189,0,811:15,0:57,13:0:.   0/1:PASS:20:70,0,999:27,0:79,16:.:.     0/0:HomRef:224:0,174,999:18,0:101,14:.:.
```