### PR TITLE
Add improved liftover pipeline (using bcftools +liftover)

### DIFF
--- a/nextflow/liftover/Dockerfile
+++ b/nextflow/liftover/Dockerfile
@@ -1,0 +1,56 @@
+###############################################################################
+# BCFtools +liftover
+#   - Ubuntu 22.04 base
+#   - Downloads latest stable BCFtools (1.21 as of 2025-05)
+#   - Compiles freeseek/score plugins (inc. liftover)
+###############################################################################
+
+# --------------------------- Build -------------------------------------------
+FROM ubuntu:22.04 AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+# build-time dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential wget curl ca-certificates \
+        autoconf automake libtool pkg-config \
+        zlib1g-dev libbz2-dev liblzma-dev \
+        libcurl4-openssl-dev libssl-dev \
+        libopenblas0-openmp libsuitesparse-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# fetch and unpack the latest bcftools tag
+ARG BCFTOOLS_VERSION=1.21
+WORKDIR /opt
+RUN wget -q https://github.com/samtools/bcftools/releases/download/${BCFTOOLS_VERSION}/bcftools-${BCFTOOLS_VERSION}.tar.bz2 \
+ && tar xjf bcftools-${BCFTOOLS_VERSION}.tar.bz2
+
+# replace stock plugins with the freeseek/score versions
+RUN set -eux; \
+    cd bcftools-${BCFTOOLS_VERSION}/plugins; \
+    for f in score.c score.h munge.c liftover.c metal.c blup.c; do rm -f "$f" || true; done; \
+    wget -q -P . \
+      https://raw.githubusercontent.com/freeseek/score/master/liftover.c
+
+# compile bcftools + plugins
+RUN cd bcftools-${BCFTOOLS_VERSION} \
+ && make -j$(nproc) \
+ && make install PREFIX=/usr/local \
+ && mkdir -p /usr/local/lib/bcftools/plugins \
+ && cp plugins/*.so /usr/local/lib/bcftools/plugins/
+
+# --------------------------- Runtime -----------------------------------------
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+# runtime libs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libcurl4 libbz2-1.0 liblzma5 \
+        libopenblas0-openmp libcholmod3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# copy bcftools and its plugins from builder
+COPY --from=builder /usr/local /usr/local
+ENV BCFTOOLS_PLUGINS=/usr/local/lib/bcftools/plugins
+
+ENTRYPOINT ["bcftools"]
+CMD ["--help"]

--- a/nextflow/liftover/README.md
+++ b/nextflow/liftover/README.md
@@ -1,0 +1,44 @@
+# liftover
+
+**A Nextflow pipeline to remap VCF files with `bcftools +liftover`**
+
+Based on the Ensembl-Variation _Remapping_ workflow.  
+CrossMap has been replaced by a containerised **bcftools 1.20** build that
+includes the _freeseek/score_ `liftover` plug-in.
+
+---
+
+## Quick start
+
+Clone the repo
+
+```bash
+git clone https://github.com/ensembl/ensembl-variation.git
+```
+
+Create a run script. In this example, a GRCh38 ClinVar VCF is being lifted over to T2T.
+You will need to supply:
+
+- A list of target genome IDs. In this example, `ids.txt` contains just `T2T_CHM13_v2`.
+- A bgzipped and tabixed input VCF (`clinvar_chr.filtered.vcf.gz`). In this example, to match the liftover and .fa files,
+  'chr' was added to the seqnames. Non-standard contigs were also filtered out.
+- `src_fasta` is the source `.fa` file. In this example, this is `hg38.fa`.
+- `dst_fasta` is the destination/target `.fa` file. In this example, this is `chm13v2.0.fa`.
+
+```bash
+# load modules
+module load nextflow/23.04.1
+module load singularity/3.8.7
+module load htslib
+
+# run
+nextflow run main.nf \
+  -profile singularity \
+  --ids        ids.txt \
+  --vcf        clinvar_chr.filtered.vcf.gz \
+  --chain      hg38ToT2T.chm13v2.chain.gz  \
+  --src_fasta  hg38.fa \
+  --dst_fasta  chm13v2.0.fa \
+  --out_dir    results/ \
+  -resume
+```

--- a/nextflow/liftover/main.nf
+++ b/nextflow/liftover/main.nf
@@ -1,0 +1,163 @@
+#!/usr/bin/env nextflow
+
+/* 
+ * Nextflow pipeline to remap VCF files using 
+ */
+
+nextflow.enable.dsl=2
+description = "Pipeline to remap VCF files using bcftools/liftover"
+separator   = "-" * description.length()
+
+// Default params
+params.help   = false
+params.ids    = null
+params.vcf    = null
+
+params.chain = null
+params.src_fasta = null
+params.dst_fasta = null
+params.keep_id   = false
+
+params.out_dir = 'output'
+params.report  = 'bcftools-liftover_report.txt'
+
+lookup = [
+  "HG02257.1"    : "GCA_018466835.1",
+  "HG02257.2"    : "GCA_018466845.1",
+  "HG02559.1"    : "GCA_018466855.1",
+  "HG02559.2"    : "GCA_018466985.1",
+  "HG02486.1"    : "GCA_018467005.1",
+  "HG02486.2"    : "GCA_018467015.1",
+  "HG01891.2"    : "GCA_018467155.1",
+  "HG01891.1"    : "GCA_018467165.1",
+  "HG01258.2"    : "GCA_018469405.1",
+  "HG03516.1"    : "GCA_018469415.1",
+  "HG03516.2"    : "GCA_018469425.1",
+  "HG01123.2"    : "GCA_018469665.1",
+  "HG01258.1"    : "GCA_018469675.1",
+  "HG01361.2"    : "GCA_018469685.1",
+  "HG01123.1"    : "GCA_018469695.1",
+  "HG01361.1"    : "GCA_018469705.1",
+  "HG01358.2"    : "GCA_018469865.1",
+  "HG02622.2"    : "GCA_018469875.1",
+  "HG02622.1"    : "GCA_018469925.1",
+  "HG02717.2"    : "GCA_018469935.1",
+  "HG02630.1"    : "GCA_018469945.1",
+  "HG02630.2"    : "GCA_018469955.1",
+  "HG01358.1"    : "GCA_018469965.1",
+  "HG02717.1"    : "GCA_018470425.1",
+  "HG02572.1"    : "GCA_018470435.1",
+  "HG02572.2"    : "GCA_018470445.1",
+  "HG02886.2"    : "GCA_018470455.1",
+  "HG02886.1"    : "GCA_018470465.1",
+  "HG01175.1"    : "GCA_018471065.1",
+  "HG01106.1"    : "GCA_018471075.1",
+  "HG01175.2"    : "GCA_018471085.1",
+  "HG00741.2"    : "GCA_018471095.1",
+  "HG00741.1"    : "GCA_018471105.1",
+  "HG01106.2"    : "GCA_018471345.1",
+  "HG00438.2"    : "GCA_018471515.1",
+  "HG02148.1"    : "GCA_018471525.1",
+  "HG02148.2"    : "GCA_018471535.1",
+  "HG01952.2"    : "GCA_018471545.1",
+  "HG01952.1"    : "GCA_018471555.1",
+  "HG00673.2"    : "GCA_018472565.1",
+  "HG00621.1"    : "GCA_018472575.1",
+  "HG00673.1"    : "GCA_018472585.1",
+  "HG00438.1"    : "GCA_018472595.1",
+  "HG00621.2"    : "GCA_018472605.1",
+  "HG01071.2"    : "GCA_018472685.1",
+  "HG01928.2"    : "GCA_018472695.1",
+  "HG01928.1"    : "GCA_018472705.1",
+  "HG00735.1"    : "GCA_018472715.1",
+  "HG01071.1"    : "GCA_018472725.1",
+  "HG00735.2"    : "GCA_018472765.1",
+  "HG03579.2"    : "GCA_018472825.1",
+  "HG03579.1"    : "GCA_018472835.1",
+  "HG01978.1"    : "GCA_018472845.1",
+  "HG03453.2"    : "GCA_018472855.1",
+  "HG01978.2"    : "GCA_018472865.1",
+  "HG03540.2"    : "GCA_018473295.1",
+  "HG03453.1"    : "GCA_018473305.1",
+  "HG03540.1"    : "GCA_018473315.1",
+  "HG03486.1"    : "GCA_018503245.1",
+  "NA18906.2"    : "GCA_018503255.1",
+  "NA18906.1"    : "GCA_018503285.1",
+  "HG03486.2"    : "GCA_018503525.1",
+  "HG02818.1"    : "GCA_018503575.1",
+  "HG02818.2"    : "GCA_018503585.1",
+  "HG01243.1"    : "GCA_018504045.1",
+  "HG02080.1"    : "GCA_018504055.1",
+  "HG02723.2"    : "GCA_018504065.1",
+  "HG02723.1"    : "GCA_018504075.1",
+  "HG02080.2"    : "GCA_018504085.1",
+  "HG01109.2"    : "GCA_018504365.1",
+  "HG01243.2"    : "GCA_018504375.1",
+  "NA20129.1"    : "GCA_018504625.1",
+  "NA20129.2"    : "GCA_018504635.1",
+  "HG01109.1"    : "GCA_018504645.1",
+  "NA21309.2"    : "GCA_018504655.1",
+  "NA21309.1"    : "GCA_018504665.1",
+  "HG02109.2"    : "GCA_018505825.1",
+  "HG03492.1"    : "GCA_018505835.1",
+  "HG03492.2"    : "GCA_018505845.1",
+  "HG02055.1"    : "GCA_018505855.1",
+  "HG02109.1"    : "GCA_018505865.1",
+  "HG02055.2"    : "GCA_018506125.1",
+  "HG03098.1"    : "GCA_018506155.1",
+  "HG03098.2"    : "GCA_018506165.1",
+  "HG00733.1"    : "GCA_018506955.1",
+  "HG00733.2"    : "GCA_018506975.1",
+  "HG02145.2"    : "GCA_018852585.1",
+  "HG02145.1"    : "GCA_018852595.1",
+  "T2T_CHM13_v2" : "GCA_009914755.4"
+]
+
+// Print usage
+if (params.help) {
+  log.info """
+  ${description}
+  ${separator}
+
+  Usage:
+    nextflow run -profile slurm -resume main.nf \\
+      --ids ids.txt \\
+      --vcf sample.vcf.gz \\
+      --chain /path/to/chain/file \\
+      --src_fasta /path/to/source/fasta/file \\
+      --dst_fasta /path/to/destination/fasta/file
+
+  Mandatory arguments:
+    --vcf        VCF file to remap
+    --ids        File containing IDs of genomes
+    --chain  Path to chain directory (filenames must contain ID from --ids)
+    --src_fasta  Path to source fasta file
+    --dst_fasta  Path to destination fasta file 
+
+  Optional arguments:
+    --out_dir    Path to output directory (default: 'output')
+    --report     Filename with remapping stats (default: 'crossmap_report.txt')
+    --keep_id    Boolean: keep original ID in output filenames (true) or use
+                 respective assembly from lookup table (false; default)?
+  """
+  exit 1
+}
+
+include { bcftools_liftover; tabix; report } from './modules/bcftools_liftover.nf'
+
+include { check_JVM_mem; print_params; print_summary } from '../utils/utils.nf'
+check_JVM_mem(min=0.4)
+print_summary()
+
+workflow {
+  ids        = Channel.fromPath(params.ids, checkIfExists:true).splitText { it.trim() }
+  vcf        = Channel.fromPath(params.vcf, checkIfExists:true)
+
+  chainFile  = Channel.value(params.chain)
+  srcFa      = Channel.value(params.src_fasta)
+  dstFa      = Channel.value(params.dst_fasta)
+
+  bcftools_liftover(vcf, ids, chainFile, srcFa, dstFa)
+  tabix(bcftools_liftover.out.vcf, lookup)
+  report(bcftools_liftover.out.report.collect(), lookup)
+}

--- a/nextflow/liftover/modules/bcftools_liftover.nf
+++ b/nextflow/liftover/modules/bcftools_liftover.nf
@@ -1,0 +1,104 @@
+#!/usr/bin/env nextflow
+
+process bcftools_liftover {
+
+    tag "$id"
+    container 'fairbrot/bcftools-liftover:latest'
+    cpus    1
+    memory  '4 GB'
+    time    '1h'
+
+    input:
+        path vcf
+        each id
+        val  chainFile  // params.chain
+        val  srcFa      // params.src_fasta
+        val  dstFa      // params.dst_fasta
+
+    output:
+        tuple val(id), path("${vcf.simpleName}_${id}.vcf"), path("${vcf.simpleName}_${id}.unmap"), emit: vcf
+        path ("${id}_report.txt"), emit: report
+
+    script:
+      def outVcf = "${vcf.simpleName}_${id}.vcf"
+      def unmVcf = "${vcf.simpleName}_${id}.unmap"
+    """
+    set -euo pipefail
+
+    # ---------- liftover ----------
+    bcftools +liftover ${vcf} -Ov -o ${outVcf} -- \\
+            -s ${srcFa} \\
+            -f ${dstFa} \\
+            -c ${chainFile} \\
+            --reject ${unmVcf}
+
+    # ---------- mini report ----------
+    total=\$(bcftools view -H ${vcf} | wc -l)
+    failed=\$(grep -vc '^#' ${unmVcf} || true)
+    {
+      echo "Total entries: \$total"
+      echo "Failed to map: \$failed"
+    } > ${id}_report.txt
+    """
+}
+
+process tabix {
+  tag "$id"
+  memory '4GB'
+  time '1h'
+
+  publishDir "${params.out_dir}", mode: 'copy'
+
+  input:
+    tuple val(id), path(vcf), path(unmap)
+    val lookup
+
+  output:
+    tuple val(id), path("*.vcf.gz*")
+
+  script:
+    def assembly = !params.keep_id && lookup[id] ? lookup[id] : id
+  """
+  for file in $vcf $unmap; do
+    final=\${file/$id/$assembly}
+    (grep "^#" \${file} && grep -v "^#" \${file} | sort -k1,1d -k2,2n) > \${final}
+    bgzip \${final}
+    tabix -p vcf \${final}.gz
+  done
+  """
+}
+
+process report {
+  memory '1GB'
+  time '1h'
+
+  publishDir "${params.out_dir}", mode: 'copy'
+
+  input:
+    path report
+    val lookup
+  output:
+    path "${params.report}"
+
+  script:
+    def mapping = lookup.collect { "['${it.key}']=\"${it.value}\"" }.join(' ')
+  """
+  declare -A arr=(${mapping})
+  for i in `echo ${report} | tr " " "\n" | sort`; do
+    id=\${i/_report.txt/}
+    total=`grep -Eo "Total entries: .*" \$i | grep -Eo "[0-9]+"`
+    failed=`grep -Eo "Failed to map: .*" \$i | grep -Eo "[0-9]+"`
+    percentage=`bc <<< "scale=2; \$failed * 100 / \$total"`
+
+    # set assembly to empty string if no match is found
+    assembly=`[ -v arr[\$id] ] && echo \${arr[\$id]} || echo ''`
+    echo "\$id\t\$assembly\t\$failed\t\$total\t\$percentage" >> ${params.report}
+  done
+
+  # sort by percentage of failed variants (descending)
+  sort -k5,5nr ${params.report} -o ${params.report}
+
+  # add header
+  sed -ie '1i\\#ID\tAssembly\tFailed\tTotal\tPercentage' ${params.report}
+  """
+}

--- a/nextflow/liftover/nextflow.config
+++ b/nextflow/liftover/nextflow.config
@@ -1,0 +1,82 @@
+profiles {
+  standard { process.executor = 'local' }
+
+  singularity {
+    singularity {
+      enabled     = true
+      autoMounts  = true
+    }
+    process {
+      container = 'docker://fairbrot/bcftools-liftover:latest'
+    }
+  }
+
+  lsf {
+    executor {
+      name            = 'lsf'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
+    }
+  }
+
+  slurm {
+    executor {
+      name            = 'slurm'
+      queueSize       = 500
+      submitRateLimit = '50/10sec'
+    }
+  }
+}
+
+notification {
+  enabled = true
+  to = "fairbrot@ebi.ac.uk"
+}
+
+process {
+
+  container = 'fairbrot/bcftools-liftover:latest'
+
+  withName: tabix {
+    container = ''
+  }
+  withName: report {
+    container = ''
+  }
+
+  memory = { ["1 GB", "4 GB", "8 GB", "40 GB"][task.attempt - 1] }
+  time   = '2d'
+
+  // Exit status codes:
+  // - 130: job exceeded LSF allocated memory
+  // - 140: job exceeded SLURM allocated resources (memory, CPU, time)
+  errorStrategy = { task.exitStatus in [130, 140] ? 'retry' : 'ignore' }
+
+  maxRetries = 3
+
+}
+
+trace {
+    enabled = true
+    overwrite = true
+    file = "reports/trace.txt"
+    //fields = 'task_id,name,status,exit,realtime,%cpu,rss'
+}
+
+dag {
+    enabled = true
+    overwrite = true
+    file = "reports/flowchart.mmd"
+}
+
+timeline {
+    enabled = true
+    overwrite = true
+    file = "reports/timeline.html"
+}
+
+report {
+    enabled = true
+    overwrite = true
+    file = "reports/report.html"
+}


### PR DESCRIPTION
# Description

In response to [ticket #6088](https://embl.atlassian.net/browse/ENSVAR-6088). 

This PR re-implements the Remapping Nextflow pipeline using `bcftools +liftover` (freeseek/score plug-in) instead of `CrossMap`.
- `modules/bcftools_liftover.nf` — new module that mirrors the old `crossmap.nf` (input: `*.vcf`, outputs: `*.unmap`, `_report.txt`).
-`bcftools +liftover` runs inside the docker image fairbrot/bcftools-liftover:latest (bcftools 1.20 + plug-ins).
- Added README.md with usage, container notes, and sample command lines.

# Use case

`bcftools +liftover` performs better on a number of metrics than `CrossMap` - see [ticket comments](https://embl.atlassian.net/browse/ENSVAR-6088) for detailed benchmarking info summarise from the manuscript. 

# Testing

I benchmarked the older `Remapping` pipeline (using `CrossMap`) against this one. 
- Input: ClinVar VCF
- Liftover: GRCh38 > T2T

Report coming out of this pipeline (`liftover`): 
```
#ID	Assembly	Failed	Total	Percentage
T2T_CHM13_v2	GCA_009914755.4	2099	3503922	.05
```

Report coming out of `Remapping` pipeline
```
#ID	Assembly	Failed	Total	Percentage
T2T_CHM13_v2	GCA_009914755.4	35905	3503922	1.02
```

As you can see, `Remapping` failed to lift over 35,905 variants, whereas `liftover` only failed to lift over 2,099 variants.  