### PR TITLE
bugfix: HGVSg - the check length gets truncated

### DIFF
--- a/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
+++ b/modules/Bio/EnsEMBL/Variation/Utils/Sequence.pm
@@ -798,8 +798,8 @@ sub get_3prime_seq_offset{
 
   return ($seq_to_check, $offset)  unless defined  $post_seq;
 
-  ## get length of pattern to check 
-  my $check_length = length($post_seq) - length($seq_to_check);
+  ## get length of pattern to check
+  my $check_length = length($post_seq);
 
   ## move along sequence after deletion looking for match to start of deletion
   for (my $n = 0; $n<= $check_length; $n++ ){


### PR DESCRIPTION
https://github.com/Ensembl/ensembl-vep/issues/1984

When shifting 3' for HGVSg we should skim through whole of downstream sequence (`post_seq`) instead of just the difference between the variation reference sequence (`seq_to_check`) and the downstream sequence. 

Generally the difference is only 50 bp added as extra to the total variant length in [_get_flank_seq](https://github.com/Ensembl/ensembl-variation/blob/23c76f60b1592e4df86159cf5530bdc326120c3d/modules/Bio/EnsEMBL/Variation/VariationFeature.pm#L1816) function.