### PR TITLE
Update predicates to handle special cases

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1369,6 +1369,10 @@ sub _overlaps_stop_codon {
 
         my ($cdna_start, $cdna_end) = ($bvfo->cdna_start, $bvfo->cdna_end);
         return 0 unless $cdna_start && $cdna_end;
+
+        # for insertion add inserted seq length to see overlap
+        my $vf_feature_seq = $bvfoa->feature_seq;
+        $cdna_end = $cdna_end < $cdna_start ? $cdna_start + length $vf_feature_seq : $cdna_end;
         
         $cache->{overlaps_stop_codon} = overlap(
             $cdna_start, $cdna_end,

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1122,7 +1122,7 @@ sub inframe_insertion {
         # trim off everything after it
         # this allows us to detect inframe insertions that retain a stop
         $alt_pep =~ s/\*.+/\*/;
-        return 0 if $ref_pep eq "*" && $alt_pep eq "*";
+        return 0 if $ref_pep eq "*" && $alt_pep eq "*"; # e.g. ref codon - TAG, alt codon - TAAG 
         return 0 if $ref_pep eq "" && $alt_pep eq "*";
         return 1 if ($alt_pep =~ /^\Q$ref_pep\E/) || ($alt_pep =~ /\Q$ref_pep\E$/);
 
@@ -1251,7 +1251,7 @@ sub stop_lost {
     #        }
             
             my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
-            if(defined($ref_pep) && defined($alt_pep) && $alt_pep !~ /\X/) {
+            if(defined($ref_pep) && defined($alt_pep) && $alt_pep !~ 'X') {
                 $cache->{stop_lost} = ( ($alt_pep !~ /\*/) and ($ref_pep =~ /\*/) );
             }
             else {

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1122,7 +1122,8 @@ sub inframe_insertion {
         # trim off everything after it
         # this allows us to detect inframe insertions that retain a stop
         $alt_pep =~ s/\*.+/\*/;
-
+        return 0 if $ref_pep eq "*" && $alt_pep eq "*";
+        return 0 if $ref_pep eq "" && $alt_pep eq "*";
         return 1 if ($alt_pep =~ /^\Q$ref_pep\E/) || ($alt_pep =~ /\Q$ref_pep\E$/);
 
     }
@@ -1250,7 +1251,7 @@ sub stop_lost {
     #        }
             
             my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
-            if(defined($ref_pep) && defined($alt_pep)) {
+            if(defined($ref_pep) && defined($alt_pep) && $alt_pep !~ /\X/) {
                 $cache->{stop_lost} = ( ($alt_pep !~ /\*/) and ($ref_pep =~ /\*/) );
             }
             else {
@@ -1304,10 +1305,10 @@ sub stop_retained {
 
         my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
 
-        if(defined($alt_pep) && $alt_pep ne '') {
+        if(defined($alt_pep) && $alt_pep ne '' && $alt_pep !~ 'X') {
          
-          ## handle inframe insertion of a stop just before the stop (no ref peptide)
-          $cache->{stop_retained} = ref_eq_alt_sequence(@_);
+            ## handle inframe insertion of a stop just before the stop (no ref peptide)
+            $cache->{stop_retained} = ref_eq_alt_sequence(@_);
         }
         else {
             $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _overlaps_stop_codon(@_) && !_ins_del_stop_altered(@_);
@@ -1324,7 +1325,6 @@ sub ref_eq_alt_sequence {
    $bvfo ||= $bvfoa->base_variation_feature_overlap;
    my $ref_seq = $bvfo->_peptide;
 
-   my $mut_seq = $ref_seq;
    my $tl_start = $bvfo->translation_start;
    my $tl_end = $bvfo->translation_end;
    
@@ -1339,19 +1339,19 @@ sub ref_eq_alt_sequence {
    # this is a logic from the former logic 
    return 1 if ($bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptVariationAllele') && defined($ref_seq) && $tl_start > length($ref_seq) && $alt_pep =~ /^\*/);
 
+   my $mut_seq = $ref_seq;
    substr($mut_seq, $tl_start-1, $tl_end - $tl_start + 1) = $alt_pep; # creating a mutated sequence from the ref sequence. 
 
    my $mut_substring = substr($mut_seq, 0, length($ref_seq)); # getting a substring up to the length of the ref sequence for comparison from index 0 to the length of the ref seq;
-   
+        
    my $final_stop = substr($mut_seq, length($ref_seq)) if length($ref_seq) < length($mut_seq); # getting the length of the $mut_seq from the length of the ref_seq to the end 
    
-   my $final_stop_length = length($final_stop) if defined($final_stop) ne '';
-   
-   # 1 is if the ref_pep and the first letter of the alt_pep is the same and the alt_pep has * in it 
-   # 2 is the ref_seq eq $mut_substring and the final stop length is less than 3
-   # 3 is * in ref_pep and the same index position exists for both the ref and alt pep
-   return 1 if ( ($ref_pep eq substr($alt_pep, 0, 1) && $alt_pep =~ /\*/) ||
-       ($ref_seq eq $mut_substring && defined($final_stop_length) && $final_stop_length < 3) || ( $ref_pep =~ /\*/ && (index($ref_pep, "*") + 1 == index($alt_pep, "*") + 1) ));
+   # 1 is the ref_seq eq $mut_substring and the final stop is *
+   # 2 is * in ref_pep and the same index position exists for both the ref and alt pep
+   return 1 if (
+        ($ref_seq eq $mut_substring && defined($final_stop) && $final_stop eq "*") ||  
+        ($ref_pep =~ /\*/ && (index($ref_pep, "*") == index($alt_pep, "*")))
+    );
    return 0;
 }
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1119,7 +1119,6 @@ sub inframe_insertion {
         return 0 if start_retained_variant(@_) && $alt_pep =~ /\Q$ref_pep\E$/;
 
         return 0 if $ref_pep eq "*" && $alt_pep eq "*"; # e.g. ref codon - TAG, alt codon - TAAG 
-        return 0 if $ref_pep eq "" && $alt_pep eq "*";
 
         # if we have a stop codon in the alt peptide
         # trim off everything after it
@@ -1349,8 +1348,9 @@ sub ref_eq_alt_sequence {
    
    # 1 is the ref_seq eq $mut_substring and the final stop is *
    # 2 is * in ref_pep and the same index position exists for both the ref and alt pep
+#    print $final_stop, "\n";
    return 1 if (
-        ($ref_seq eq $mut_substring && defined($final_stop) && $final_stop eq "*") ||  
+        ($ref_seq eq $mut_substring && defined($final_stop) && $final_stop =~ /^\Q*\E/) ||
         ($ref_pep =~ /\*/ && (index($ref_pep, "*") == index($alt_pep, "*")))
     );
    return 0;

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1315,7 +1315,7 @@ sub stop_retained {
             $cache->{stop_retained} = ref_eq_alt_sequence(@_);
         }
         else {
-            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _ins_overlaps_stop_codon(@_, 1) && !_ins_del_stop_altered(@_);
+            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _ins_overlaps_stop_codon(@_) && !_ins_del_stop_altered(@_);
         }
 
     }
@@ -1391,6 +1391,7 @@ sub _ins_overlaps_stop_codon {
     my $cache = $bvfoa->{_predicate_cache} ||= {};
 
     # same as overlaps_stop_codon but for insertion add inserted seq length to see overlap
+    # because of intron we need to check overlap based on genomic coords when adding inserted seq length
     unless(exists($cache->{ins_overlaps_stop_codon})) {
         $cache->{ins_overlaps_stop_codon} = 0;
 
@@ -1398,17 +1399,27 @@ sub _ins_overlaps_stop_codon {
         $feat ||= $bvfo->feature;
         return 0 if grep {$_->code eq 'cds_end_NF'} @{$feat->get_all_Attributes()};
 
-        my ($cdna_start, $cdna_end) = ($bvfo->cdna_start, $bvfo->cdna_end);
-        return 0 unless $cdna_start && $cdna_end;
+        my ($v_start, $v_end) = ($bvf->seq_region_start, $bvf->seq_region_end);
+        return 0 unless $v_start && $v_end;
 
+        # direction of adding inserted seq length depends on transcript strand
         my $vf_feature_seq = $bvfoa->feature_seq;
-        $cdna_end = (($cdna_end < $cdna_start) && $vf_feature_seq =~ /^[ACTGN]+$/) ? 
-            $cdna_start + length $vf_feature_seq : 
-            $cdna_end;
+        if (($v_end < $v_start) && $vf_feature_seq =~ /^[ACTGN]+$/) {
+            if ($feat->strand == 1) {
+                $v_start =  $v_start + length $vf_feature_seq; 
+            }
+            else {
+                $v_start =  $v_start - length $vf_feature_seq; 
+            }
+        }
+
+        # from doxygen always coding_region_start < coding_region_end, so need to swap for reverse strand
+        my ($t_start, $t_end) = ($feat->coding_region_start, $feat->coding_region_end);
+        ($t_start, $t_end) = ($t_end, $t_start) if $feat->strand == -1;
 
         $cache->{ins_overlaps_stop_codon} = overlap(
-            $cdna_start, $cdna_end,
-            $feat->cdna_coding_end - 2, $feat->cdna_coding_end
+            $v_start, $v_end,
+            $t_end - 2, $t_end
         );
     }
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1394,6 +1394,7 @@ sub _overlaps_stop_codon_cil {
     unless(exists($cache->{ins_overlaps_stop_codon})) {
         $cache->{ins_overlaps_stop_codon} = 0;
 
+        return 0 unless $bvf;
         $bvfo ||= $bvfoa->base_variation_feature_overlap;
         $feat ||= $bvfo->feature;
         return 0 if grep {$_->code eq 'cds_end_NF'} @{$feat->get_all_Attributes()};

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1214,11 +1214,12 @@ sub stop_gained {
     # use cache for this method as it gets called a lot
     my $cache = $bvfoa->{_predicate_cache} ||= {};
 
+
     unless(exists($cache->{stop_gained})) {
         $cache->{stop_gained} = 0;
         
-        ## check for inframe insertion before stop 
         return 0 if stop_retained(@_);
+        return 0 if stop_lost(@_);
 
         my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
         

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1315,7 +1315,7 @@ sub stop_retained {
             $cache->{stop_retained} = ref_eq_alt_sequence(@_);
         }
         else {
-            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _overlaps_stop_codon(@_, 1) && !_ins_del_stop_altered(@_, 1);
+            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _overlaps_stop_codon_cil(@_) && !_ins_del_stop_altered_cil(@_);
         }
 
     }
@@ -1361,11 +1361,7 @@ sub ref_eq_alt_sequence {
 }
 
 sub _overlaps_stop_codon {
-    my ($bvfoa, $feat, $bvfo, $bvf, $consider_ins_len) = @_;
-
-    # same as overlaps_stop_codon but for insertion add inserted seq length to see overlap
-    # generally used by stop_retained
-    return _ins_overlaps_stop_codon(@_) if $consider_ins_len;
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
 
     my $cache = $bvfoa->{_predicate_cache} ||= {};
 
@@ -1389,7 +1385,8 @@ sub _overlaps_stop_codon {
 }
 
 
-sub _ins_overlaps_stop_codon {
+# same as overlaps_stop_codon but "consider insertion length" to see overlap
+sub _overlaps_stop_codon_cil {
     my ($bvfoa, $feat, $bvfo, $bvf) = @_;
 
     my $cache = $bvfoa->{_predicate_cache} ||= {};
@@ -1480,6 +1477,61 @@ sub _ins_del_stop_altered {
     }
 
     return $cache->{ins_del_stop_altered};
+}
+
+
+# same as _ins_del_stop_altered but "consider insertion length" to see stop codon overlap
+sub _ins_del_stop_altered_cil {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+
+    # use cache for this method as it gets called a lot
+    my $cache = $bvfoa->{_predicate_cache} ||= {};
+
+    unless(exists($cache->{ins_del_stop_altered_cil})) {
+        $cache->{ins_del_stop_altered_cil} = 0;
+
+        return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptStructuralVariationAllele');
+        return 0 unless $bvfoa->seq_is_unambiguous_dna();
+        return 0 unless _overlaps_stop_codon_cil(@_);
+
+        my $pre = $bvfoa->_pre_consequence_predicates;
+        return 0 unless $pre->{increase_length} || $pre->{decrease_length};
+
+        $bvfo ||= $bvfoa->base_variation_feature_overlap;
+
+        # get cDNA coords and CDS start
+        my ($cdna_start, $cdna_end, $cds_start) = ($bvfo->cdna_start, $bvfo->cdna_end, $bvfo->cds_start);
+        return 0 unless $cdna_start && $cdna_end && $cds_start;
+
+        # make and edit UTR + translateable seq
+        my $translateable = $bvfo->_translateable_seq();
+        my $utr = $bvfo->_three_prime_utr();
+
+        my $utr_and_translateable = $translateable.($utr ? $utr->seq : '');
+
+        my $vf_feature_seq = $bvfoa->feature_seq;
+        $vf_feature_seq = '' if $vf_feature_seq eq '-';
+
+        # use CDS start to anchor the edit
+        # and cDNA coords to get the length (could use VF, but have already retrieved cDNA coords)
+        substr($utr_and_translateable, $cds_start - 1, ($cdna_end - $cdna_start) + 1) = $vf_feature_seq;
+
+        # new sequence shorter, we know it has been altered
+        return $cache->{ins_del_stop_altered_cil} = 1 if length($utr_and_translateable) < length($translateable);
+
+        # now we need the codon from the new seq at the equivalent end pos from translateable
+        # and to translate it to check if it is still a stop
+        my $pep = Bio::Seq->new(
+            -seq        => substr($utr_and_translateable, length($translateable) - 3, 3),
+            -moltype    => 'dna',
+            -alphabet   => 'dna',
+        )->translate(
+            undef, undef, undef, $bvfo->_codon_table
+        )->seq;
+        $cache->{ins_del_stop_altered_cil} = !($pep && $pep eq '*');
+    }
+
+    return $cache->{ins_del_stop_altered_cil};
 }
 
 sub frameshift {

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1171,7 +1171,9 @@ sub inframe_deletion {
         my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
         return 0 unless defined $ref_codon;
         return 0 unless length($alt_codon) < length ($ref_codon);
-        
+
+        return 0 if $ref_pep eq "*"; # e.g. ref codon - TAG, alt codon - G
+
         # simple string match
         return 1 if ($ref_codon =~ /^\Q$alt_codon\E/) || ($ref_codon =~ /\Q$alt_codon\E$/);
 

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1315,7 +1315,7 @@ sub stop_retained {
             $cache->{stop_retained} = ref_eq_alt_sequence(@_);
         }
         else {
-            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _ins_overlaps_stop_codon(@_) && !_ins_del_stop_altered(@_);
+            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _overlaps_stop_codon(@_, 1) && !_ins_del_stop_altered(@_, 1);
         }
 
     }
@@ -1361,7 +1361,11 @@ sub ref_eq_alt_sequence {
 }
 
 sub _overlaps_stop_codon {
-    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    my ($bvfoa, $feat, $bvfo, $bvf, $consider_ins_len) = @_;
+
+    # same as overlaps_stop_codon but for insertion add inserted seq length to see overlap
+    # generally used by stop_retained
+    return _ins_overlaps_stop_codon(@_) if $consider_ins_len;
 
     my $cache = $bvfoa->{_predicate_cache} ||= {};
 
@@ -1390,8 +1394,6 @@ sub _ins_overlaps_stop_codon {
 
     my $cache = $bvfoa->{_predicate_cache} ||= {};
 
-    # same as overlaps_stop_codon but for insertion add inserted seq length to see overlap
-    # because of intron we need to check overlap based on genomic coords when adding inserted seq length
     unless(exists($cache->{ins_overlaps_stop_codon})) {
         $cache->{ins_overlaps_stop_codon} = 0;
 
@@ -1399,6 +1401,7 @@ sub _ins_overlaps_stop_codon {
         $feat ||= $bvfo->feature;
         return 0 if grep {$_->code eq 'cds_end_NF'} @{$feat->get_all_Attributes()};
 
+        # because of intron we need to check overlap based on genomic coords when adding inserted seq length
         my ($v_start, $v_end) = ($bvf->seq_region_start, $bvf->seq_region_end);
         return 0 unless $v_start && $v_end;
 
@@ -1427,7 +1430,7 @@ sub _ins_overlaps_stop_codon {
 }
 
 sub _ins_del_stop_altered {
-    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+    my ($bvfoa, $feat, $bvfo, $bvf, $consider_ins_len) = @_;
 
     # use cache for this method as it gets called a lot
     my $cache = $bvfoa->{_predicate_cache} ||= {};
@@ -1437,7 +1440,7 @@ sub _ins_del_stop_altered {
 
         return 0 if $bvfoa->isa('Bio::EnsEMBL::Variation::TranscriptStructuralVariationAllele');
         return 0 unless $bvfoa->seq_is_unambiguous_dna();
-        return 0 unless _overlaps_stop_codon(@_);
+        return 0 unless _overlaps_stop_codon(@_, $consider_ins_len);
 
         my $pre = $bvfoa->_pre_consequence_predicates;
         return 0 unless $pre->{increase_length} || $pre->{decrease_length};
@@ -1493,7 +1496,7 @@ sub frameshift {
 
         my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
         return 0 if defined $ref_pep && $ref_pep =~ /^\*/; # if the first base affected is the stop codon then it does no affect the reading frame
-        
+
         my $var_len = $bvfo->cds_end - $bvfo->cds_start + 1;
     
         my $allele_len = $bvfoa->seq_length;

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1450,6 +1450,9 @@ sub frameshift {
         return 0 if stop_retained(@_);
     
         return 0 unless defined $bvfo->cds_start && defined $bvfo->cds_end;
+
+        my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
+        return 0 if defined $ref_pep && $ref_pep =~ /^\*/; # if the first base affected is the stop codon then it does no affect the reading frame
         
         my $var_len = $bvfo->cds_end - $bvfo->cds_start + 1;
     

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1311,12 +1311,11 @@ sub stop_retained {
         my ($ref_pep, $alt_pep) = _get_peptide_alleles(@_);
 
         if(defined($alt_pep) && $alt_pep ne '' && $alt_pep !~ 'X') {
-         
             ## handle inframe insertion of a stop just before the stop (no ref peptide)
             $cache->{stop_retained} = ref_eq_alt_sequence(@_);
         }
         else {
-            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _overlaps_stop_codon(@_) && !_ins_del_stop_altered(@_);
+            $cache->{stop_retained} = ($pre->{increase_length} || $pre->{decrease_length}) && _ins_overlaps_stop_codon(@_, 1) && !_ins_del_stop_altered(@_);
         }
 
     }
@@ -1376,12 +1375,6 @@ sub _overlaps_stop_codon {
         my ($cdna_start, $cdna_end) = ($bvfo->cdna_start, $bvfo->cdna_end);
         return 0 unless $cdna_start && $cdna_end;
 
-        # for insertion add inserted seq length to see overlap
-        my $vf_feature_seq = $bvfoa->feature_seq;
-        $cdna_end = (($cdna_end < $cdna_start) && $vf_feature_seq =~ /^[ACTGN]+$/) ? 
-            $cdna_start + length $vf_feature_seq : 
-            $cdna_end;
-
         $cache->{overlaps_stop_codon} = overlap(
             $cdna_start, $cdna_end,
             $feat->cdna_coding_end - 2, $feat->cdna_coding_end
@@ -1389,6 +1382,37 @@ sub _overlaps_stop_codon {
     }
 
     return $cache->{overlaps_stop_codon};
+}
+
+
+sub _ins_overlaps_stop_codon {
+    my ($bvfoa, $feat, $bvfo, $bvf) = @_;
+
+    my $cache = $bvfoa->{_predicate_cache} ||= {};
+
+    # same as overlaps_stop_codon but for insertion add inserted seq length to see overlap
+    unless(exists($cache->{ins_overlaps_stop_codon})) {
+        $cache->{ins_overlaps_stop_codon} = 0;
+
+        $bvfo ||= $bvfoa->base_variation_feature_overlap;
+        $feat ||= $bvfo->feature;
+        return 0 if grep {$_->code eq 'cds_end_NF'} @{$feat->get_all_Attributes()};
+
+        my ($cdna_start, $cdna_end) = ($bvfo->cdna_start, $bvfo->cdna_end);
+        return 0 unless $cdna_start && $cdna_end;
+
+        my $vf_feature_seq = $bvfoa->feature_seq;
+        $cdna_end = (($cdna_end < $cdna_start) && $vf_feature_seq =~ /^[ACTGN]+$/) ? 
+            $cdna_start + length $vf_feature_seq : 
+            $cdna_end;
+
+        $cache->{ins_overlaps_stop_codon} = overlap(
+            $cdna_start, $cdna_end,
+            $feat->cdna_coding_end - 2, $feat->cdna_coding_end
+        );
+    }
+
+    return $cache->{ins_overlaps_stop_codon};
 }
 
 sub _ins_del_stop_altered {

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1235,6 +1235,8 @@ sub stop_lost {
 
     # use cache for this method as it gets called a lot
     my $cache = $bvfoa->{_predicate_cache} ||= {};
+
+    return 0 if partial_codon(@_);
     
     unless(exists($cache->{stop_lost})) {
         $cache->{stop_lost} = 0;

--- a/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm
@@ -1418,9 +1418,12 @@ sub _overlaps_stop_codon_cil {
         my ($t_start, $t_end) = ($feat->coding_region_start, $feat->coding_region_end);
         ($t_start, $t_end) = ($t_end, $t_start) if $feat->strand == -1;
 
+        my ($t_end_s, $t_end_e) = ($t_end - 2, $t_end);
+        ($t_end_s, $t_end_e) = ($t_end, $t_end + 2) if $feat->strand == -1;
+
         $cache->{ins_overlaps_stop_codon} = overlap(
             $v_start, $v_end,
-            $t_end - 2, $t_end
+            $t_end_s, $t_end_e
         );
     }
 

--- a/modules/t/variation_effect.t
+++ b/modules/t/variation_effect.t
@@ -688,7 +688,7 @@ $transcript_tests->{$tf->stable_id}->{tests} = [
         alleles => '-',
         start   => $cds_end-2,
         end     => $cds_end,
-        effects => [qw(stop_lost inframe_deletion)],
+        effects => [qw(stop_lost)],
     }, {
         alleles => 'TAA',
         start   => $cds_end-2,


### PR DESCRIPTION
[ENSVAR-6654](https://embl.atlassian.net/browse/ENSVAR-6654)

Handle special cases for `inframe_insertion`
- ref and alt pep both `*` - not an inframe_insertion. 
Ideally we should not get `$ref_pep == $alt_pep` with the check of `length($alt_codon) > length ($ref_codon)`. But cases found where alt_codon can be just a 1bp/2bp larger than ref_codon and the insertion is not inframe. 
For example, `5 134750948 . TG T` variant have codons `TAA/TAAG` and peptides `*/*`.
We only handle cases where `$ref_pep=$alt_pep=*` to incur minimal change and do not add logic to check if `$ref_pep=$alt_pep`.

`stop_retained` and `stop_lost` 
- Check transcript sequence if alt_pep has `X`
In these functions first the peptide is used to infer if the effect is present, if not possible, such as peptide string is not available than the genomic sequences is used to infer the effect. We should use the transcript sequence if alt_pep has `X` as in some cases it cannot infer the effect with such peptide sequence.
For example, `3 149520808 . G GTTAA` has peptides `L/L*X` which says it is stop_gained but if we look at the transcript sequence it is actually stop_retained.

  **by product**: for stop lost a case appears that, in some cases stop lost is reported along with incomplete_terminal_codon (before it was not). That is because now we are checking if alt_pep is `X`. 

  A patch is applied by returning 0 if partial_codon is true as like stop_retained.

`stop_gained`
- In some cases `stop_gained` and `stop_lost` is now appearing together after the above edit. For example, `rs2154303328` the change happens as `-/LPRFKTRS*P*SX`. The insertion is happening just before stop codon and `L` is replacing the stop codon. So it is definitely stop lost. So this part is corrected (by checking genomic sequence as alt_pep has `X` in it).

  But stop_gained is wrong because the new stop codon that appearing is not premature stop codon. It is an old issue and present in pre-112 VEP. The reason it is appearing is we are not checking if the newly added stop codon comes after the original stop codon.

  A patch has been applied to check if we already have stop_lost. If stop is lost then it cannot be stop_gained.

Remove false cases from `ref_eq_alt_sequence` function -
- `# 1` - even if  alt_pep has * it might not be exact stop location.
Because we do not know if the stop codon is actually at the original stop position. (Ola also removed this case in her last [PR](https://github.com/Ensembl/ensembl-variation/pull/1149/files) and I agree)
- `# 2` - why we are checking $final_stop_length < 3
I do not know why we are checking `$final_stop_length` is less than 3 here. First of all final_stop_length is the number of aa in the mut aa string from the length of ref aa string. We do not care about the length as long as the first aa is a stop (i.e. the stop is at the same position). I change it to $final_stop =~ /^\Q*\E/ so we know that first aa is a stop codon. 
(What happens if ref_seq does not go all the way until stop codon?)

`_overlaps_stop_codon` vs `_ins_overlaps_stop_codon`
- consider length of insertion when checking for stop_codon overlap.
For example, `3 149520808 . G GTTAA` variant, the insertion is happened before stop codon. If we only consider the position where it is inserted it does not overlap stop codon and we never know that stop is actually retained. So, we consider the full length of insertion in the reference sequence to see if it actually overlaps stop codon.
This functionality is only required for stop_retained. For example for stop_lost or stop_gain we not need to check if the inserted sequence overlaps the current stop codon. That is why a new function `_ins_overlaps_stop_codon` is added used only by stop_retained.
As we are adding the genomic alt sequence length there is a chance there will be intron in the middle. To account for that the function has been changed to check the stop codon overlap considering DNA sequence instead of cDNA sequence.

(What happens if an indel length does not go until the stop codon but after adding in the change in the transcript sequence it is actually a stop_retained? - is it something to do with VEP not being completely haplotype-aware?)

`frameshift`
- if the first base affected is the stop codon then we do not report as frameshift. As the reading frame excludes the start and stop codon. In such case the current reading frame keeps the same but new aa added with a new stop.

  **by product**: A case appears for inframe_deletion as the one mentioned at top for inframe_insertion. For example, a variant such `TAG/G` (`*/X`) now considered as stop_lost,inframe_deletion. Stop lost is fine but inframe deletion is not. Inframe deletion is appearing as by product of the frameshift change. 
  
  As the variant is not classified as frameshift the `_get_codon_alleles` returns the codon and the [condition for inframe deletion](https://github.com/Ensembl/ensembl-variation/blob/23c76f60b1592e4df86159cf5530bdc326120c3d/modules/Bio/EnsEMBL/Variation/Utils/VariationEffect.pm#L1175) resulted in truth. Why we are checking with codon instead of peptide? - it is probably based on frameshift check, if it is not frameshift than we would see any deletion that is modulo 3. The above update to frameshift open a case for deletion at stop codon.
  
  So we add a check if the `ref_pep` is exactly `*`, if so even if it is deleted that would not be an inframe deletion.

### Impact
This PR is supposed to fix some edge cases. To determine it is not impacting a lot of known variants I tested the difference in consequence for variants in Ensembl variation database for human GRCh38 (this [file](https://ftp.ensembl.org/pub/release-115/variation//vcf/homo_sapiens/homo_sapiens-chr1.vcf.gz)). And it shows no difference in variant consequences.