### PR TITLE
Add tiny fix for mapping data with missing 'post_mapped' key 

### DIFF
--- a/nextflow/MaveDB/bin/map_scores_to_variants_fromfiles.py
+++ b/nextflow/MaveDB/bin/map_scores_to_variants_fromfiles.py
@@ -329,7 +329,9 @@ def map_scores_to_variants(scores, mappings, metadata, map_ids, matches=None, ro
        continue
 
     row = round_float_columns(row, round)
-    mapped_info = mapping['post_mapped']
+    # some rows don't have post-mapped (i.e. no mapping, so only consider rows with mapping)
+    if 'post_mapped' in mapping.keys():
+      mapped_info = mapping['post_mapped']
     
     # Process phased variants if multiple members exist; otherwise, process the mapping directly
     if mapped_info.get("members", []):


### PR DESCRIPTION
In the new (2025) data, some entries in the mappings JSON files had no `post_mapped` key (not previously the case in older data that the pipeline had been tested on). This key was being relied upon to pull out the mapping data, and as such, was throwing an error and aborting all mapping extraction for the URN ID in question. This means that URN IDs were being skipped entirely and thus data was missing from the output file. 

This fix allows these single rows (that have no mapping data) to be skipped. 