### PR TITLE
HGVSc for RefSeq transcripts - represent the alleles relative to the feature

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -1439,8 +1439,8 @@ sub hgvs_transcript {
 
   if(scalar @edit_attrs > 0) {
     my $ref = $tv->get_reference_TranscriptVariationAllele;
-    $hgvs_notation->{ref} = $ref->variation_feature_seq;
-    $hgvs_notation->{alt} = $self->variation_feature_seq;
+    $hgvs_notation->{ref} = $ref->feature_seq; # ref allele relative to the feature (transcript)
+    $hgvs_notation->{alt} = $self->feature_seq; # alt allele relative to the feature (transcript)
   }
 
   my $misalignment_offset = 0;


### PR DESCRIPTION
In this PR https://github.com/Ensembl/ensembl-variation/pull/1103/files the HGVSc was updated to reflect the alleles used in the annotation after a refseq editing. 
Original ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-4493

This PR fixes the alleles to be represented relative to the transcript.
It also fixes one of the issues reported here https://github.com/Ensembl/ensembl-vep/issues/1775