### PR TITLE
Nextflow ProteinFunction: support for SQLite db

### DIFF
--- a/nextflow/ProteinFunction/bin/capture_expected_errors.sh
+++ b/nextflow/ProteinFunction/bin/capture_expected_errors.sh
@@ -18,6 +18,12 @@ elif [ "${category}" == "pph2" ]; then
   errors=("Failed to locate sequence position")
 fi
 
+# catch memory error
+mem_error="Some of the step tasks have been OOM Killed."
+if grep -q "${mem_error}" ${stderr_file}; then
+  exit 140
+fi
+
 # Capture expected errors
 for error in "${errors[@]}"; do
   if grep -q "${error}" ${stderr_file}; then

--- a/nextflow/ProteinFunction/bin/store_polyphen_scores.pl
+++ b/nextflow/ProteinFunction/bin/store_polyphen_scores.pl
@@ -6,6 +6,7 @@ use Bio::EnsEMBL::Variation::ProteinFunctionPredictionMatrix;
 use Digest::MD5 qw(md5_hex);
 
 my ($species, $port, $host, $user, $pass, $dbname,
+    $offline, $sqlite,
     $peptide, $output_file, $model) = @ARGV;
 
 # Extract model name
@@ -63,25 +64,34 @@ while (<RESULT>) {
 
 # save the predictions to the database unless they are null matrices
 if ( $any_results ){
-  my $var_dba = Bio::EnsEMBL::Variation::DBSQL::DBAdaptor->new(
-      '-species' => $species,
-      '-port'    => $port,
-      '-host'    => $host,
-      '-user'    => $user,
-      '-pass'    => $pass,
-      '-dbname'  => $dbname
-    );
-  my $pfpma = $var_dba->get_ProteinFunctionPredictionMatrixAdaptor
-      or die "Failed to get matrix adaptor";
-
-  # check if identical predictions are already stored                           
-  my $data = $pfpma->fetch_polyphen_predictions_by_translation_md5($md5, $model_name);
-  if (defined $data && defined $data->{matrix} && $data->{matrix} eq $pred_matrix->serialize) {
-    warn "Skipping: identical PolyPhen-2 predictions already stored in database\n"
-  } else {
-    $pfpma->store($pred_matrix);
+  if (!$offline){
+    my $var_dba = Bio::EnsEMBL::Variation::DBSQL::DBAdaptor->new(
+        '-species' => $species,
+        '-port'    => $port,
+        '-host'    => $host,
+        '-user'    => $user,
+        '-pass'    => $pass,
+        '-dbname'  => $dbname
+      );
+    my $pfpma = $var_dba->get_ProteinFunctionPredictionMatrixAdaptor
+        or die "Failed to get matrix adaptor";
+    # check if identical predictions are already stored                           
+    my $data = $pfpma->fetch_polyphen_predictions_by_translation_md5($md5, $model_name);
+    if (defined $data && defined $data->{matrix} && $data->{matrix} eq $pred_matrix->serialize) {
+      warn "Skipping: identical PolyPhen-2 predictions already stored in database\n"
+    } else {
+      $pfpma->store($pred_matrix);
+    }
+    $var_dba->dbc and $var_dba->dbc->disconnect_if_idle();
   }
-  $var_dba->dbc and $var_dba->dbc->disconnect_if_idle();
+
+  if ($sqlite){
+    my $dbh = DBI->connect("dbi:SQLite:dbname=$db","","");
+    my $sth = $dbh->prepare("INSERT INTO predictions VALUES(?, ?, ?)");
+
+    my $attrib_id = $model_name eq "humdiv" ? 269 : 268;
+    $sth->execute($pred_matrix->translation_md5, $attrib_id, $pred_matrix->serialize)
+  }
 } else {
   warn "Skipping: no PolyPhen-2 predictions to store\n";
 }

--- a/nextflow/ProteinFunction/bin/store_polyphen_scores.pl
+++ b/nextflow/ProteinFunction/bin/store_polyphen_scores.pl
@@ -5,8 +5,8 @@ use Bio::EnsEMBL::Variation::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Variation::ProteinFunctionPredictionMatrix;
 use Digest::MD5 qw(md5_hex);
 
-my ($species, $port, $host, $user, $pass, $dbname,
-    $offline, $sqlite,
+my ($species, $offline, $sqlite,
+    $port, $host, $user, $pass, $dbname,
     $peptide, $output_file, $model) = @ARGV;
 
 # Extract model name
@@ -86,7 +86,7 @@ if ( $any_results ){
   }
 
   if ($sqlite){
-    my $dbh = DBI->connect("dbi:SQLite:dbname=$db","","");
+    my $dbh = DBI->connect("dbi:SQLite:dbname=$sqlite","","");
     my $sth = $dbh->prepare("INSERT INTO predictions VALUES(?, ?, ?)");
 
     my $attrib_id = $model_name eq "humdiv" ? 269 : 268;

--- a/nextflow/ProteinFunction/bin/store_sift_scores.pl
+++ b/nextflow/ProteinFunction/bin/store_sift_scores.pl
@@ -5,8 +5,8 @@ use Bio::EnsEMBL::Variation::DBSQL::DBAdaptor;
 use Bio::EnsEMBL::Variation::ProteinFunctionPredictionMatrix;
 use Digest::MD5 qw(md5_hex);
 
-my ($species, $port, $host, $user, $pass, $dbname,
-    $offline, $sqlite,
+my ($species, $offline, $sqlite,
+    $port, $host, $user, $pass, $dbname,
     $peptide, $res_file) = @ARGV;
 
 # parse the results file
@@ -73,7 +73,7 @@ if ($results_available == 1 ){
   }
 
   if ($sqlite){
-    my $dbh = DBI->connect("dbi:SQLite:dbname=$db","","");
+    my $dbh = DBI->connect("dbi:SQLite:dbname=$sqlite","","");
     my $sth = $dbh->prepare("INSERT INTO predictions VALUES(?, ?, ?)");
     $sth->execute($pred_matrix->translation_md5, 267, $pred_matrix->serialize)
   }

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -230,20 +230,15 @@ workflow {
   errors = Channel.of("# failure reasons")
 
   if ( params.sift_run_type != "NONE" ) {
-    sift_errors = run_sift_pipeline( translated, sqlite_db_prep ).errors
-    errors = errors.concat(sift_errors)
-  } else {
-    sift_errors = "none"
+    errors = errors.concat(run_sift_pipeline( translated, sqlite_db_prep ).errors)
   }
+
   if ( params.pph_run_type  != "NONE" ) {
-    pph_errors = run_pph2_pipeline( translated, sqlite_db_prep ).errors
-    errors = errors.concat(pph_errors)
-  } else {
-    pph_errors = "none"
+    errors = errors.concat(run_pph2_pipeline( translated, sqlite_db_prep ).errors)
   }
 
   if ( params.sqlite ) {
-    postprocess_sqlite_db(sift_errors.collect(), pph_errors.collect())
+    postprocess_sqlite_db(errors.collect())
   }
 
   errors

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -58,12 +58,19 @@ if (params.help) {
     --species VAL        Latin species name (default: homo_sapiens);
                          PolyPhen-2 only works for human
 
-  Database options (mandatory):
+  Database options:
+    Ensembl variation database params -
     --host VAL           Server host
     --port VAL           Server port
     --user VAL           Server user
     --pass VAL           Server password
     --database VAL       Name of database
+    --offline            No database connection to variation database
+
+    SQLite database params -
+    --sqlite             0 or 1, tells whether to create SQLite database (default: params.offline)
+    --sqlite_dir         Directory where SQLite db would be created (default: params.outdir)
+    --sqlite_db          Full path to SQLite db (--sqlite_dir would be ignored)
 
   SIFT options:
     --sift_run_type VAL  SIFT run type:

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -230,18 +230,20 @@ workflow {
   errors = Channel.of("# failure reasons")
 
   if ( params.sift_run_type != "NONE" ) {
-    errors = errors.concat(run_sift_pipeline( translated, sqlite_db_prep ))
+    sift_errors = run_sift_pipeline( translated, sqlite_db_prep ).errors
+    errors = errors.concat(sift_errors)
   } else {
-    sift_run = "done"
+    sift_errors = "none"
   }
   if ( params.pph_run_type  != "NONE" ) {
-    errors = errors.concat(run_pph2_pipeline( translated, sqlite_db_prep ))
+    pph_errors = run_pph2_pipeline( translated, sqlite_db_prep ).errors
+    errors = errors.concat(pph_errors)
   } else {
-    polyphen_run = "done"
+    pph_errors = "none"
   }
 
   if ( params.sqlite ) {
-    postprocess_sqlite_db(sift_run, polyphen_run)
+    postprocess_sqlite_db(sift_errors.collect(), pph_errors.collect())
   }
 
   errors

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -204,7 +204,7 @@ workflow {
                               md5: it.seqString.replaceAll(/\*/, "").md5() ]}
 
   // Write translation mapping with transcript ID and MD5 hashes to database
-  if ( params.sift_run_type == "FULL" && params.pph_run_type == "FULL" ) {
+  if ( !params.offline && params.sift_run_type == "FULL" && params.pph_run_type == "FULL" ) {
     drop_translation_mapping()
     translation_mapping_wait = drop_translation_mapping.out
     clear_assemblies()

--- a/nextflow/ProteinFunction/main.nf
+++ b/nextflow/ProteinFunction/main.nf
@@ -224,14 +224,12 @@ workflow {
 
   if ( params.sift_run_type != "NONE" ) {
     errors = errors.concat(run_sift_pipeline( translated, sqlite_db_prep ))
-  }
-  else {
+  } else {
     sift_run = "done"
   }
   if ( params.pph_run_type  != "NONE" ) {
     errors = errors.concat(run_pph2_pipeline( translated, sqlite_db_prep ))
-  }
-  else {
+  } else {
     polyphen_run = "done"
   }
 

--- a/nextflow/ProteinFunction/nf_modules/database.nf
+++ b/nextflow/ProteinFunction/nf_modules/database.nf
@@ -158,8 +158,8 @@ process init_sqlite_db {
 
 process postprocess_sqlite_db {
   input:
-    val sift_run
-    val polyphen_run
+    val sift_errors
+    val pph_errors
 
   output: stdout
 

--- a/nextflow/ProteinFunction/nf_modules/database.nf
+++ b/nextflow/ProteinFunction/nf_modules/database.nf
@@ -158,8 +158,7 @@ process init_sqlite_db {
 
 process postprocess_sqlite_db {
   input:
-    val sift_errors
-    val pph_errors
+    val errors
 
   output: stdout
 

--- a/nextflow/ProteinFunction/nf_modules/database.nf
+++ b/nextflow/ProteinFunction/nf_modules/database.nf
@@ -147,22 +147,30 @@ process init_sqlite_db {
 
   """
   #!/usr/bin/perl
-  my $dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
 
-  $dbh->do("DROP TABLE IF EXISTS predictions");
-  $dbh->do("CREATE TABLE predictions(md5, analysis, matrix)");
+  use DBI;
+  
+  my \$dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
+  \$dbh->do("DROP TABLE IF EXISTS predictions");
+  \$dbh->do("CREATE TABLE predictions(md5, analysis, matrix)");
   """
 }
 
 process postprocess_sqlite_db {
+  input:
+    val sift_run
+    val polyphen_run
+
   output: stdout
 
   cache false
 
   """
   #!/usr/bin/perl
-  my $dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
+  
+  use DBI;
 
-  $dbh->do("CREATE INDEX md5_idx ON predictions(md5)");
+  my \$dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
+  \$dbh->do("CREATE INDEX md5_idx ON predictions(md5)");
   """
 }

--- a/nextflow/ProteinFunction/nf_modules/database.nf
+++ b/nextflow/ProteinFunction/nf_modules/database.nf
@@ -139,3 +139,30 @@ process get_current_MD5_translations {
   EOF
   """
 }
+
+process init_sqlite_db {
+  output: stdout
+
+  cache false
+
+  """
+  #!/usr/bin/perl
+  my $dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
+
+  $dbh->do("DROP TABLE IF EXISTS predictions");
+  $dbh->do("CREATE TABLE predictions(md5, analysis, matrix)");
+  """
+}
+
+process postprocess_sqlite_db {
+  output: stdout
+
+  cache false
+
+  """
+  #!/usr/bin/perl
+  my $dbh = DBI->connect("dbi:SQLite:dbname=${params.sqlite_db}","","");
+
+  $dbh->do("CREATE INDEX md5_idx ON predictions(md5)");
+  """
+}

--- a/nextflow/ProteinFunction/nf_modules/polyphen2.nf
+++ b/nextflow/ProteinFunction/nf_modules/polyphen2.nf
@@ -106,6 +106,9 @@ process store_pph2_scores {
     val species
     tuple val(peptide), path(weka_output), val(model)
 
+  output:
+    stdout
+
   """
   store_polyphen_scores.pl ${species} ${params.offline} ${params.sqlite_db} \
                            ${params.port} ${params.host} ${params.user} ${params.pass} ${params.database} \
@@ -130,6 +133,8 @@ workflow run_pph2_pipeline {
     wait = delete_prediction_data.out
     get_pph2_version()
     update_meta("polyphen_version", get_pph2_version.out)
+  } else {
+    wait = "ready"
   }
   // Run PolyPhen-2 and Weka
   pph2 = run_pph2_on_all_aminoacid_substitutions(translated)

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -127,8 +127,8 @@ process store_sift_scores {
     tuple val(peptide), path(sift_scores)
 
   """
-  store_sift_scores.pl ${species} ${params.port} ${params.host} \
-                       ${params.user} ${params.pass} ${params.database} \
+  store_sift_scores.pl ${species} ${params.offline} ${params.sqlite_db} \
+                       ${params.port} ${params.host} ${params.user} ${params.pass} ${params.database} \
                        ${peptide.seqString} ${sift_scores}
   """
 }
@@ -150,12 +150,14 @@ workflow update_sift_db_version {
 }
 
 workflow run_sift_pipeline {
-  take: translated
+  take: 
+    translated
+    sqlite_db_prep
   main:
-    if ( params.sift_run_type == "UPDATE" ) {
+    if ( params.sift_run_type == "UPDATE" && !params.offline ) {
       translated = filter_existing_translations( "sift", translated )
       wait = "ready"
-    } else if ( params.sift_run_type == "FULL" ) {
+    } else if ( params.sift_run_type == "FULL" && !params.offline ) {
       delete_prediction_data("sift")
       wait = delete_prediction_data.out
       update_sift_version()

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -89,9 +89,12 @@ process run_sift_on_all_aminoacid_substitutions {
   container "ensemblorg/sift:6.2.1"
   publishDir "${params.outdir}/sift"
 
-  memory { peptide.size() * 40.MB + 4.GB }
-  errorStrategy 'ignore'
-  maxRetries 1
+  memory { 
+    mem = (peptide.seqString.size() * task.attempt * 4.MB + 4.GB)
+    mem < 50.GB ? mem : 50.GB 
+  }
+  errorStrategy { (task.exitStatus == 140 && task.attempt <= maxRetries ) ? 'retry' : 'ignore' }
+  maxRetries 2
 
   input:
     tuple val(peptide), path(aln)

--- a/nextflow/ProteinFunction/nf_modules/sift.nf
+++ b/nextflow/ProteinFunction/nf_modules/sift.nf
@@ -126,6 +126,9 @@ process store_sift_scores {
     val species
     tuple val(peptide), path(sift_scores)
 
+  output:
+    stdout
+
   """
   store_sift_scores.pl ${species} ${params.offline} ${params.sqlite_db} \
                        ${params.port} ${params.host} ${params.user} ${params.pass} ${params.database} \
@@ -162,6 +165,8 @@ workflow run_sift_pipeline {
       wait = delete_prediction_data.out
       update_sift_version()
       update_sift_db_version( file(params.blastdb) )
+    } else {
+      wait = "ready"
     }
     // Align translated sequences against BLAST database to run SIFT
     blast = align_peptides(translated,

--- a/nextflow/utils/utils.nf
+++ b/nextflow/utils/utils.nf
@@ -71,6 +71,8 @@ def check_JVM_mem (min=0.4) {
     @param min Min memory in GiB (default: 0.4)
   */
 
+  // converts min to float to avoid error while rounding
+  min = min / 10.0 * 10.0
   mem = Runtime.getRuntime().maxMemory() / (1024 ** 3) // in GiB
   if (mem < min) {
     log.error """


### PR DESCRIPTION
[ENSVAR-6567](https://www.ebi.ac.uk/panda/jira/browse/ENSVAR-6567)

Extend ProteinFunction nextflow pipeline to be able to write to a SQLite db. It introduces the following params - 

`params.offline` - if set, no ensembl database connection would be made (and not storing data in MySQL db)
`params.sqlite` - if set, a SQLite db would be created with the results. (if params.offline is set params.sqlite is automatically set too, otherwise there would be no output)
`params.sqlite_dir` - directory location where sqlite db should be stored. By default it is the `param.outdir`. The db name is set to `${params.species}_PolyPhen_SIFT.db`
`params.sqlite_db` - give full path of the SQLite db with name. Alternative way to give db name.

### Test:

Nextflow command -
```
nextflow run $ENSEMBL_ROOT_DIR/ensembl-variation/nextflow/ProteinFunction \
-profile $profile \
--sift_run_type FULL \
--outdir $PWD/temp \
--species felis_catus \
--offline 1 \
--gtf <gtf file>
--fasta <fasta file>
```

Test the generated SQLite db ($PWD/temp/felis_catus_PolyPhen_SIFT.db) against what we have in Ensembl database.

<details>
<summary><b>Test script</b></summary>

```perl

use DBI;
use Data::Dumper;
use Bio::EnsEMBL::Variation::ProteinFunctionPredictionMatrix;
use Bio::EnsEMBL::Registry;

$sqlite_db = "/some/path/felis_catus_PolyPhen_SIFT.db";

my $dbh = DBI->connect("dbi:SQLite:dbname=$sqlite_db","","");

my $registry = 'Bio::EnsEMBL::Registry';
$registry->load_registry_from_db(
    -host => 'HOST',
    -user => 'USER',
    -port => PORT,
    -pass => '',
    -db_version   => 110
);
$registry->add_alias('felis_catus', 'cat');

my $vdb = $registry->get_DBAdaptor('cat', 'variation');
my $pfpma = $vdb->get_ProteinFunctionPredictionMatrixAdaptor();

my $ITER = 5;
my $sth = $dbh->prepare("SELECT * from predictions LIMIT $ITER;");
$sth->execute();

foreach my $iter (1..$ITER) { 
    my $row = $sth->fetch();
    my $pfpm = Bio::EnsEMBL::Variation::ProteinFunctionPredictionMatrix->new(
        -analysis     => 'sift',
        -matrix       => $row->[2],
    );

    my $pfpm_test = $pfpma->fetch_sift_predictions_by_translation_md5($row->[0]);


    my $AAs = ['A', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'V', 'W', 'Y'];
    my $times = 0;
    my $POS = scalar keys $pfpm->deserialize;
    foreach my $aa (@{ $AAs }) {
        foreach my $pos (1..$POS) {
            my ($pred, $score) = $pfpm->prediction_from_matrix($pos, $aa);
            my ($pred_test, $score_test) = $pfpm_test->prediction_from_matrix($pos, $aa);

            if ($pred ne $pred_test && $score ne $score_test) {
                my $pred_match = $pred eq $pred_test ? "pred_match" : "pred_nomatch";
                print "$pos - $aa; $pred_match ; ", $score - $score_test, "\n";
            }
        }
    }
}
```

</details>