### PR TITLE
Fix method codon() in TranscriptVariationAllele

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -868,7 +868,9 @@ sub codon {
     $cds = ( $self->{is_reference} ? $tv->_translateable_seq() : $cds_obj->seq() );
 
     # modifies the $cds at the specific positions
-    if($self->{is_reference}) {
+    # this is necessary for RefSeq transcripts that have edited alleles
+    # these transcripts are flagged with 'invalid_alleles'
+    if($self->{is_reference} && $self->{invalid_alleles}) {
       substr($cds, $tv->cds_start(undef, $tr->strand * $shifting_offset) -1, $vf_nt_len) = $seq;
     }
 

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -674,7 +674,7 @@ sub display_codon_allele_string {
     $ref_tva->{shift_hash} = $self->{shift_hash};
     
     my $ref_display_codon = $ref_tva->display_codon;
-    
+
     return undef unless $ref_display_codon;
     
     return $ref_display_codon.'/'.$display_codon;
@@ -866,6 +866,11 @@ sub codon {
     my $cds_obj = $self->_get_alternate_cds();
     return undef unless defined($cds_obj);
     $cds = ( $self->{is_reference} ? $tv->_translateable_seq() : $cds_obj->seq() );
+
+    # modifies the $cds at the specific positions
+    if($self->{is_reference}) {
+      substr($cds, $tv->cds_start(undef, $tr->strand * $shifting_offset) -1, $vf_nt_len) = $seq;
+    }
 
     # and extract the codon sequence
     my $codon = ( $self->{is_reference} ? substr($cds, $codon_cds_start-1, $codon_len ) : substr($cds, $codon_cds_start-1, $codon_len + ($allele_len - $vf_nt_len)));

--- a/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
+++ b/modules/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm
@@ -868,9 +868,8 @@ sub codon {
     $cds = ( $self->{is_reference} ? $tv->_translateable_seq() : $cds_obj->seq() );
 
     # modifies the $cds at the specific positions
-    # this is necessary for RefSeq transcripts that have edited alleles
-    # these transcripts are flagged with 'invalid_alleles'
-    if($self->{is_reference} && $self->{invalid_alleles}) {
+    # this is necessary for RefSeq transcripts that have edited alleles saved in @edit_attrs
+    if($self->{is_reference} && scalar @edit_attrs > 0) {
       substr($cds, $tv->cds_start(undef, $tr->strand * $shifting_offset) -1, $vf_nt_len) = $seq;
     }
 


### PR DESCRIPTION
The method to calculate the codon was updated in release 113 -[ check this PR](https://github.com/Ensembl/ensembl-variation/pull/1067/files).
After this update, the `Codons` and `Consequence` are wrong for some RefSeq transcripts.
Check ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6640

The line `substr($cds, $tv->cds_start(undef, $tr->strand * $shifting_offset) -1, $vf_nt_len) = $seq;` has been removed from the method but it is important for these RefSeq transcripts.
This code edits the `$cds` at the specific position start and end ($tv->cds_start(undef, $tr->strand * $shifting_offset) -1, $vf_nt_len). It replaces the allele by $seq. 

This code update should be cherry-picked to 113. 
It should fix the following issues:
https://github.com/Ensembl/ensembl-vep/issues/1775
https://github.com/Ensembl/ensembl-vep/issues/1787
https://github.com/Ensembl/ensembl-vep/issues/1793