### PR TITLE
optimising for human

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -258,7 +258,7 @@ sub pipeline_analyses {
               include_lrg => $self->o('include_lrg'),
               @common_params,
             },
-            -rc_name   => 'default',
+            -rc_name   => 'default_long',
             -flow_into => {
               1 => ['gene_factory'],
               2 => ['rebuild_tv_indexes'],
@@ -325,9 +325,9 @@ sub pipeline_analyses {
           },
           { -logic_name => 'by_gene_transcript_effect',
             -module => 'Bio::EnsEMBL::Variation::Pipeline::TranscriptEffect',
-            -hive_capacity  => 50,
+            -hive_capacity  => 100,
             -max_retry_count => 1,
-            -analysis_capacity  => 50,
+            -analysis_capacity  => 100,
             -parameters => {
               mtmp_table => $self->o('mtmp_table'),
               fasta => $self->o('fasta'),


### PR DESCRIPTION
I've manually set these in eHive for running the pipeline in 113 and 114 with no problems.

It should not have an impact (other than speeding up) for other species, but I would recommend to test it out on mouse and confirm the transcript variation / variation feature tables are generated as expected (compare to a handed over DB).