### PR TITLE
Fix hgvsg for insertion with ref allele `-`

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1967,7 +1967,7 @@ sub hgvs_genomic {
     if ($is_multi_allelic) {
       # fix for multi-allelic variants
       my $old_chr_start = $chr_start;
-      ($ref_allele, $allele, $chr_start, $chr_end) = @{trim_sequences($original_ref_allele, $allele, $chr_start)};
+      ($ref_allele, $allele, $chr_start, $chr_end) = @{trim_sequences($original_ref_allele, $allele, $chr_start, $chr_end)};
       $allele ||= '-';
       $offset = $chr_start - $old_chr_start;
       $ref_start = $original_ref_start + $offset;

--- a/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
+++ b/modules/Bio/EnsEMBL/Variation/VariationFeature.pm
@@ -1929,7 +1929,7 @@ sub hgvs_genomic {
   my @all_alleles = split(/\//,$tr_vf->allele_string());
   my $ref_allele = shift @all_alleles;  ## remove reference allele - not useful for HGVS
   my $original_ref_allele = $ref_allele;
-  my $original_ref_start  = $ref_start;
+  my ($original_ref_start, $original_ref_end)  = ($ref_start, $ref_end);
 
   my $is_multi_allelic = scalar @all_alleles > 1;
   foreach my $original_allele ( @all_alleles ) {
@@ -1966,11 +1966,12 @@ sub hgvs_genomic {
 
     if ($is_multi_allelic) {
       # fix for multi-allelic variants
-      my $old_chr_start = $chr_start;
+      my ($old_chr_start, $old_chr_end) = ($chr_start, $chr_end);
       ($ref_allele, $allele, $chr_start, $chr_end) = @{trim_sequences($original_ref_allele, $allele, $chr_start, $chr_end)};
       $allele ||= '-';
-      $offset = $chr_start - $old_chr_start;
-      $ref_start = $original_ref_start + $offset;
+
+      $ref_start = $original_ref_start + ($chr_start - $old_chr_start);
+      $ref_end = $original_ref_end + ($chr_end - $old_chr_end);
       $ref_allele ||= '-';
     }
     my $var_class  =  $self->var_allele_class($ref_allele . '/' . $allele);


### PR DESCRIPTION
### Problem

Here https://github.com/Ensembl/ensembl-variation/pull/1077 we have fixed hgvsg for multi-allelic variant. But it introduced a bug for insertion types.

We are not sending the end position during trimming -
https://github.com/nuno-agostinho/ensembl-variation/blob/3ed1013c5bfacb2416db9e67d50cb96fb2fcb0b6/modules/Bio/EnsEMBL/Variation/VariationFeature.pm#L1970

What it does for insertion is that it increase the end position by `length of reference sequence -1` - 
https://github.com/nuno-agostinho/ensembl-variation/blob/3ed1013c5bfacb2416db9e67d50cb96fb2fcb0b6/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm#L970

This becomes problematic if the `length of reference sequence -1` is not the same as `end - start` and there is no trimming happening so that position sticks around. This happen only in the case when we have `-` in ref allele for insertion. 

The end result is different position in slice and sub slice -
https://github.com/nuno-agostinho/ensembl-variation/blob/3ed1013c5bfacb2416db9e67d50cb96fb2fcb0b6/modules/Bio/EnsEMBL/Variation/VariationFeature.pm#L2016-L2019

and, terminating in a error here -
https://github.com/nuno-agostinho/ensembl-variation/blob/3ed1013c5bfacb2416db9e67d50cb96fb2fcb0b6/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm#L511

### Fix
- Simply provide end position so `trim_sequences` do not try to calculate it.
- And, update the `ref_end` position. Otherwise it will fail in trim on reverse direction.

### Test:

```
chr8 143694491 143694490 -/TT/TTT +
chr8 143694491 143694490 -/GG/GGG +
chr8 143694490 143694492 GTT/GT/T + (trim on reverse direction)
```