### PR TITLE
Update transcript variation pipeline - remove ehive version

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
+++ b/modules/Bio/EnsEMBL/Variation/Pipeline/VariationConsequence_conf.pm
@@ -32,7 +32,6 @@ package Bio::EnsEMBL::Variation::Pipeline::VariationConsequence_conf;
 
 use strict;
 use warnings;
-use Bio::EnsEMBL::Hive::Version 2.6;
 use Bio::EnsEMBL::Hive::PipeConfig::HiveGeneric_conf;
 use base ('Bio::EnsEMBL::Hive::PipeConfig::EnsemblGeneric_conf');
 


### PR DESCRIPTION
It was announced the 2.6 branch doesn't have Slurm support (officially) and is now behind.
The new version start at 2.7.0