### PR TITLE
Remove XML::Hash::XS from cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,5 @@ requires 'JSON';
 requires 'Sereal';
 requires 'Set::IntervalTree';
 requires 'String::Approx';
-requires 'XML::Hash::XS';
 requires 'XML::LibXML::Reader';
 requires 'Date::Manip::Date';


### PR DESCRIPTION
`XML::Hash::XS` breaks the tests for perl 5.14
As this package is only used by the ClinVar import we can temporarily remove it from cpanfile. Later we'll find another package to import XML and/or remove 5.14 from the tests.