### PR TITLE
Update trim_sequences in utils - add parameter $strand

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
+++ b/modules/Bio/EnsEMBL/Variation/DBSQL/VariationFeatureAdaptor.pm
@@ -2078,7 +2078,7 @@ sub _hgvs_from_components {
   }
   elsif ($description =~ m/ins/i && $description =~ m/del/i) {
     ## check for malformed indels
-    ($ref_allele, $alt_allele,  $start, $end) = @{trim_sequences($ref_allele, $alt_allele,  $start, $end, 1)};
+    ($ref_allele, $alt_allele,  $start, $end) = @{trim_sequences($ref_allele, $alt_allele,  $start, $end, 1, 0, $strand)};
   }
   elsif ($description =~ m/ins/i && $description !~ m/del/i) {
      # insertion: the start & end positions are inverted by convention

--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -932,6 +932,7 @@ sub align_seqs {
   Arg[4]      : (optional) int $end
   Arg[5]      : (optional) bool $empty_to_dash
   Arg[6]      : (optional) bool $end_first
+  Arg[7]      : (optional) int $strand
   Example     : my ($new_ref, $new_alt, $new_start) = @{trim_sequences($ref, $alt, $start)}
   Description : Takes a pair of reference and alternate sequences and trims common sequence
                 from the start and then the end to give the minimal pair of alleles,
@@ -962,12 +963,13 @@ sub align_seqs {
 =cut
 
 sub trim_sequences {
-  my ($ref, $alt, $start, $end, $empty_to_dash, $end_first) = @_;
+  my ($ref, $alt, $start, $end, $empty_to_dash, $end_first, $strand) = @_;
 
   throw("Missing reference or alternate sequence") unless defined $ref && defined $alt;
 
   $start ||= 0;
   $end ||= $start + (length($ref) - 1);
+  $strand ||= 1;
 
   my $changed = 0;
 
@@ -976,7 +978,12 @@ sub trim_sequences {
     while($ref && $alt && substr($ref, -1, 1) eq substr($alt, -1, 1)) {
       $ref = substr($ref, 0, length($ref) - 1);
       $alt = substr($alt, 0, length($alt) - 1);
-      $end--;
+      if($strand == -1) {
+        $start++;
+      }
+      else {
+        $end--;
+      }
       $changed = 1;
     }
 
@@ -984,7 +991,12 @@ sub trim_sequences {
     while($ref && $alt && substr($ref, 0, 1) eq substr($alt, 0, 1)) {
       $ref = substr($ref, 1);
       $alt = substr($alt, 1);
-      $start++;
+      if($strand == -1) {
+        $end--;
+      }
+      else {
+        $start++;
+      }
       $changed = 1;
     }
   }
@@ -994,7 +1006,12 @@ sub trim_sequences {
     while($ref && $alt && substr($ref, 0, 1) eq substr($alt, 0, 1)) {
       $ref = substr($ref, 1);
       $alt = substr($alt, 1);
-      $start++;
+      if($strand == -1) {
+        $end--;
+      }
+      else {
+        $start++;
+      }
       $changed = 1;
     }
 
@@ -1002,7 +1019,12 @@ sub trim_sequences {
     while($ref && $alt && substr($ref, -1, 1) eq substr($alt, -1, 1)) {
       $ref = substr($ref, 0, length($ref) - 1);
       $alt = substr($alt, 0, length($alt) - 1);
-      $end--;
+      if($strand == -1) {
+        $start++;
+      }
+      else {
+        $end--;
+      }
       $changed = 1;
     }
   }

--- a/modules/t/sequence_utils.t
+++ b/modules/t/sequence_utils.t
@@ -115,6 +115,20 @@ is_deeply(
   'trim_sequences Accept 0 as alt allele'
 );
 
+# test trimming on foward strand (default)
+is_deeply(
+  trim_sequences(qw(TCT TAG 183 185 1)),
+  ['CT', 'AG', 184, 185, 1],
+  'trim_sequences - foward strand (default)'
+);
+
+# test trimming on reverse strand
+is_deeply(
+  trim_sequences(qw(TCT TAG 183 185 1 0 -1)),
+  ['CT', 'AG', 183, 184, 1],
+  'trim_sequences - reverse strand'
+);
+
 throws_ok {trim_sequences(undef, 'A')} qr/Missing reference or alternate sequence/, 'trim_sequences - no ref';
 throws_ok {trim_sequences('A')} qr/Missing reference or alternate sequence/, 'trim_sequences - no alt';
 throws_ok {trim_sequences()} qr/Missing reference or alternate sequence/, 'trim_sequences - no both';


### PR DESCRIPTION
Ticket: [ENSVAR-6780](https://embl.atlassian.net/browse/ENSVAR-6780)

This PR adds a new option to trim_sequences()
New option: $strand
The strand is necessary when we input a HGVSc in VEP.

**Testing**
Run VEP with input `ENST00000357654:c.4729_4731delinsTAG`